### PR TITLE
Added Windows install instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ $ curl -L https://github.com/adamdecaf/terraform-provider-namecheap/releases/dow
 $ chmod +x ~/.terraform.d/plugins/terraform-provider-namecheap
 ```
 
+## Windows
+```powershell
+Invoke-WebRequest -Uri https://github.com/adamdecaf/terraform-provider-namecheap/releases/download/1.5.0/terraform-provider-namecheap.exe -OutFile ( New-Item -Path $env:APPDATA\terraform.d\plugins\registry.terraform.io\hashicorp\namecheap\1.5.0\windows_amd64\terraform-provider-namecheap_v1.5.0.exe -Force )
+```
+
 Then inside a Terraform file within your project (Ex. `providers.tf`):
 
 ```hcl


### PR DESCRIPTION
This will add the `terraform-provider-namecheap.exe` to `%APPDATA%\terraform.d\plugins\registry.terraform.io\hashicorp\namecheap\1.5.0\windows_amd64\terraform-provider-namecheap_v1.5.0.exe`. 

In `-OutFile ( New-Item -Path $env:APPDATA\terraform.d\plugins\registry.terraform.io\hashicorp\namecheap\1.5.0\windows_amd64\terraform-provider-namecheap_v1.5.0.exe -Force )` the `-Force` flag will create the directory if it does not exist.

If there is any easier way then let me know it took me like 2 hours to figure this out because the documentation is so sparse.