### PR TITLE
Improve CAA record handling

### DIFF
--- a/namecheap/namecheap_domain_record.go
+++ b/namecheap/namecheap_domain_record.go
@@ -90,7 +90,7 @@ func resourceNamecheapDomainRecords() *schema.Resource {
 						"ttl": {
 							Type:        schema.TypeInt,
 							Optional:    true,
-							Default:     1799,
+							Default:     1800,
 							Description: fmt.Sprintf("Time to live for all record types. Possible values: any value between %d to %d", namecheap.MinTTL, namecheap.MaxTTL),
 						},
 					},

--- a/namecheap/namecheap_domain_record_functions.go
+++ b/namecheap/namecheap_domain_record_functions.go
@@ -566,7 +566,7 @@ func convertInterfacesToString(stringsRaw []interface{}) []string {
 	return stringList
 }
 
-func fixCAAIodefAddressValue(address *string) (*string, error) {
+func fixCAAAddressValue(address *string) (*string, error) {
 	addressValues := strings.Split(strings.TrimSpace(*address), " ")
 	var addressValuesFixed []string
 
@@ -582,11 +582,11 @@ func fixCAAIodefAddressValue(address *string) (*string, error) {
 	}
 
 	hasPrefixQuote := strings.HasPrefix(addressValuesFixed[2], `"`)
-	hasSuffixQuite := strings.HasSuffix(addressValuesFixed[2], `"`)
+	hasSuffixQuote := strings.HasSuffix(addressValuesFixed[2], `"`)
 
-	if !hasPrefixQuote && !hasSuffixQuite {
+	if !hasPrefixQuote && !hasSuffixQuote {
 		addressValuesFixed[2] = fmt.Sprintf(`"%s"`, addressValuesFixed[2])
-	} else if !hasPrefixQuote || !hasSuffixQuite {
+	} else if !hasPrefixQuote || !hasSuffixQuote {
 		return nil, fmt.Errorf(`Invalid value "%s"`, *address)
 	}
 
@@ -604,7 +604,7 @@ func fixAddressEndWithDot(address *string) *string {
 // getFixedAddressOfRecord check the record type and return the fixed address with either dot suffix or quotes around domain name
 // The following addresses should be returned:
 // - for CNAME, ALIAS, NS, MX records, if the address has been provided without dot suffix, then it will be added
-// - for CAA records with iodef key word, if no quotes wrapping the domain, then the quotes will be added
+// - for CAA records, if no quotes wrapping the domain, then the quotes will be added
 // - for other cases the method will just return the address equal to input one
 func getFixedAddressOfRecord(record *namecheap.DomainsDNSHostRecord) (*string, error) {
 	if *record.RecordType == namecheap.RecordTypeCNAME ||
@@ -614,8 +614,8 @@ func getFixedAddressOfRecord(record *namecheap.DomainsDNSHostRecord) (*string, e
 		return fixAddressEndWithDot(record.Address), nil
 	}
 
-	if *record.RecordType == namecheap.RecordTypeCAA && strings.Contains(*record.Address, "iodef") {
-		return fixCAAIodefAddressValue(record.Address)
+	if *record.RecordType == namecheap.RecordTypeCAA {
+		return fixCAAAddressValue(record.Address)
 	}
 
 	return record.Address, nil

--- a/namecheap/namecheap_domain_record_functions_test.go
+++ b/namecheap/namecheap_domain_record_functions_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestFixCAAIodefAddressValue(t *testing.T) {
+func TestFixCAAAddressValue(t *testing.T) {
 	cases := []struct {
 		Input  string
 		Output string
@@ -16,11 +16,17 @@ func TestFixCAAIodefAddressValue(t *testing.T) {
 		{"0 iodef http://domain.com", `0 iodef "http://domain.com"`},
 		{"  0 iodef http://domain.com  ", `0 iodef "http://domain.com"`},
 		{`0 iodef "http://domain.com"`, `0 iodef "http://domain.com"`},
+		{"0 iodef mailto:admin@domain.com", `0 iodef "mailto:admin@domain.com"`},
+		{`0 iodef "mailto:admin@domain.com"`, `0 iodef "mailto:admin@domain.com"`},
+		{"0 issue domain.com", `0 issue "domain.com"`},
+		{`0 issue "domain.com"`, `0 issue "domain.com"`},
+		{"0 issuewild domain.com", `0 issuewild "domain.com"`},
+		{`0 issuewild "domain.com"`, `0 issuewild "domain.com"`},
 	}
 
 	for i, caseItem := range cases {
 		t.Run("test_"+strconv.Itoa(i+1), func(t *testing.T) {
-			fixedValue, _ := fixCAAIodefAddressValue(&caseItem.Input)
+			fixedValue, _ := fixCAAAddressValue(&caseItem.Input)
 			assert.Equal(t, caseItem.Output, *fixedValue)
 		})
 	}
@@ -29,7 +35,7 @@ func TestFixCAAIodefAddressValue(t *testing.T) {
 
 	for i, errorCaseItem := range errorCases {
 		t.Run("test_error_"+strconv.Itoa(i+1), func(t *testing.T) {
-			_, err := fixCAAIodefAddressValue(&errorCaseItem)
+			_, err := fixCAAAddressValue(&errorCaseItem)
 			assert.NotNil(t, err)
 			assert.Errorf(t, err, `Invalid value "`+errorCaseItem+`"`)
 		})

--- a/vendor/github.com/namecheap/go-namecheap-sdk/v2/namecheap/domains_dns_set_hosts.go
+++ b/vendor/github.com/namecheap/go-namecheap-sdk/v2/namecheap/domains_dns_set_hosts.go
@@ -37,7 +37,7 @@ var AllowedRecordTypeValues = []string{RecordTypeA, RecordTypeAAAA, RecordTypeAl
 var AllowedEmailTypeValues = []string{EmailTypeNone, EmailTypeMXE, EmailTypeMX, EmailTypeForward, EmailTypePrivate, EmailTypeGmail}
 
 var allowedTagValues = []string{"issue", "issuewild", "iodef"}
-var validURLProtocolPrefix = regexp.MustCompile("[a-z]+://")
+var validURLProtocolPrefix = regexp.MustCompile("[a-z]+:(?://)?")
 
 type DomainsDNSHostRecord struct {
 	// Sub-domain/hostname to create the record for


### PR DESCRIPTION
This PR aims to address two issues I ran into attempting to create CAA records with the Provider. Feel free to use it as idea fodder rather than merging it directly. (See especially the 2nd bullet under "What I Changed" below.)

**What I wanted to fix**
- It seems that the issuing domain for CAA `issue` and `issuewild` records is wrapped in quotes by your back-end. For example, `0 issue amazon.com` becomes `0 issue "amazon.com"`. (My conclusion that this happens is based creating the records in TF and then inspecting the records in the Namecheap web console.). However, because the provider allows the record without quotes, _and stores it like that in TF state_, such records forever shows a difference when planned, saying the record was removed outside of Terraform and needs to be created. (Edit: That behavior describes a `MERGE` mode operation.)
- CAA `iodef` records should permit a `mailto:` address, but the provider (or more accurately, the vendored `go-namecheap-sdk` library) checks that the record against a regex that only permits `proto://` style addresses with two trailing slashes. There are no trailing slashes with the `mailto:` protocol.

**What I changed**

This PR contains what seemed like minimal changes needed to address these issues.
- I renamed `fixCAAIodefAddressValue()` to `fixCAAAddressValue()` and apply it to _all_ CAA records, not just `iodef` types. This ensures the domain is always quoted, to match what your back-end actually creates.
- I modified the regex used in `iodef` URL protocol matches to make the `//` after the `:` optional. I realize this should really not be changed in a vendored copy of the `go-namecheap-sdk`, but I figured this was a simple way to show the change in context. Honestly, this regex (and the check in general) could stand to be made smarter. From what I can tell, _only_ `http://`, `https://` and `mailto:` are expected in an `iodef` CAA record, so the regex could be something like `https?://|mailto:`. And if you're going to check the protocol at all, you might want to check the whole URI for validity. For example, the current logic doesn't care what protocol name you put in front of the slashes or check that the rest of the URL is valid.
- I fixed a small spelling error / typo. `hasSuffixQuite()` -> `hasSuffixQuote()`
- I also tossed in a change you should feel free to ignore if it isn't valid or reasonable: the default `ttl` for records being 1799s seconds, or 29 minutes, 59 seconds. That just seemed strange, since even your web console offers standard values like 5, 10, 30 and 60 minutes. But you may have good reasons for using that value here. :man_shrugging: 

**Did I test this?**

Yes. I modified the tests so `go test` will pass with the changes to `fixCAAIodefAddressValue()`. I also added new test cases for the expanded use.

Additionally, I tested the provider locally and verified the following:
- CAA `issue` and `issuewild` records that lack quotes around the domain now show no differences when you plan after apply. Note that Terraform thinks that records with and without quotes are different records, so changing them back and forth to quoted or not in HCL will cause plan differences between changes. However, entries are now consistent with your back-end behavior whether they have quotes in the HCL or not.
- I was able to create a CAA `iodef` records with a `mailto:` URI. where previously this would fail on apply.