### PR TITLE
fix: use literal slash in CodeQL badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Namecheap Terraform Provider
 
 [![CI](https://github.com/namecheap/terraform-provider-namecheap/actions/workflows/ci.yml/badge.svg)](https://github.com/namecheap/terraform-provider-namecheap/actions/workflows/ci.yml)
-[![CodeQL](https://github.com/namecheap/terraform-provider-namecheap/actions/workflows/github-code-scanning%2Fcodeql/badge.svg)](https://github.com/namecheap/terraform-provider-namecheap/actions/workflows/github-code-scanning%2Fcodeql)
+[![CodeQL](https://github.com/namecheap/terraform-provider-namecheap/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/namecheap/terraform-provider-namecheap/actions/workflows/github-code-scanning/codeql)
 [![Release](https://img.shields.io/github/v/release/namecheap/terraform-provider-namecheap)](https://github.com/namecheap/terraform-provider-namecheap/releases)
 [![Terraform Registry](https://img.shields.io/badge/terraform-registry-blueviolet)](https://registry.terraform.io/providers/namecheap/namecheap/latest)
 [![Go version](https://img.shields.io/github/go-mod/go-version/namecheap/terraform-provider-namecheap)](https://github.com/namecheap/terraform-provider-namecheap/blob/master/go.mod)


### PR DESCRIPTION
## Summary

Fix broken CodeQL badge by replacing `%2F` with a literal `/` in the URL. GitHub's markdown renderer double-encodes `%2F`, causing the badge to fail.

**Before:** `github-code-scanning%2Fcodeql` (broken)
**After:** `github-code-scanning/codeql` (works)

## Test plan

- Docs-only change.