### PR TITLE
chore: add git privacy recommendation to CLAUDE.md and CONTRIBUTING.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,10 @@ All git commits must include a `Signed-off-by` line for the [Developer Certifica
 - To sign off an entire branch retroactively: `git rebase HEAD~N --signoff` (replace N with the number of commits).
 - The `Signed-off-by` identity must match the commit's author or committer name and email.
 
+## Git privacy
+
+Before creating git commits, verify the current `git config user.email` is a GitHub noreply address (matching `*@users.noreply.github.com`). If it is not, look up the user's GitHub ID and username via `gh api user` and set it to `<id>+<username>@users.noreply.github.com` using `git config user.email`.
+
 ## Pull Requests
 
 - All CI checks must pass before merge (unit tests, acceptance tests, CodeQL, DCO).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ All git commits must include a `Signed-off-by` line for the [Developer Certifica
 
 ## Git privacy
 
-Before creating git commits, verify the current `git config user.email` is a GitHub noreply address (matching `*@users.noreply.github.com`). If it is not, look up the user's GitHub ID and username via `gh api user` and set it to `<id>+<username>@users.noreply.github.com` using `git config user.email`.
+Before creating git commits, check that `git config user.email` is set. If it is not configured, suggest the contributor set one. Do not override an already-configured email.
 
 ## Pull Requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,19 @@ Run acceptance tests:
 $ make testacc
 ```
 
+## Git Email Privacy
+
+To keep your personal email out of the public git history, consider using a GitHub noreply address.
+You can enable this in [GitHub Settings → Emails](https://github.com/settings/emails) by checking **"Keep my email addresses private"**. Your noreply address follows the format `<id>+<username>@users.noreply.github.com` and is shown on that page.
+
+To use it for this repo:
+
+```shell
+$ git config user.email "YOUR_ID+YOUR_USERNAME@users.noreply.github.com"
+```
+
+This is optional — use whichever email you prefer.
+
 ## Commits and DCO
 
 This project enforces the [Developer Certificate of Origin](https://developercertificate.org/) (DCO) on all pull


### PR DESCRIPTION
## Summary
- **CLAUDE.md**: add soft git privacy rule — only check that `user.email` is set, never override
- **CONTRIBUTING.md**: add optional recommendation to use GitHub noreply email

## Test plan
- [x] Verify both files render correctly on GitHub
- [x] Confirm Claude Code picks up the new rule in future sessions