### PR TITLE
fix: address code quality findings from AI scan

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Before going forward, you must set up the following environment variables:
 NAMECHEAP_USER_NAME=user_name
 NAMECHEAP_API_USER=user_name
 NAMECHEAP_API_KEY=api_key
-NAMECHEAP_CLIENT_IP=your.whitelisted.ip # optional, defaults to 0.0.0.0
+NAMECHEAP_CLIENT_IP=your.whitelisted.ip # optional
 NAMECHEAP_TEST_DOMAIN=my-domain.com
 NAMECHEAP_USE_SANDBOX=true # optional
 ```
@@ -81,7 +81,7 @@ $ git push --force-with-lease
 ## Pull Requests
 
 - Ensure all CI checks pass: unit tests, acceptance tests, CodeQL analysis, and DCO.
-- Include both unit tests and [Terraform acceptance tests](https://developer.hashicorp.com/terraform/plugin/sdkv2/testing/acceptance-tests)
+- Include both unit tests and [Terraform acceptance tests](https://developer.hashicorp.com/terraform/plugin/testing/acceptance-tests)
   where applicable. Acceptance tests should use `resource.Test()` with `TestStep`.
 - Keep PRs focused — one logical change per PR.
 

--- a/namecheap/namecheap_domain_record_test.go
+++ b/namecheap/namecheap_domain_record_test.go
@@ -168,8 +168,18 @@ func testAccDomainNameserversDefault(response *namecheap.DomainsDNSGetListComman
 	}
 }
 
-// equalDomainRecord compares only Name, Type, Address, TTL, MXPref fields only
+// equalDomainRecord compares only Name, Type, Address, TTL, MXPref fields only.
 func equalDomainRecord(sRec *namecheap.DomainsDNSHostRecordDetailed, dRec *namecheap.DomainsDNSHostRecordDetailed) bool {
+	if sRec == nil || dRec == nil {
+		return false
+	}
+	if sRec.Name == nil || dRec.Name == nil ||
+		sRec.Type == nil || dRec.Type == nil ||
+		sRec.Address == nil || dRec.Address == nil ||
+		sRec.TTL == nil || dRec.TTL == nil ||
+		sRec.MXPref == nil || dRec.MXPref == nil {
+		return false
+	}
 	return *sRec.Name == *dRec.Name &&
 		*sRec.Type == *dRec.Type &&
 		*sRec.Address == *dRec.Address &&


### PR DESCRIPTION
## Summary

Fixes 3 findings flagged by GitHub's AI code quality scan:

- **CONTRIBUTING.md**: Remove misleading `defaults to 0.0.0.0` comment for `NAMECHEAP_CLIENT_IP` — `0.0.0.0` is not a valid client IP for Namecheap API calls, so advertising it as a default is confusing
- **CONTRIBUTING.md**: Update Terraform acceptance tests URL from `/sdkv2/testing/acceptance-tests` to `/testing/acceptance-tests` (framework-agnostic path, more stable over time)
- **namecheap_domain_record_test.go**: Add nil guards in `equalDomainRecord()` to prevent potential nil-pointer panics when struct or field pointers are nil

## Test plan

- [x] `make test` passes (90% coverage, all unit tests green)
- [ ] Verify updated acceptance tests URL resolves correctly