### PR TITLE
ci: SHA-pin namecheap/ec2-github-runner in start and stop steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,10 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Start EC2 runner
         id: start-ec2-runner
-        uses: namecheap/ec2-github-runner@feat/al2023-support
+        # SHA-pinned (was @feat/al2023-support). The same SHA is reused by
+        # the stop-runner step so both halves of the runner lifecycle run
+        # identical action code.
+        uses: namecheap/ec2-github-runner@6654a7e62b1f37081a92d90036e80685f5381a87 # feat/al2023-support @ 2026-04-20
         with:
           mode: start
           github-token: ${{ secrets.GH_TOKEN }}
@@ -148,7 +151,9 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Stop EC2 runner
-        uses: namecheap/ec2-github-runner@main
+        # SHA-pinned (was @main). Matches the start-runner step above so
+        # stop logic is in lockstep with the code that started the runner.
+        uses: namecheap/ec2-github-runner@6654a7e62b1f37081a92d90036e80685f5381a87 # feat/al2023-support @ 2026-04-20
         with:
           mode: stop
           github-token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Closes #148.

## Summary

Pin both `uses: namecheap/ec2-github-runner@…` lines in `.github/workflows/ci.yml` to commit SHA `6654a7e62b1f37081a92d90036e80685f5381a87` (tip of `feat/al2023-support` as of 2026-04-20) and drop the mutable branch refs.

## Why

- `@feat/al2023-support` and `@main` are mutable — anyone with push rights to `namecheap/ec2-github-runner` can change what runs on our self-hosted EC2 runner, which has `AWS_ACCESS_KEY_ID`, `GH_TOKEN`, and an Elastic IP in scope. See issue #148 for the full threat model.
- The start step was using `feat/al2023-support` while stop used `main`. The feature branch is **5 commits ahead of `main`, 0 behind**, so stop was running older code than start. Using the feat-branch SHA for both aligns them (stop upgrades to match start, never downgrades).

## Follow-ups tracked

- #147 — SHA-pin remaining third-party actions (codecov, goreleaser, aws-actions, etc.)
- #145 — Add Dependabot config so these SHA pins rotate automatically
- #146 — Add `go mod verify` to CI
- #144 — Verify Go and Terraform download checksums

## Test plan

- [ ] Push triggers CI; `start-runner` resolves and launches an EC2 runner.
- [ ] `stop-runner` successfully terminates the instance at the end of the run.
- [ ] No behavioral change beyond the pin itself.