### PR TITLE
ci: add Dependabot config for gomod and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
Closes #145.

## Summary

Add `.github/dependabot.yml` enabling weekly scans for `gomod` (Go module dependencies) and `github-actions` (workflow `uses:` refs). PR cap of 5 per ecosystem.

## Why now

- #149 introduced SHA-pinned references to `namecheap/ec2-github-runner`; follow-up #147 will SHA-pin the remaining third-party actions. Pinning without automated rotation is how projects end up stuck on years-old action versions that ship with their own CVEs.
- Dependabot updates SHA-pinned actions with trailing `# <tag>` comments in-place — it bumps both the SHA and the comment — so this config becomes more useful the moment #147 lands.
- `gomod` coverage catches indirect dependency CVEs (the `tj-actions/changed-files` and `hc-install` PGP-key events from the past year are direct arguments for this).

## Follow-ups tracked

- #147 — SHA-pin third-party actions (codecov, goreleaser, aws-actions, golangci-lint, crazy-max). Dependabot will drive maintenance once landed.
- #146 — Add `go mod verify` to CI.
- #144 — Verify Go and Terraform download checksums.

## Test plan

- [ ] PR merged; Dependabot tab shows the two ecosystems as "Enabled".
- [ ] First scheduled scan opens at least one update PR (expected: indirect `gomod` updates or a `github-actions` minor bump).