### PR TITLE
ci: skip EC2-backed jobs on Dependabot-triggered runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,11 @@ jobs:
   start-runner:
     name: Start self-hosted EC2 runner
     needs: check
+    # Dependabot-triggered runs don't have access to secrets.* (GitHub
+    # redacts them for dependabot[bot]), so start-runner and the
+    # acceptance test would fail at "Configure AWS credentials". Skip
+    # those jobs for Dependabot; the check job still runs on its PRs.
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
@@ -91,6 +96,7 @@ jobs:
     name: Acceptance test
     runs-on: ${{ needs.start-runner.outputs.label }} # run the job on the newly created runner
     needs: start-runner
+    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v4 # pinned to v4 (node20) — self-hosted EC2 runner doesn't support node24 yet
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,20 @@ Before creating git commits, check that `git config user.email` is set. If it is
 - PRs should include both unit tests and Terraform acceptance tests where applicable.
 - Acceptance tests use `resource.Test()` with `TestStep` — see `namecheap/provider_test.go` for examples.
 
+### Dependabot PRs
+
+Workflow runs triggered by `dependabot[bot]` do **not** have access to `secrets.*` (GitHub redacts them by design). The `start-runner`, `acceptance_test`, and `stop-runner` jobs are gated with `if: ${{ github.actor != 'dependabot[bot]' }}` and appear as **skipped**, not failed, on Dependabot PRs — treat that as the expected state, not a regression.
+
+When reviewing or preparing a Dependabot PR for merge:
+
+- The `check` job (unit tests, lint, Codecov) must still be green.
+- Skipped EC2 jobs are not a failure and do not need "re-running" as-is.
+- Before approving merge, trigger acceptance tests manually under a maintainer identity so secrets resolve:
+  ```shell
+  gh workflow run CI --ref dependabot/go_modules/<branch-name>
+  ```
+  The resulting run is attributed to the maintainer, so `github.actor != 'dependabot[bot]'` is true and the full pipeline executes.
+
 ## Architecture
 
 Terraform provider (terraform-plugin-sdk/v2) managing Namecheap domain DNS via go-namecheap-sdk/v2. Single resource: `namecheap_domain_records`. All logic in `namecheap/` package (package name: `namecheap_provider`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,19 @@ $ git push --force-with-lease
   where applicable. Acceptance tests should use `resource.Test()` with `TestStep`.
 - Keep PRs focused — one logical change per PR.
 
+### Dependabot PRs (maintainers)
+
+Dependabot-triggered workflow runs don't have access to repository secrets — GitHub redacts `secrets.*` for `dependabot[bot]` by design, so any job that reaches AWS, the self-hosted EC2 runner, or the Namecheap sandbox credentials cannot complete. For that reason the `start-runner`, `acceptance_test`, and `stop-runner` jobs are gated with `if: ${{ github.actor != 'dependabot[bot]' }}` and will show as **skipped** (not failed) on Dependabot PRs. The `check` job still runs and must pass.
+
+Before merging a Dependabot PR, a maintainer must trigger acceptance tests manually under their own identity. Secrets resolve for maintainer-initiated runs, so the full pipeline executes:
+
+```shell
+gh workflow run CI --ref dependabot/go_modules/<branch-name>
+# or: Actions tab → CI → Run workflow → select the Dependabot branch
+```
+
+Once the manual run is green, merge as usual. If the dependency touches code paths exercised only by acceptance tests, do not merge on the `check` job alone.
+
 ## Release
 
 We'll publish a new tagged release once significant changes have accumulated. A new version will be available on the registry


### PR DESCRIPTION
Closes #156.

## Summary

1. **ci.yml** — add `if: ${{ github.actor != 'dependabot[bot]' }}` to the `start-runner` and `acceptance_test` jobs. `stop-runner` is already guarded by `needs.start-runner.outputs.ec2-instance-id != ''`, which evaluates to false when start-runner is skipped, so the full EC2 lifecycle cleanly skips on Dependabot PRs.
2. **CONTRIBUTING.md** + **CLAUDE.md** — document the flow for maintainers and for Claude-driven reviews: skipped EC2 jobs on Dependabot PRs are expected; trigger acceptance manually via `gh workflow run CI --ref <branch>` under a maintainer identity before merging.

## Why

After #150 merged, Dependabot started opening PRs (#155 etc.) and every workflow run failed at `start-runner → Configure AWS credentials`:

```
##[error]Input required and not supplied: aws-region
```

Root cause is GitHub's default: workflow runs triggered by `dependabot[bot]` have `secrets.*` redacted to empty strings. That's working as designed — it stops a malicious dep update from touching AWS credentials, the self-hosted EC2 runner, or the GH token. The fix is to recognize that design and skip the jobs that need those secrets, and to give future maintainers (human and otherwise) a clear flow for rerunning acceptance under their own identity.

## What Dependabot PRs still run

The `check` job — `make check`, `make test`, lint, Codecov upload. No hard secret dependency (Codecov has `fail_ci_if_error: false`). So unit-test regressions introduced by a dep bump are still caught on the Dependabot PR.

## Test plan

- [ ] On this PR: `check` runs, `start-runner` / `acceptance_test` / `stop-runner` run normally (author is not `dependabot[bot]`).
- [ ] On a Dependabot PR (#155 after rebase): `check` runs, the three EC2 jobs show as **skipped**, not failed.
- [ ] `gh workflow run CI --ref dependabot/go_modules/<branch>` started by a maintainer resolves secrets and runs the full pipeline.