### PR TITLE
ci: rotate ec2-github-runner SHA to v2.333.1 runner and drop @v4 carve-out

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
         # SHA-pinned (was @feat/al2023-support). The same SHA is reused by
         # the stop-runner step so both halves of the runner lifecycle run
         # identical action code.
-        uses: namecheap/ec2-github-runner@6654a7e62b1f37081a92d90036e80685f5381a87 # feat/al2023-support @ 2026-04-20
+        uses: namecheap/ec2-github-runner@a6a82df58c619623b9fd0d273b290c197b5bc675 # feat/al2023-support @ 2026-04-20 — actions/runner v2.333.1 (ships externals/node24)
         with:
           mode: start
           github-token: ${{ secrets.GH_TOKEN }}
@@ -98,7 +98,7 @@ jobs:
     needs: start-runner
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
-      - uses: actions/checkout@v4 # pinned to v4 (node20) — self-hosted AL2023 EC2 runner doesn't support node24 yet, so actions/checkout@v5+ cannot start here
+      - uses: actions/checkout@v6
 
       - name: Set up Go
         run: |
@@ -159,7 +159,7 @@ jobs:
       - name: Stop EC2 runner
         # SHA-pinned (was @main). Matches the start-runner step above so
         # stop logic is in lockstep with the code that started the runner.
-        uses: namecheap/ec2-github-runner@6654a7e62b1f37081a92d90036e80685f5381a87 # feat/al2023-support @ 2026-04-20
+        uses: namecheap/ec2-github-runner@a6a82df58c619623b9fd0d273b290c197b5bc675 # feat/al2023-support @ 2026-04-20 — actions/runner v2.333.1 (ships externals/node24)
         with:
           mode: stop
           github-token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Closes #158.

## Summary

Three line changes in `.github/workflows/ci.yml`:

- Rotate both `namecheap/ec2-github-runner` SHA pins from `6654a7e6…` (pre-bump) to `a6a82df5…` — the tip of `feat/al2023-support` after [namecheap/ec2-github-runner#3](https://github.com/namecheap/ec2-github-runner/pull/3) merged (bumps `actions/runner` v2.321.0 → v2.333.1).
- Move the `acceptance_test` step's checkout from `actions/checkout@v4` to `@v6`, aligning with the `check` job (`ci.yml:25`) and `release.yml`.
- Drop the now-obsolete `# pinned to v4 (node20) — self-hosted AL2023 EC2 runner doesn't support node24 yet` comment.

## Why this is safe now

Runner v2.333.1 ships `externals/node24`. `actions/checkout@v5/@v6` declares `runs: using: node24` in its `action.yml` and is satisfied on the self-hosted AL2023 runner the moment the new runner binary is downloaded during EC2 user-data. No AMI change was needed — the runner brings its own Node.

Full chain: namecheap/ec2-github-runner#3 (runner bump) → new `feat/al2023-support` tip `a6a82df5` → this PR rotates the pin → `@v6` works on the acceptance runner.

## Test plan

- [ ] Push triggers CI; `check` job green.
- [ ] `start-runner` launches an EC2 instance off the latest AL2023 AMI and registers an actions/runner v2.333.1 worker (visible in the EC2 user-data log).
- [ ] `acceptance_test` completes the `actions/checkout@v6` step without a node24 missing-externals error (the former failure mode).
- [ ] `make testacc` runs to completion against the sandbox domain.
- [ ] `stop-runner` terminates the EC2 instance.

## Follow-ups (out of scope for this PR)

- #147 — SHA-pin third-party actions (codecov, goreleaser, aws-actions, golangci-lint). Lower priority now but still relevant.
- #146 — Add `go mod verify` in CI.
- #144 — Verify Go and Terraform download checksums.