### PR TITLE
ci: verify Go and Terraform download checksums on self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,8 @@ jobs:
       - name: Set up Go
         run: |
           curl -fsSLo go1.25.9.linux-amd64.tar.gz https://dl.google.com/go/go1.25.9.linux-amd64.tar.gz
+          expected_go_sha="$(curl -fsSL https://dl.google.com/go/go1.25.9.linux-amd64.tar.gz.sha256)"
+          echo "${expected_go_sha}  go1.25.9.linux-amd64.tar.gz" | sha256sum -c -
           rm -rf .go-instance
           mkdir .go-instance
           tar -C .go-instance -xzf go1.25.9.linux-amd64.tar.gz
@@ -120,6 +122,8 @@ jobs:
       - name: Set up Terraform
         run: |
           curl -fsSLo terraform.zip https://releases.hashicorp.com/terraform/1.14.8/terraform_1.14.8_linux_amd64.zip
+          expected_tf_sha="$(curl -fsSL https://releases.hashicorp.com/terraform/1.14.8/terraform_1.14.8_SHA256SUMS | awk '/terraform_1.14.8_linux_amd64.zip$/ {print $1}')"
+          echo "${expected_tf_sha}  terraform.zip" | sha256sum -c -
           rm -rf .terraform-bin
           mkdir .terraform-bin
           unzip -o terraform.zip -d .terraform-bin


### PR DESCRIPTION
Closes #144.

## Summary

Add sha256 verification to the two vendor-CDN tarball downloads in the `acceptance_test` job. Both vendors already publish signed checksum manifests next to their release artifacts; this PR just starts consulting them.

Four added lines, two per step:

```yaml
# Go
expected_go_sha="$(curl -fsSL https://dl.google.com/go/go1.25.9.linux-amd64.tar.gz.sha256)"
echo "${expected_go_sha}  go1.25.9.linux-amd64.tar.gz" | sha256sum -c -

# Terraform
expected_tf_sha="$(curl -fsSL https://releases.hashicorp.com/terraform/1.14.8/terraform_1.14.8_SHA256SUMS | awk '/terraform_1.14.8_linux_amd64.zip$/ {print $1}')"
echo "${expected_tf_sha}  terraform.zip" | sha256sum -c -
```

Fail-closed: a mismatch or a non-zero exit from either `curl` causes `sha256sum -c -` to fail the step (`bash -euo pipefail` is the GitHub Actions default for `run:` blocks).

## Why

TLS protects transport but not origin. A CDN compromise, origin tampering, or a typo in a future version bump would be accepted silently today. With this change, any deviation between the downloaded artifact and the vendor-published digest stops CI before `tar -xzf` or `unzip` runs.

## Verification

Smoke-tested locally against the real URLs:

```
=== Go ===
go1.25.9.linux-amd64.tar.gz: OK
=== Terraform ===
terraform.zip: OK
=== Negative test (tamper) ===
sha256sum: WARNING: 1 computed checksum did NOT match
terraform.zip: FAILED
OK: failed closed on tamper as expected
```

## Scope notes

- GPG signature verification on `terraform_…_SHA256SUMS.sig` is *not* added here — that would bring in a keyring rotation concern (exactly the one #142 highlighted). If the team wants that later, it's a separate PR.
- The `check` job uses `actions/setup-go@v6` which fetches via the official GitHub Actions setup (already integrity-checked), so no change needed there.

## Test plan

- [x] Green CI on this PR confirms both verification steps pass against the current Go 1.25.9 and Terraform 1.14.8 publications.
- [ ] Manual negative test (optional): temporarily change `1.25.9` to `1.25.10` in the `.sha256` URL — the step should fail immediately at the checksum line, not at tar extraction.

## Follow-ups tracked separately

- #147 — SHA-pin third-party actions.
- #146 — `go mod verify` in the check job.