### PR TITLE
ci: SHA-pin third-party GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         run: make check
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           version: v2.8.0
           skip-cache: true
@@ -42,7 +42,7 @@ jobs:
         run: make test
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           files: coverage.out
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -62,7 +62,7 @@ jobs:
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -155,7 +155,7 @@ jobs:
     if: ${{ always() && needs.start-runner.outputs.ec2-instance-id != '' }} # stop the runner only if it was actually started
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,13 +27,13 @@ jobs:
 
       - name: Import GPG key
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v7
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@e24998b8b67b290c2fa8b7c14fcfa7de2c5c9b8c # v7.1.0
         with:
           version: latest
           args: release --clean


### PR DESCRIPTION
Closes #147.

## Summary

Rotate five third-party `uses:` entries from floating major tags (`@v6`, `@v7`, `@v9`) to 40-char commit SHAs with a trailing release-tag comment:

| Workflow | Action | Before | After |
|---|---|---|---|
| `ci.yml:36` | `golangci/golangci-lint-action` | `@v9` | `@1e7e51e7…` # v9.2.0 |
| `ci.yml:45` | `codecov/codecov-action` | `@v6` | `@57e3a136…` # v6.0.0 |
| `ci.yml:65, 158` | `aws-actions/configure-aws-credentials` | `@v6` | `@ec61189d…` # v6.1.0 |
| `release.yml:30` | `crazy-max/ghaction-import-gpg` | `@v7` | `@2dc316de…` # v7.0.0 |
| `release.yml:36` | `goreleaser/goreleaser-action` | `@v7` | `@e24998b8…` # v7.1.0 |

First-party `actions/*` refs (`checkout`, `setup-go`, `attest-build-provenance`) are intentionally left alone — out of scope per #147.

## Why

GitHub tags are mutable. If any of these action maintainers (or an attacker who compromises their account) force-moves `@v6` / `@v7` / `@v9`, the next CI run executes whatever the moved tag points at. In this repo that means:
- `codecov` → `CODECOV_TOKEN`
- `aws-actions` → `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / the self-hosted EC2 runner
- `crazy-max` → the release GPG private key and passphrase
- `goreleaser` → `GITHUB_TOKEN` + whatever artifacts it publishes to the registry

Pinning to a 40-char SHA locks the consumed code; the trailing `# vX.Y.Z` comment keeps the human-readable version and lets Dependabot (landed in #145) rotate both the SHA and the comment in a single PR when a new release is available.

## Provenance

Each SHA was captured via `gh api /repos/OWNER/REPO/commits/vN --jq .sha` on 2026-04-20 and cross-checked against the repo's `/releases` feed to confirm the precise tag the major-version alias currently points at. No intermediate commit was chosen.

## Test plan

- [ ] CI job runs to green on this PR — each SHA-pinned action resolves and runs normally.
- [ ] Dependabot opens an update PR the next time any of these actions cuts a new release (we can verify this is wired up as expected rather than by waiting).

## Follow-ups tracked

- #146 — `go mod verify` in the `check` job. Remaining open item from the original supply-chain audit.