### PR TITLE
docs: generalize Dependabot branch pattern in CI re-trigger example

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,9 +40,9 @@ When reviewing or preparing a Dependabot PR for merge:
 
 - The `check` job (unit tests, lint, Codecov) must still be green.
 - Skipped EC2 jobs are not a failure and do not need "re-running" as-is.
-- Before approving merge, trigger acceptance tests manually under a maintainer identity so secrets resolve:
+- Before approving merge, trigger acceptance tests manually under a maintainer identity so secrets resolve. Copy the exact branch name from the PR (Dependabot prefixes branches with the ecosystem — `go_modules`, `github_actions`, etc.):
   ```shell
-  gh workflow run CI --ref dependabot/go_modules/<branch-name>
+  gh workflow run CI --ref <dependabot-branch-from-the-PR>
   ```
   The resulting run is attributed to the maintainer, so `github.actor != 'dependabot[bot]'` is true and the full pipeline executes.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,10 +89,11 @@ $ git push --force-with-lease
 
 Dependabot-triggered workflow runs don't have access to repository secrets — GitHub redacts `secrets.*` for `dependabot[bot]` by design, so any job that reaches AWS, the self-hosted EC2 runner, or the Namecheap sandbox credentials cannot complete. For that reason the `start-runner`, `acceptance_test`, and `stop-runner` jobs are gated with `if: ${{ github.actor != 'dependabot[bot]' }}` and will show as **skipped** (not failed) on Dependabot PRs. The `check` job still runs and must pass.
 
-Before merging a Dependabot PR, a maintainer must trigger acceptance tests manually under their own identity. Secrets resolve for maintainer-initiated runs, so the full pipeline executes:
+Before merging a Dependabot PR, a maintainer must trigger acceptance tests manually under their own identity. Secrets resolve for maintainer-initiated runs, so the full pipeline executes. Use the exact branch name shown on the PR — Dependabot prefixes branches with the ecosystem (`go_modules`, `github_actions`, etc.), and the package segment that follows varies per update:
 
 ```shell
-gh workflow run CI --ref dependabot/go_modules/<branch-name>
+# copy the branch from the PR page, e.g. dependabot/go_modules/github.com/hashicorp/go-cty-1.5.0
+gh workflow run CI --ref <dependabot-branch-from-the-PR>
 # or: Actions tab → CI → Run workflow → select the Dependabot branch
 ```
 


### PR DESCRIPTION
Addresses the AI-findings scan note on `CONTRIBUTING.md` — the example

```shell
gh workflow run CI --ref dependabot/go_modules/<branch-name>
```

hardcodes the `go_modules` segment, which only applies to gomod dependency PRs. Dependabot is configured for both `gomod` and `github-actions` in this repo (see #145), and could be extended to more ecosystems; a reader who applies the example verbatim to an Actions-ecosystem PR would hit a `ref not found` error without understanding why.

## What changed

- Generic placeholder `<dependabot-branch-from-the-PR>`.
- One-line note in both `CONTRIBUTING.md` and `CLAUDE.md` explaining that the ecosystem segment (`go_modules`, `github_actions`, etc.) and package segment both vary per update.
- Example branch shown alongside so the reader knows what the full name shape looks like.

5-line diff across the two files.

## Test plan

- [ ] `make docs-validate` not applicable (Markdown only).
- [ ] Visual: the CLAUDE.md + CONTRIBUTING.md render cleanly on the PR page.