### PR TITLE
ci: verify Go module integrity in check job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
         with:
           go-version: 1.25.9
 
+      - name: Verify module integrity
+        run: go mod verify
+
       - name: Check
         run: make check
 


### PR DESCRIPTION
Closes #146.

## Summary

Add a `go mod verify` step to the `check` job, immediately after `Set up Go`. The command rehashes every module in the local cache against its recorded `go.sum` hash; any mismatch (proxy tamper, corrupt cache, `go.sum` drift) fails the step before `make check` / lint / test run against potentially compromised code.

```yaml
- name: Verify module integrity
  run: go mod verify
```

Runtime impact: under a second on a warm cache.

## Placement note

Issue #146 suggested placing it before `make test`. I put it one step earlier — before `make check` — so every Go-toolchain step in the pipeline (`go vet`, lint, test) runs under verified modules. No downside versus the original placement; fails even closer to the point of compromise.

## Verification

Local smoke test on the PR branch:

```
$ go mod verify
all modules verified
```

Negative test was not required — `go mod verify` is a well-tested Go toolchain command.

## Follow-ups

This closes the last remaining open item from the original supply-chain pinning audit. #144, #145, #147, #148, #156, #158 are all merged; #146 is this one.