### PR TITLE
ci: rotate ec2-github-runner SHA (node24 runtime, GITHUB_OUTPUT writes)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
         # SHA-pinned (was @feat/al2023-support). The same SHA is reused by
         # the stop-runner step so both halves of the runner lifecycle run
         # identical action code.
-        uses: namecheap/ec2-github-runner@a6a82df58c619623b9fd0d273b290c197b5bc675 # feat/al2023-support @ 2026-04-20 — actions/runner v2.333.1 (ships externals/node24)
+        uses: namecheap/ec2-github-runner@945b406e4793b33a43c36b0539aa81b4a2a4af5e # feat/al2023-support @ 2026-04-20 — actions/runner v2.333.1, action.yml node24, GITHUB_OUTPUT writes
         with:
           mode: start
           github-token: ${{ secrets.GH_TOKEN }}
@@ -166,7 +166,7 @@ jobs:
       - name: Stop EC2 runner
         # SHA-pinned (was @main). Matches the start-runner step above so
         # stop logic is in lockstep with the code that started the runner.
-        uses: namecheap/ec2-github-runner@a6a82df58c619623b9fd0d273b290c197b5bc675 # feat/al2023-support @ 2026-04-20 — actions/runner v2.333.1 (ships externals/node24)
+        uses: namecheap/ec2-github-runner@945b406e4793b33a43c36b0539aa81b4a2a4af5e # feat/al2023-support @ 2026-04-20 — actions/runner v2.333.1, action.yml node24, GITHUB_OUTPUT writes
         with:
           mode: stop
           github-token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
## Summary

Rotate both `namecheap/ec2-github-runner` SHA pins from `a6a82df5…` (tip of `feat/al2023-support` as of #159) to `945b406e…` (current tip after two more fixes):

- [namecheap/ec2-github-runner#4](https://github.com/namecheap/ec2-github-runner/pull/4) — `action.yml` `using:` moved from `node12` to `node24`. Silences GitHub's "Node.js 20 actions are deprecated" warning that's been surfacing on every Actions run of this repo.
- [namecheap/ec2-github-runner#5](https://github.com/namecheap/ec2-github-runner/pull/5) — outputs written directly to `$GITHUB_OUTPUT` instead of via the deprecated `::set-output` workflow command. Silences the "set-output command is deprecated" warning.

## Rotation history

| Event | Runner SHA |
|---|---|
| Initial SHA pin (#148 → #149) | `6654a7e6…` |
| Runner bump to v2.333.1 for node24 externals (#158 → #159) | `a6a82df5…` |
| **This PR** — action.yml node24 + GITHUB_OUTPUT writes | `945b406e…` |

Two-line diff, same pattern as #159.

## Why now

Both warnings show up on every CI run in the Actions tab as [annotations](https://github.com/namecheap/terraform-provider-namecheap/actions/runs/24670994484). Neither was blocking yet, but GitHub has already announced:
- Node 20 actions forced to run on node 24 starting **2026-06-02**.
- `::set-output` disabled outright on an unspecified date (2022 deprecation notice).

Landing the fix early costs nothing and kills the annotation spam so real warnings stay visible.

## Test plan

- [ ] Push triggers CI; Actions tab shows **zero** warnings on the `start-runner` and `stop-runner` jobs (the two surfacing earlier).
- [ ] `start-runner` successfully launches an instance — `label` and `ec2-instance-id` outputs are populated from `$GITHUB_OUTPUT`, and `acceptance_test` consumes them as `${{ needs.start-runner.outputs.label }}` without change.
- [ ] `stop-runner` terminates the instance at the end of the run.