### PR TITLE
ci: rotate ec2-github-runner SHA (DEP0169 url.parse filter)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
         # SHA-pinned (was @feat/al2023-support). The same SHA is reused by
         # the stop-runner step so both halves of the runner lifecycle run
         # identical action code.
-        uses: namecheap/ec2-github-runner@945b406e4793b33a43c36b0539aa81b4a2a4af5e # feat/al2023-support @ 2026-04-20 — actions/runner v2.333.1, action.yml node24, GITHUB_OUTPUT writes
+        uses: namecheap/ec2-github-runner@54459d6e0bb2372133adc8070d20a048a5418289 # feat/al2023-support @ 2026-04-20 — actions/runner v2.333.1, action.yml node24, GITHUB_OUTPUT writes, DEP0169 filter
         with:
           mode: start
           github-token: ${{ secrets.GH_TOKEN }}
@@ -166,7 +166,7 @@ jobs:
       - name: Stop EC2 runner
         # SHA-pinned (was @main). Matches the start-runner step above so
         # stop logic is in lockstep with the code that started the runner.
-        uses: namecheap/ec2-github-runner@945b406e4793b33a43c36b0539aa81b4a2a4af5e # feat/al2023-support @ 2026-04-20 — actions/runner v2.333.1, action.yml node24, GITHUB_OUTPUT writes
+        uses: namecheap/ec2-github-runner@54459d6e0bb2372133adc8070d20a048a5418289 # feat/al2023-support @ 2026-04-20 — actions/runner v2.333.1, action.yml node24, GITHUB_OUTPUT writes, DEP0169 filter
         with:
           mode: stop
           github-token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
## Summary

Rotate both `namecheap/ec2-github-runner` SHA pins from `945b406e…` to `54459d6e…` — new tip of `feat/al2023-support` after [namecheap/ec2-github-runner#6](https://github.com/namecheap/ec2-github-runner/pull/6) merged.

That PR added a `process.emitWarning` override filtering **only** `DEP0169` (the `url.parse()` deprecation emitted by the bundled aws-sdk v2 on every EC2 API call). All other warnings — including future deprecations, user-installed `'warning'` listeners, and Node's default stderr formatter — still pass through.

## Rotation history

| Event | Runner SHA |
|---|---|
| Initial pin (#148 → #149) | `6654a7e6…` |
| Runner bump to v2.333.1 for node24 externals (#158 → #159) | `a6a82df5…` |
| action.yml node24 + `GITHUB_OUTPUT` writes (#164) | `945b406e…` |
| **This PR** — DEP0169 filter | `54459d6e…` |

Two-line diff, same pattern as #159 / #164.

## Why

With #164 merged, two of the three recurring CI-page warnings went away. The remaining `DEP0169` was visible on [this run](https://github.com/namecheap/terraform-provider-namecheap/actions/runs/). Landing the filter closes the set — the `start-runner` and `stop-runner` jobs should now emit zero annotations.

## Test plan

- [ ] Push triggers CI; Actions tab shows **zero** warnings on `start-runner` / `stop-runner`.
- [ ] `acceptance_test` completes end-to-end unchanged.
- [ ] No new warnings surface that were previously masked by the DEP0169 noise.