### PR TITLE
ci: add Trivy security scan (SCA + IaC + secrets) plus SBOM artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,9 +51,54 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
+  security:
+    # Trivy scan covers three concerns in one job:
+    #  - SCA: CVEs in Go dependencies declared by go.mod / go.sum.
+    #  - IaC: misconfigurations in any Terraform or YAML at the
+    #    repo root (examples/, .github/workflows/, etc.).
+    #  - Secret scan: accidental tokens or keys checked into the tree.
+    # A separate step emits a CycloneDX SBOM as a workflow artifact so
+    # downstream tooling (dependency-track, release provenance, legal
+    # audits) can consume a signed inventory without re-running scans.
+    name: Security scan (Trivy)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Trivy vuln + misconfig + secret scan
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          scanners: vuln,misconfig,secret
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: '1'
+          format: table
+
+      - name: Generate CycloneDX SBOM
+        # Runs even if the scan above found HIGH/CRITICAL — the SBOM is
+        # a static inventory and should be produced regardless of
+        # gating outcome so consumers can see what went into the tree.
+        if: ${{ !cancelled() }}
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: cyclonedx
+          output: sbom.cdx.json
+
+      - name: Upload SBOM artifact
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: sbom-cyclonedx
+          path: sbom.cdx.json
+          retention-days: 90
+
   start-runner:
     name: Start self-hosted EC2 runner
-    needs: check
+    needs: [check, security]
     # Dependabot-triggered runs don't have access to secrets.* (GitHub
     # redacts them for dependabot[bot]), so start-runner and the
     # acceptance test would fail at "Configure AWS credentials". Skip


### PR DESCRIPTION
## Summary

New `security` job in `ci.yml` running `aquasecurity/trivy-action` on `ubuntu-latest` in parallel with the existing `check` job. Three concerns handled in one job, plus a CycloneDX SBOM artifact:

| Concern | Trivy scanner | Gating |
|---|---|---|
| **SCA** — CVEs in Go deps declared by `go.mod` / `go.sum` | `vuln` | Fails on `CRITICAL,HIGH` with `ignore-unfixed: true` |
| **IaC** — misconfig in workflow YAML / Terraform / any config file | `misconfig` | Same |
| **Secrets** — accidentally checked-in tokens / keys | `secret` | Same |
| **SBOM** — CycloneDX inventory | `trivy fs --format cyclonedx` | Runs even on scan failure (`if: !cancelled()`) so audit data is preserved |

## Why the gate placement

`start-runner`'s `needs:` is updated from `check` to `[check, security]`. A HIGH/CRITICAL finding now stops the pipeline before the self-hosted EC2 runner spins up — no wasted EC2 lifecycle on a PR that's already blocked on security grounds.

## Why `ignore-unfixed: true`

CVEs without an upstream fix can't be resolved by a dependency bump; gating on them turns security into a dice roll every day a new advisory is published. Unfixed findings still appear in `trivy-results` via SBOM / manual scans, they just don't block merges.

## Supply-chain pinning

Both new actions are SHA-pinned per #147:

- `aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1` # v0.35.0
- `actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02` # v4

Dependabot (landed in #145) will propose version bumps in-place on these SHAs.

## Verification

Local smoke test:

```
$ trivy fs --scanners vuln,misconfig,secret --severity CRITICAL,HIGH --ignore-unfixed .

┌────────┬───────┬─────────────────┬───────────────────┬─────────┐
│ Target │ Type  │ Vulnerabilities │ Misconfigurations │ Secrets │
├────────┼───────┼─────────────────┼───────────────────┼─────────┤
│ go.mod │ gomod │        0        │         -         │    -    │
└────────┴───────┴─────────────────┴───────────────────┴─────────┘
```

Zero findings on the current tree — first CI run will be green.

## Test plan

- [ ] Push triggers CI; `security` job runs and passes (exit code 0 from Trivy).
- [ ] `sbom-cyclonedx` artifact is produced and downloadable from the run summary.
- [ ] `start-runner` depends on both `check` and `security` completing successfully — a forced failure of either blocks acceptance test.

## Follow-ups (separate PRs)

- Add a GitHub Code Scanning upload (`github/codeql-action/upload-sarif`) once the repo has code scanning enabled. Would surface findings under the Security tab rather than only the job log.
- Consider adding Trivy to `release.yml` for a post-tag scan on the released archive.