### PR TITLE
ci: force node24 for JS actions on Security scan job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,13 @@ jobs:
     # audits) can consume a signed inventory without re-running scans.
     name: Security scan (Trivy)
     runs-on: ubuntu-latest
+    # trivy-action v0.35.0 transitively uses actions/cache@v3 (Node 20).
+    # Force Node 24 for every JS action in this job so the deprecation
+    # warning goes away without waiting for aquasecurity to bump their
+    # internal actions/cache pin. Drop this once trivy-action ships an
+    # actions/cache@v5 (Node 24) internally.
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary

Set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'` on the `security` job. Seven added lines in `ci.yml`, all inside the job's new `env:` block plus an explanatory comment.

## Why

After #166 merged, every run of the `security` job surfaces this warning:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: `actions/cache@0400d5f6…`

The flagged action is **inside** `aquasecurity/trivy-action@v0.35.0` (which is the latest — there's no newer release that bumps the internal `actions/cache` pin). We can't SHA-rotate our way out of this without aquasecurity cutting a new release.

`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` is GitHub's official opt-in env var for exactly this case: it tells the runner to execute any JS action declaring `node16` / `node20` on the installed `node24` binary anyway. GitHub's deprecation notice recommends this as the interim workaround.

## Scope

Scoped to the `security` job only via `jobs.security.env`. Other jobs run first-party actions (`actions/checkout@v6`, `actions/setup-go@v6`, `actions/attest-build-provenance@v4`) that are already on node24 natively, so they don't need the flag.

## Removal condition

Drop the env block once `aquasecurity/trivy-action` ships a release with `actions/cache@v5` (or whatever the node24 successor ends up being) internally. Comment in the YAML documents this.

## Test plan

- [ ] Push triggers CI; the `Security scan (Trivy)` job no longer shows the node20 deprecation warning.
- [ ] Trivy still runs and the SBOM artifact is still produced.