### PR TITLE
ci: fail check job on go.mod / go.sum drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,11 @@ jobs:
       - name: Verify module integrity
         run: go mod verify
 
+      - name: Verify go.mod and go.sum are tidy
+        run: |
+          go mod tidy
+          git diff --exit-code -- go.mod go.sum
+
       - name: Check
         run: make check
 


### PR DESCRIPTION
Closes #168.

## Summary

Five-line addition to the `check` job in `.github/workflows/ci.yml`: `go mod tidy` followed by `git diff --exit-code -- go.mod go.sum`. Fails the build if a contributor edits `go.mod` without re-tidying, so the resulting churn doesn't land on someone else's unrelated PR.

```yaml
- name: Verify go.mod and go.sum are tidy
  run: |
    go mod tidy
    git diff --exit-code -- go.mod go.sum
```

Placed after `go mod verify` (from #163), before `make check`. Fails even closer to the point of edit than the existing integrity check.

## Verification

Local run on current master:

```
$ go mod tidy
$ git diff --exit-code -- go.mod go.sum
(no diff)
```

First CI run will be green; any future drift produces a clear `git diff` output in the job log.

## Follow-ups tracked in the compliance plan (#173)

- #169 — mirror of this check for `vendor/` consistency
- #170 — Trivy license scanner + denylist
- #171 — SBOM on releases
- #172 — `SECURITY_COMPLIANCE.md` reference doc