### PR TITLE
ci: fail check job on vendor/ drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,11 @@ jobs:
           go mod tidy
           git diff --exit-code -- go.mod go.sum
 
+      - name: Verify vendor/ matches go.mod
+        run: |
+          go mod vendor
+          git diff --exit-code -- vendor/
+
       - name: Check
         run: make check
 


### PR DESCRIPTION
Closes #169.

## Summary

Mirror of the `go mod tidy` drift check in #174, for the committed `vendor/` tree. Five-line addition to the `check` job.

```yaml
- name: Verify vendor/ matches go.mod
  run: |
    go mod vendor
    git diff --exit-code -- vendor/
```

Placed right after `go mod verify`, colocating the three integrity gates (verify, tidy in #174, vendor here).

## Why

The repo ships a 29 MB `vendor/` directory. Without CI enforcement, a contributor who bumps a dep in `go.mod` without running `make vendor` lands a stale vendor tree, and downstream reviewers can't spot the drift without re-vendoring locally. This closes that gap.

## Scope note

This task explicitly **does not remove `vendor/`** — that's a separate decision flagged earlier during the #142 review. Scope here is "make the vendor tree trustworthy as long as we ship it."

## Verification

Local on current master:

```
$ go mod vendor
$ git diff --exit-code -- vendor/
(no diff)
```

First CI run will be green.

## Ordering with #174

If #174 merges first, this becomes a 5-line change right next to the tidy step. If this merges first, #174 does the same thing with its own step. No semantic conflict.

## Follow-ups tracked in the compliance plan (#173)

- #170 — Trivy license scanner + denylist
- #171 — SBOM on releases
- #172 — `SECURITY_COMPLIANCE.md`