### PR TITLE
ci: enable Trivy license scanner with explicit denylist policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,16 +72,19 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Trivy vuln + misconfig + secret scan
+      - name: Trivy vuln + misconfig + secret + license scan
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: fs
           scan-ref: .
-          scanners: vuln,misconfig,secret
+          scanners: vuln,misconfig,secret,license
           severity: CRITICAL,HIGH
           ignore-unfixed: true
           exit-code: '1'
           format: table
+          # License denylist lives in trivy.yaml at repo root; the
+          # action auto-loads it before each scanner runs.
+          trivy-config: trivy.yaml
 
       - name: Generate CycloneDX SBOM
         # Runs even if the scan above found HIGH/CRITICAL — the SBOM is

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,0 +1,20 @@
+# Trivy policy file — auto-loaded from repo root by `trivy fs`.
+# Applied to every CI run of the `security` job in .github/workflows/ci.yml.
+#
+# License policy: denylist the copyleft and source-available licenses we
+# cannot ship in a Terraform provider distributed via the public registry.
+# Everything else is permitted — enumerating a permissive allowlist is a
+# losing battle because new permissive licenses land each year and don't
+# need review to keep CI green.
+#
+# To request an exception, open a PR that adds a scoped `ignored-licenses:`
+# entry covering the specific package + license combination, with a
+# justification and a reviewer from outside the requesting team.
+license:
+  forbidden:
+    - GPL-2.0
+    - GPL-3.0
+    - AGPL-1.0
+    - AGPL-3.0
+    - LGPL-3.0
+    - SSPL-1.0


### PR DESCRIPTION
Closes #170.

## Summary

Two files:
- `trivy.yaml` — new, at repo root. Declares the license denylist (the six copyleft / source-available licenses we can't ship in a public-registry Terraform provider).
- `.github/workflows/ci.yml` — extend the existing Trivy step's `scanners:` from `vuln,misconfig,secret` to `vuln,misconfig,secret,license`, and point it at `trivy.yaml` via `trivy-config`.

```yaml
# trivy.yaml
license:
  forbidden:
    - GPL-2.0
    - GPL-3.0
    - AGPL-1.0
    - AGPL-3.0
    - LGPL-3.0
    - SSPL-1.0
```

## Why explicit policy (not rely on Trivy defaults)

Trivy's current defaults already cover these six licenses identically — I verified by running `trivy config --generate-default-config`. Committing the policy explicitly:
- **Discoverable:** a contributor sees `trivy.yaml` at repo root and knows what the rules are without reading Trivy's source.
- **Version-controlled:** changing the denylist requires a PR and a reviewer.
- **Durable:** protected against Trivy shifting its own defaults.

## Why denylist, not allowlist

The [AI Compliance Remediation Plan](#173) proposed a `.trivyignore` allowlist (`MIT`, `Apache-2.0`, `BSD-3-Clause`). Two reasons this PR goes the other way:

1. `.trivyignore` is Trivy's format for **CVE / misconfig ID suppressions**, not license configuration. Correct location for license policy is `trivy.yaml` with a `license.*` key.
2. An allowlist has to enumerate every permissive license we accept — MIT, Apache-2.0, BSD-2/3-Clause, MPL-2.0, ISC, 0BSD, and so on. New permissive licenses land every year and need manual additions to keep CI green. A denylist captures only the handful of copyleft licenses we reject, and permissive novelties don't need review to pass.

These two departures from the plan text are called out in #173.

## Verification

Local four-scanner run on current master (Trivy CLI 0.69.x):

```
$ trivy fs --scanners vuln,misconfig,secret,license --severity CRITICAL,HIGH \
    --ignore-unfixed --config trivy.yaml .

┌────────┬───────┬─────────────────┬───────────────────┬─────────┬──────────┐
│ Target │ Type  │ Vulnerabilities │ Misconfigurations │ Secrets │ Licenses │
├────────┼───────┼─────────────────┼───────────────────┼─────────┼──────────┤
│ go.mod │ gomod │        0        │         -         │    -    │    -     │
├────────┼───────┼─────────────────┼───────────────────┼─────────┼──────────┤
│ go.mod │   -   │        -        │         -         │    -    │    0     │
└────────┴───────┴─────────────────┴───────────────────┴─────────┴──────────┘
```

Zero findings across all four scanners. First CI run green.

## Exception workflow

Per the comment in `trivy.yaml`: open a PR adding a scoped `ignored-licenses:` entry (package + license combination) with a justification and a reviewer from outside the requesting team. Keeps policy changes auditable.

## Follow-ups in the compliance plan (#173)

- #171 — attach SBOM to GitHub Releases
- #172 — `SECURITY_COMPLIANCE.md` reference doc (will reference this denylist)