### PR TITLE
ci: attach CycloneDX SBOM to GitHub Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,3 +49,19 @@ jobs:
         uses: actions/attest-build-provenance@v4
         with:
           subject-checksums: ${{ steps.checksums.outputs.path }}
+
+      - name: Generate CycloneDX SBOM for release
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: cyclonedx
+          output: terraform-provider-namecheap_${{ github.ref_name }}_sbom.cdx.json
+
+      - name: Attach SBOM to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ github.ref_name }}" \
+            "terraform-provider-namecheap_${{ github.ref_name }}_sbom.cdx.json" \
+            --clobber


### PR DESCRIPTION
Closes #171.

## Summary

Two steps added to `.github/workflows/release.yml` after `attest-build-provenance`:

1. **Generate** a CycloneDX SBOM of the source tree via the same SHA-pinned `aquasecurity/trivy-action@57a97c7e…` already used in CI (#166). Output filename follows the release archive pattern: `terraform-provider-namecheap_<tag>_sbom.cdx.json`.
2. **Attach** to the GitHub Release via `gh release upload --clobber`. Works against GoReleaser's draft releases; `--clobber` makes re-runs idempotent.

## Why post-GoReleaser instead of GoReleaser's `sboms:` stanza

GoReleaser has a native `sboms:` section, but its semantics don't match the goal:
- `artifacts: archive` → one SBOM per archive (13 os/arch combos → 13 identical-content SBOMs).
- `artifacts: source` → requires enabling `source:` tarball generation first, which adds a new source-zip to every release and changes what release consumers expect.

`gh release upload` after GoReleaser finishes produces exactly one source-tree SBOM attached alongside the binaries, with no changes to `.goreleaser.yml`. Simpler review, smaller blast radius.

## Pinning

- `aquasecurity/trivy-action@57a97c7e…` — reused from #166, per #147 SHA-pin policy.
- `gh` CLI — preinstalled on `ubuntu-latest`, no extra action to pin.

## Test plan

- [ ] Next release tag (e.g. `v2.x.y`) triggers `release.yml`.
- [ ] The draft release on GitHub gains a `terraform-provider-namecheap_vX.Y.Z_sbom.cdx.json` asset.
- [ ] File opens as a valid CycloneDX JSON (`bomFormat: CycloneDX`, `specVersion: 1.x`, populated `components:`).
- [ ] Existing assets (binaries, `_SHA256SUMS`, `_SHA256SUMS.sig`, provenance attestation) are unchanged.

## Follow-ups in the compliance plan (#173)

- #172 — `SECURITY_COMPLIANCE.md` (will reference the release SBOM location).