### PR TITLE
docs: add SECURITY_COMPLIANCE.md as the compliance reference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ Before creating git commits, check that `git config user.email` is set. If it is
 - All CI checks must pass before merge (unit tests, acceptance tests, CodeQL, DCO).
 - PRs should include both unit tests and Terraform acceptance tests where applicable.
 - Acceptance tests use `resource.Test()` with `TestStep` — see `namecheap/provider_test.go` for examples.
+- `SECURITY_COMPLIANCE.md` is the authoritative reference for the compliance gates a PR is judged against (dependency drift, vulnerability/license scans, SBOM, supply-chain pinning). Check it before proposing anything that touches `go.mod`, `vendor/`, CI workflows, or action pins.
 
 ### Dependabot PRs
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,7 @@ $ git push --force-with-lease
 - Include both unit tests and [Terraform acceptance tests](https://developer.hashicorp.com/terraform/plugin/testing/acceptance-tests)
   where applicable. Acceptance tests should use `resource.Test()` with `TestStep`.
 - Keep PRs focused — one logical change per PR.
+- Familiarize yourself with [`SECURITY_COMPLIANCE.md`](SECURITY_COMPLIANCE.md) for the compliance gates your PR will be checked against (dependency drift, vulnerability and license scans, SBOM publication, etc.).
 
 ### Dependabot PRs (maintainers)
 

--- a/README.md
+++ b/README.md
@@ -73,4 +73,11 @@ resource "namecheap_domain_records" "domain2-com" {
 
 ### Contributing
 
-To contribute, please read our [contributing](CONTRIBUTING.md) docs.  
+To contribute, please read our [contributing](CONTRIBUTING.md) docs.
+
+### Compliance & security
+
+See [`SECURITY_COMPLIANCE.md`](SECURITY_COMPLIANCE.md) for the full set of
+controls (dependency pinning, vulnerability and license scanning, SBOM
+publication, supply-chain pinning) and for how to report a vulnerability.
+

--- a/SECURITY_COMPLIANCE.md
+++ b/SECURITY_COMPLIANCE.md
@@ -1,0 +1,117 @@
+# Security & Compliance
+
+This document is the single entry point for the security and compliance controls
+enforced in this repository. It is a reference for auditors, maintainers, and
+contributors — kept short, current, and linked to the PR or issue that
+introduced each control. If you are looking for "how do I report a
+vulnerability", see [Reporting a vulnerability](#reporting-a-vulnerability) at
+the bottom.
+
+## Dependency declaration and pinning
+
+- Every direct and indirect Go dependency is declared in [`go.mod`](go.mod)
+  with an exact version or pseudo-version.
+- [`go.sum`](go.sum) records a cryptographic hash for each module; re-fetches
+  that don't match the hash fail the build.
+- [`vendor/`](vendor/) is committed and kept in sync with `go.mod`. Vendoring
+  is not a soft policy — CI fails if `go mod vendor` would produce a diff.
+- Go toolchain version is pinned in `go.mod` (currently `go 1.25.9`).
+
+CI gates (in [`.github/workflows/ci.yml`](.github/workflows/ci.yml), `check` job):
+
+- `go mod verify` — rehashes the module cache against `go.sum` (#163).
+- `go mod tidy` + `git diff --exit-code` — fails on `go.mod` / `go.sum` drift
+  (#174).
+- `go mod vendor` + `git diff --exit-code` — fails on `vendor/` drift (#175).
+
+## Vulnerability, misconfig, secret, and license scanning
+
+- [Trivy](https://trivy.dev) runs on every push in the `security` job with
+  `scanners: vuln,misconfig,secret,license` (#166, #176).
+- Gate: `CRITICAL,HIGH` with `ignore-unfixed: true` — unfixable advisories
+  surface in the run log but don't block merges.
+- License policy lives in [`trivy.yaml`](trivy.yaml) at repo root. Denylist
+  (not allowlist) — six copyleft / source-available licenses are rejected:
+  `GPL-2.0`, `GPL-3.0`, `AGPL-1.0`, `AGPL-3.0`, `LGPL-3.0`, `SSPL-1.0`.
+  Every other license is accepted automatically, no review needed.
+- Exception workflow: open a PR adding a scoped `ignored-licenses:` entry
+  (package + license combination) to `trivy.yaml`, with a justification and
+  a reviewer from outside the requesting team.
+
+## Software Bill of Materials (SBOM)
+
+- CycloneDX JSON SBOM generated per push, uploaded as a workflow artifact
+  (`sbom-cyclonedx`, 90-day retention) (#166).
+- CycloneDX JSON SBOM attached to every tagged GitHub Release as
+  `terraform-provider-namecheap_<tag>_sbom.cdx.json` (#177).
+- SBOM is produced by Trivy against the source tree, matching the CVE /
+  license scans so the three views (scan report, workflow artifact,
+  release asset) are consistent.
+
+## CI / supply-chain pinning
+
+- Every third-party GitHub Action is pinned by 40-char commit SHA with a
+  trailing `# v<semver>` comment (#147, #161). Dependabot's `github-actions`
+  ecosystem (#150) rotates the SHA + comment atomically when a new version
+  releases.
+- `namecheap/ec2-github-runner` is SHA-pinned for both the `start-runner`
+  and `stop-runner` jobs at the same SHA (#149). Rotations are tracked
+  as single-line PRs (#159, #164, #165).
+- Dependabot covers `gomod` and `github-actions` with a weekly cadence
+  and a 5-PR cap per ecosystem (#150).
+
+## Binary download integrity
+
+On the self-hosted acceptance-test runner, two binaries are fetched from
+vendor CDNs. Both are checksum-verified before use (#160):
+
+- Go toolchain tarball → verified against `dl.google.com`'s `<tarball>.sha256`.
+- Terraform CLI zip → verified against HashiCorp's `terraform_<ver>_SHA256SUMS`.
+
+Either a transport-layer tamper or an origin compromise fails the step
+before `tar -xzf` / `unzip` runs.
+
+## Reproducibility
+
+- `go.mod` + `go.sum` + the `vendor/` tree make module resolution reproducible
+  on any Go-enabled machine without proxy access.
+- `GoReleaser` runs with `mod_timestamp: '{{ .CommitTimestamp }}'` and
+  `-trimpath` in [`.goreleaser.yml`](.goreleaser.yml) for reproducible binary
+  builds.
+- Release artifacts are GPG-signed (`_SHA256SUMS.sig`) and carry a GitHub-
+  issued build-provenance attestation via `actions/attest-build-provenance`.
+
+## Self-hosted runner supply chain
+
+The acceptance-test job runs on an ephemeral EC2 instance launched by the
+self-hosted runner action:
+
+- Runner binary version is controlled via the SHA-pinned
+  `namecheap/ec2-github-runner` action (currently bundles
+  `actions/runner v2.333.1`, `externals/node24`, and writes outputs to
+  `$GITHUB_OUTPUT` rather than the deprecated `::set-output`).
+- Dependabot-triggered runs skip the EC2-backed jobs entirely because GitHub
+  redacts `secrets.*` on `dependabot[bot]` events (#157). Maintainers
+  re-trigger the acceptance pipeline manually per the flow in
+  [`CONTRIBUTING.md`](CONTRIBUTING.md#dependabot-prs-maintainers).
+- AMI comes from `DEVOPS/hardened-amazon-linux2023` (internal).
+
+## What triggers a compliance failure
+
+Any of the following fails the build and blocks merge:
+
+- `go.mod` or `go.sum` not tidy.
+- `vendor/` tree does not match `go.mod`.
+- HIGH/CRITICAL CVE with an available fix in any dependency.
+- Denied license in any dependency.
+- Trivy secret scan matches a credential-shaped string.
+- Go or Terraform tarball SHA-256 mismatch on the self-hosted runner.
+- Stale module hashes (`go mod verify`).
+- Pre-commit hook failures (DCO sign-off missing, etc.).
+
+## Reporting a vulnerability
+
+Please use GitHub's "Report a vulnerability" flow under the repository's
+**Security** tab, or open a private security advisory directly at
+<https://github.com/namecheap/terraform-provider-namecheap/security/advisories/new>.
+Do not open a public issue for security reports.


### PR DESCRIPTION
Closes #172.

## Summary

- New file: `SECURITY_COMPLIANCE.md` at repo root. One-page compliance reference covering every security / compliance control currently in the repo.
- Back-links added from `README.md` (new "Compliance & security" subsection), `CONTRIBUTING.md` (Pull Requests section), and `CLAUDE.md` (Pull Requests section).

## What's covered

1. **Dependency declaration and pinning** — `go.mod`, `go.sum`, `vendor/`, Go toolchain pin. CI gates: `go mod verify` (#163), tidy drift (#174), vendor drift (#175).
2. **Vulnerability, misconfig, secret, and license scanning** — Trivy four-scanner run + `trivy.yaml` license denylist (#166, #176). `ignore-unfixed: true` rationale.
3. **SBOM** — CycloneDX per push (#166) and per release (#177).
4. **CI / supply-chain pinning** — third-party action SHA pins (#147, #161), `ec2-github-runner` pin rotations (#149, #159, #164, #165), Dependabot (#150).
5. **Binary download integrity** — Go tarball + Terraform zip SHA-256 verification on the self-hosted runner (#160).
6. **Reproducibility** — `mod_timestamp`, `-trimpath`, GPG sigs, build-provenance attestations.
7. **Self-hosted runner supply chain** — runner version, Dependabot skip guards (#157), AMI source.
8. **What triggers a compliance failure** — single checklist of every gate.
9. **Reporting a vulnerability** — points at GitHub's private security advisory flow.

## Why this exists

Before this PR the controls existed — scattered across `CLAUDE.md`, `CONTRIBUTING.md`, closed PR descriptions, and the YAML itself. Auditors and new contributors had no single place to see the picture. This doc closes that gap without adding new enforcement (all it does is index what's already there).

## Intentionally out of scope

- No new CI jobs or policies. Pure documentation change.
- No migration to `SECURITY.md` (GitHub's conventional filename for reporting flows). This file is broader in scope; if the team later wants a slimmer `SECURITY.md` just for the reporting flow, that's a separate follow-up.

## Ordering note

The compliance plan tracker (#173) recommends landing this **after** #174, #175, #176, #177 so the doc describes actual state rather than aspirational state. This PR references those PRs / issues inline; a post-merge sweep can replace "#174" with the merged-PR number if any are still open at that point.

## Follow-ups

None — this is the last planned task in the compliance remediation plan (#173).