### PR TITLE
ci: rotate ec2-github-runner SHA to aws-sdk v3 tip (Phase 1 dogfood)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
         # SHA-pinned (was @feat/al2023-support). The same SHA is reused by
         # the stop-runner step so both halves of the runner lifecycle run
         # identical action code.
-        uses: namecheap/ec2-github-runner@54459d6e0bb2372133adc8070d20a048a5418289 # feat/al2023-support @ 2026-04-20 — actions/runner v2.333.1, action.yml node24, GITHUB_OUTPUT writes, DEP0169 filter
+        uses: namecheap/ec2-github-runner@a1bd2f99953fff1dbae09841e794c9745229a543 # feat/al2023-support @ 2026-04-21 — aws-sdk v3 migration (Phase 1)
         with:
           mode: start
           github-token: ${{ secrets.GH_TOKEN }}
@@ -231,7 +231,7 @@ jobs:
       - name: Stop EC2 runner
         # SHA-pinned (was @main). Matches the start-runner step above so
         # stop logic is in lockstep with the code that started the runner.
-        uses: namecheap/ec2-github-runner@54459d6e0bb2372133adc8070d20a048a5418289 # feat/al2023-support @ 2026-04-20 — actions/runner v2.333.1, action.yml node24, GITHUB_OUTPUT writes, DEP0169 filter
+        uses: namecheap/ec2-github-runner@a1bd2f99953fff1dbae09841e794c9745229a543 # feat/al2023-support @ 2026-04-21 — aws-sdk v3 migration (Phase 1)
         with:
           mode: stop
           github-token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Dogfood rotation for [namecheap/ec2-github-runner#17](https://github.com/namecheap/ec2-github-runner/pull/17) (Phase 1: aws-sdk v2 → v3 + ncc 0.25 → 0.38). Rotates both pins `54459d6 → a1bd2f9`. A green acceptance test here is the real validation of the Phase 1 refactor.