### PR TITLE
ci: rotate ec2-github-runner SHA to Phase 4 tip (non-root + --ephemeral)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
         # SHA-pinned (was @feat/al2023-support). The same SHA is reused by
         # the stop-runner step so both halves of the runner lifecycle run
         # identical action code.
-        uses: namecheap/ec2-github-runner@a1bd2f99953fff1dbae09841e794c9745229a543 # feat/al2023-support @ 2026-04-21 — aws-sdk v3 migration (Phase 1)
+        uses: namecheap/ec2-github-runner@7b949a3d1789a476050f3c950117c91729b54be3 # feat/al2023-support @ 2026-04-21 — Phase 4: non-root runner, --ephemeral, runner-version input
         with:
           mode: start
           github-token: ${{ secrets.GH_TOKEN }}
@@ -231,7 +231,7 @@ jobs:
       - name: Stop EC2 runner
         # SHA-pinned (was @main). Matches the start-runner step above so
         # stop logic is in lockstep with the code that started the runner.
-        uses: namecheap/ec2-github-runner@a1bd2f99953fff1dbae09841e794c9745229a543 # feat/al2023-support @ 2026-04-21 — aws-sdk v3 migration (Phase 1)
+        uses: namecheap/ec2-github-runner@7b949a3d1789a476050f3c950117c91729b54be3 # feat/al2023-support @ 2026-04-21 — Phase 4: non-root runner, --ephemeral, runner-version input
         with:
           mode: stop
           github-token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Dogfood rotation for [namecheap/ec2-github-runner#18](https://github.com/namecheap/ec2-github-runner/pull/18) (Phase 4 of plan #173-equivalent). Rotates both pins `a1bd2f9 → 7b949a3`.

Phase 4 is the flagged-medium-risk change: runner now runs as a dedicated non-root `runner` user with `--ephemeral` registration. A green acceptance test here confirms that `make testacc` plus the workspace-local Go/Terraform setup still work when the runner isn't root. If something fails, I'll investigate before stacking Phases 5/6/7 on top.