### PR TITLE
ci: rotate ec2-github-runner SHA to Phase 4 safe tip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
         # SHA-pinned (was @feat/al2023-support). The same SHA is reused by
         # the stop-runner step so both halves of the runner lifecycle run
         # identical action code.
-        uses: namecheap/ec2-github-runner@a1bd2f99953fff1dbae09841e794c9745229a543 # feat/al2023-support @ 2026-04-21 — aws-sdk v3 migration (Phase 1)
+        uses: namecheap/ec2-github-runner@78f98d15001dea276cc48d299401345570fccb09 # feat/al2023-support @ 2026-04-21 — Phase 4 (runner-version input, --ephemeral, checksum verify; non-root reverted)
         with:
           mode: start
           github-token: ${{ secrets.GH_TOKEN }}
@@ -231,7 +231,7 @@ jobs:
       - name: Stop EC2 runner
         # SHA-pinned (was @main). Matches the start-runner step above so
         # stop logic is in lockstep with the code that started the runner.
-        uses: namecheap/ec2-github-runner@a1bd2f99953fff1dbae09841e794c9745229a543 # feat/al2023-support @ 2026-04-21 — aws-sdk v3 migration (Phase 1)
+        uses: namecheap/ec2-github-runner@78f98d15001dea276cc48d299401345570fccb09 # feat/al2023-support @ 2026-04-21 — Phase 4 (runner-version input, --ephemeral, checksum verify; non-root reverted)
         with:
           mode: stop
           github-token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Second attempt at the Phase 4 dogfood after #182 failed. The action-repo [PR #19](https://github.com/namecheap/ec2-github-runner/pull/19) reverted the non-root user transition that broke registration and kept everything else from Phase 4. This pin rotation (`a1bd2f9 → 78f98d1`) is the verification.