### PR TITLE
ci: rotate ec2-github-runner SHA to Phase 4 revert tip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
         # SHA-pinned (was @feat/al2023-support). The same SHA is reused by
         # the stop-runner step so both halves of the runner lifecycle run
         # identical action code.
-        uses: namecheap/ec2-github-runner@a1bd2f99953fff1dbae09841e794c9745229a543 # feat/al2023-support @ 2026-04-21 — aws-sdk v3 migration (Phase 1)
+        uses: namecheap/ec2-github-runner@249efbdb5306ebc79ecebf864bdb9d5c9c2152b6 # feat/al2023-support @ 2026-04-21 — Phase 4 fully reverted (Phase 1 bootstrap restored)
         with:
           mode: start
           github-token: ${{ secrets.GH_TOKEN }}
@@ -231,7 +231,7 @@ jobs:
       - name: Stop EC2 runner
         # SHA-pinned (was @main). Matches the start-runner step above so
         # stop logic is in lockstep with the code that started the runner.
-        uses: namecheap/ec2-github-runner@a1bd2f99953fff1dbae09841e794c9745229a543 # feat/al2023-support @ 2026-04-21 — aws-sdk v3 migration (Phase 1)
+        uses: namecheap/ec2-github-runner@249efbdb5306ebc79ecebf864bdb9d5c9c2152b6 # feat/al2023-support @ 2026-04-21 — Phase 4 fully reverted (Phase 1 bootstrap restored)
         with:
           mode: stop
           github-token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Action-side full revert landed at [namecheap/ec2-github-runner#21](https://github.com/namecheap/ec2-github-runner/pull/21). This rotation (`a1bd2f9 → 249efbd`) re-establishes the Phase 1 bootstrap as the production path after two Phase 4 dogfood failures (#182, #183).

Phase 4 work pauses on the action side pending debug instrumentation (ec2-github-runner#20) so future bootstrap changes can be bisected instead of failing en-masse.