### PR TITLE
ci: rotate ec2-github-runner SHA to Phase 7 tip (structured logging)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
         # SHA-pinned (was @feat/al2023-support). The same SHA is reused by
         # the stop-runner step so both halves of the runner lifecycle run
         # identical action code.
-        uses: namecheap/ec2-github-runner@249efbdb5306ebc79ecebf864bdb9d5c9c2152b6 # feat/al2023-support @ 2026-04-21 — Phase 4 fully reverted (Phase 1 bootstrap restored)
+        uses: namecheap/ec2-github-runner@b1b8d6d479e2220cc4706af273ee930c60cbeebc # feat/al2023-support @ 2026-04-21 — Phase 7: structured logging + debug input
         with:
           mode: start
           github-token: ${{ secrets.GH_TOKEN }}
@@ -231,7 +231,7 @@ jobs:
       - name: Stop EC2 runner
         # SHA-pinned (was @main). Matches the start-runner step above so
         # stop logic is in lockstep with the code that started the runner.
-        uses: namecheap/ec2-github-runner@249efbdb5306ebc79ecebf864bdb9d5c9c2152b6 # feat/al2023-support @ 2026-04-21 — Phase 4 fully reverted (Phase 1 bootstrap restored)
+        uses: namecheap/ec2-github-runner@b1b8d6d479e2220cc4706af273ee930c60cbeebc # feat/al2023-support @ 2026-04-21 — Phase 7: structured logging + debug input
         with:
           mode: stop
           github-token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Dogfood rotation for [namecheap/ec2-github-runner#22](https://github.com/namecheap/ec2-github-runner/pull/22) (structured logging + debug input). Log-only change — no behavior delta in the EC2 bootstrap. Rotates both pins `249efbd → b1b8d6d`.