### PR TITLE
ci: rotate ec2-github-runner SHA to Phase 6.a tip (IMDSv2 required)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
         # SHA-pinned (was @feat/al2023-support). The same SHA is reused by
         # the stop-runner step so both halves of the runner lifecycle run
         # identical action code.
-        uses: namecheap/ec2-github-runner@46cf1d0caac2cb1698dff6ba2aba682e45bd85c7 # feat/al2023-support @ 2026-04-21 — Phase 5: retry + independent cleanup in stop
+        uses: namecheap/ec2-github-runner@6bb148b43cd5b3734d81f8a7dd7ab15b3d7f7a8b # feat/al2023-support @ 2026-04-21 — Phase 6.a: IMDSv2 required
         with:
           mode: start
           github-token: ${{ secrets.GH_TOKEN }}
@@ -231,7 +231,7 @@ jobs:
       - name: Stop EC2 runner
         # SHA-pinned (was @main). Matches the start-runner step above so
         # stop logic is in lockstep with the code that started the runner.
-        uses: namecheap/ec2-github-runner@46cf1d0caac2cb1698dff6ba2aba682e45bd85c7 # feat/al2023-support @ 2026-04-21 — Phase 5: retry + independent cleanup in stop
+        uses: namecheap/ec2-github-runner@6bb148b43cd5b3734d81f8a7dd7ab15b3d7f7a8b # feat/al2023-support @ 2026-04-21 — Phase 6.a: IMDSv2 required
         with:
           mode: stop
           github-token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Dogfood rotation for [namecheap/ec2-github-runner#24](https://github.com/namecheap/ec2-github-runner/pull/24) (IMDSv2 required by default). Rotates both pins `46cf1d0 → 6bb148b`.

Risk assessment: transparent — the provider's acceptance test (`go test` hitting api.namecheap.com) doesn't touch IMDS at all. Any metadata calls on the runner itself (SSM agent heartbeat, aws-sdk calls from the runner's own user-data) all use IMDSv2 natively.