### PR TITLE
ci: rotate ec2-github-runner SHA to Phase 4 retry tip (non-root + --ephemeral)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
         # SHA-pinned (was @feat/al2023-support). The same SHA is reused by
         # the stop-runner step so both halves of the runner lifecycle run
         # identical action code.
-        uses: namecheap/ec2-github-runner@6bb148b43cd5b3734d81f8a7dd7ab15b3d7f7a8b # feat/al2023-support @ 2026-04-21 — Phase 6.a: IMDSv2 required
+        uses: namecheap/ec2-github-runner@0fdd4014da74d56d46154f73a1cfe6d6113cbedc # feat/al2023-support @ 2026-04-21 — Phase 4 (retry): non-root runner + --ephemeral + hardcoded checksum table
         with:
           mode: start
           github-token: ${{ secrets.GH_TOKEN }}
@@ -231,7 +231,7 @@ jobs:
       - name: Stop EC2 runner
         # SHA-pinned (was @main). Matches the start-runner step above so
         # stop logic is in lockstep with the code that started the runner.
-        uses: namecheap/ec2-github-runner@6bb148b43cd5b3734d81f8a7dd7ab15b3d7f7a8b # feat/al2023-support @ 2026-04-21 — Phase 6.a: IMDSv2 required
+        uses: namecheap/ec2-github-runner@0fdd4014da74d56d46154f73a1cfe6d6113cbedc # feat/al2023-support @ 2026-04-21 — Phase 4 (retry): non-root runner + --ephemeral + hardcoded checksum table
         with:
           mode: stop
           github-token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Dogfood rotation for [namecheap/ec2-github-runner#26](https://github.com/namecheap/ec2-github-runner/pull/26). Pins both refs to `0fdd401` — Phase 4 retry with the `.sha256` 404 bug fixed via a hardcoded checksum table.

High-stakes rotation — Phase 4 failed twice before on the provider (see #182, #183 in the closed list). This time:

1. The actual failing line (`curl .sha256 | awk` under `set -e`) is gone; replaced with a table lookup in-JS + shell `sha256sum -c` against a baked-in expected hash.
2. The checksum table is cross-checked against upstream's release body on every PR to ec2-github-runner via an overhauled `verify-runner-url` job.
3. If something new breaks, I have the `aws ec2 get-console-output --latest` diagnostic recipe ready.

Everything else from the original Phase 4 ships here: non-root `runner` user (no more `RUNNER_ALLOW_RUNASROOT=1`), `--ephemeral` / `--unattended` / `--disableupdate` on `config.sh`, new optional `runner-version` input, `set -euo pipefail`.