### PR TITLE
ci: disable trivy-action internal cache (drops node20 transitive action)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,13 +72,6 @@ jobs:
     # audits) can consume a signed inventory without re-running scans.
     name: Security scan (Trivy)
     runs-on: ubuntu-latest
-    # trivy-action v0.35.0 transitively uses actions/cache@v3 (Node 20).
-    # Force Node 24 for every JS action in this job so the deprecation
-    # warning goes away without waiting for aquasecurity to bump their
-    # internal actions/cache pin. Drop this once trivy-action ships an
-    # actions/cache@v5 (Node 24) internally.
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
     steps:
       - uses: actions/checkout@v6
 
@@ -95,6 +88,10 @@ jobs:
           # License denylist lives in trivy.yaml at repo root; the
           # action auto-loads it before each scanner runs.
           trivy-config: trivy.yaml
+          # Disable trivy-action's internal actions/cache@v4.2.4 step
+          # (the Node-20 action GitHub warns about). DB is re-pulled on
+          # each run — a ~100 MB cost we accept to keep CI annotation-free.
+          cache: 'false'
 
       - name: Generate CycloneDX SBOM
         # Runs even if the scan above found HIGH/CRITICAL — the SBOM is
@@ -107,6 +104,7 @@ jobs:
           scan-ref: .
           format: cyclonedx
           output: sbom.cdx.json
+          cache: 'false'
 
       - name: Upload SBOM artifact
         if: ${{ !cancelled() }}


### PR DESCRIPTION
Root-fix for the `actions/cache@0400d5f6` Node-20 warning on the Security scan job.

## Why the previous fix wasn't enough

PR #167 set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` on the job. GitHub's current messaging:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/cache@0400d5f6…`

So the env var works — the action runs on Node 24 — but GitHub still emits a CI annotation on every run. Same noise, different phrasing.

## Actual fix

trivy-action v0.35.0 exposes a `cache` input. Setting it to `'false'` skips the internal `actions/cache@v4.2.4` step entirely. No Node-20 action invoked → no warning.

Applied on both Trivy invocations (vuln scan + SBOM generation). The `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env block is dropped — no longer needed.

## Trade-off

Trivy's vulnerability DB (~100 MB) gets re-downloaded on each run instead of restored from cache. ~5 s penalty per CI run. Worth it for annotation-free output and for not depending on GitHub's `FORCE_` flag behavior.

## When can we re-enable cache?

When `aquasecurity/trivy-action` ships a release with `actions/cache@v5` (Node 24) internally. Until then, cache stays off.