### PR TITLE
ci: pin GoReleaser binary version instead of 'latest'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,12 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@e24998b8b67b290c2fa8b7c14fcfa7de2c5c9b8c # v7.1.0
         with:
-          version: latest
+          # Pin the GoReleaser binary to an exact version so a breaking
+          # upstream minor release (has happened: v2 config schema) can't
+          # silently break a tagged release. Bump this line when the
+          # maintainer has reviewed the release notes at
+          # https://github.com/goreleaser/goreleaser/releases.
+          version: v2.15.4
           args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}


### PR DESCRIPTION
Closes the last `latest` reference in CI (per the audit conclusion after #190).

## What changed

`release.yml` step `Run GoReleaser`:

```diff
-          version: latest
+          version: v2.15.4
```

Plus an inline comment pointing a future maintainer at the release notes before bumping.

## Why

The `goreleaser-action` is SHA-pinned at v7.1.0 — good. But its `version:` **input** tells the action which GoReleaser **binary** to download at tag time, and `latest` means "fetch whatever GoReleaser's latest release is right now." GoReleaser has shipped breaking changes in minor releases before (v2's config schema was the most visible), and the failure mode is invisible until you cut the next release tag.

Pinning to an exact version means:
- Breaking GoReleaser changes can't silently land in our release flow.
- Every GoReleaser bump is a visible PR that someone has to read the release notes for.

## Trade-off

Dependabot's `github-actions` ecosystem updates `uses:` refs only, not the `version:` input. This pin is therefore a **manual-bump surface** — a human opens a PR when they want to pick up a new GoReleaser version. Roughly quarterly. Worth the occasional churn to avoid silent breakage at release time.

A custom `renovate.json` rule with a regex manager could auto-bump this; that's a separate follow-up if the team wants it.

## Post-merge pinning posture

Zero `latest` references left in CI. The only remaining floating refs are:
- First-party `actions/*` major tags (`actions/checkout@v6`, `actions/setup-go@v6`, `actions/attest-build-provenance@v4`) — scoped out by #147 as acceptable (GitHub is the entity maintaining its own actions; force-moving its own tags maliciously breaks the whole ecosystem at once, different threat model).
- `runs-on: ubuntu-latest` — image refresh managed by GitHub.

## Test plan

- [ ] `check` / `security` / `start-runner` / `acceptance_test` / `stop-runner` all green.
- [ ] `release.yml` is only exercised at tag push — full validation waits for the next release. Pre-validated by rendering the change and confirming `v2.15.4` is a real tag on the goreleaser repo (`gh api /repos/goreleaser/goreleaser/releases` returns it).