### PR TITLE
ci: rotate ec2-github-runner SHA + opt into EBS encryption (Phase 6.b)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
         # SHA-pinned (was @feat/al2023-support). The same SHA is reused by
         # the stop-runner step so both halves of the runner lifecycle run
         # identical action code.
-        uses: namecheap/ec2-github-runner@0fdd4014da74d56d46154f73a1cfe6d6113cbedc # feat/al2023-support @ 2026-04-21 — Phase 4 (retry): non-root runner + --ephemeral + hardcoded checksum table
+        uses: namecheap/ec2-github-runner@7c6a9a782d374e1c6d834b6dee1a4be3511197bf # feat/al2023-support @ 2026-04-21 — Phase 6.b: opt-in EBS encryption
         with:
           mode: start
           github-token: ${{ secrets.GH_TOKEN }}
@@ -147,6 +147,10 @@ jobs:
           security-group-id: sg-106ec76d
           eip-allocation-id: eipalloc-1796f61b
           iam-role-name: AmazonSSMRoleForInstancesQuickSetup
+          # SSE-EBS on the runner's root volume. Uses the launch
+          # account's default aws/ebs KMS key; AMI snapshot-id is
+          # dropped so AWS re-encrypts at launch time.
+          encrypt-ebs: 'true'
           aws-resource-tags: >
             [
               { "Key": "Name", "Value": "github_runner" },
@@ -224,7 +228,7 @@ jobs:
       - name: Stop EC2 runner
         # SHA-pinned (was @main). Matches the start-runner step above so
         # stop logic is in lockstep with the code that started the runner.
-        uses: namecheap/ec2-github-runner@0fdd4014da74d56d46154f73a1cfe6d6113cbedc # feat/al2023-support @ 2026-04-21 — Phase 4 (retry): non-root runner + --ephemeral + hardcoded checksum table
+        uses: namecheap/ec2-github-runner@7c6a9a782d374e1c6d834b6dee1a4be3511197bf # feat/al2023-support @ 2026-04-21 — Phase 6.b: opt-in EBS encryption
         with:
           mode: stop
           github-token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Dogfood rotation for [namecheap/ec2-github-runner#27](https://github.com/namecheap/ec2-github-runner/pull/27) (EBS encryption opt-in). Rotates both pins `0fdd401 → 7c6a9a7` and sets `encrypt-ebs: 'true'` on the start-runner step.

Risk: if this CI account can't use the default `alias/aws/ebs` KMS key, or if the shared AMI's snapshot is encrypted under a customer-managed key lacking a cross-account grant, `Start EC2 runner` will fail with a KMS/IAM error. The action throws early (doesn't time out), so diagnostics are quick via the console-output recipe if needed.

If it fails, the fix is a 1-line revert of the `encrypt-ebs` input — the SHA rotation itself is orthogonal and stays correct.