### PR TITLE
ci: replace GH_TOKEN PAT with GitHub App token for EC2 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,12 @@ jobs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
@@ -136,7 +142,7 @@ jobs:
         uses: namecheap/ec2-github-runner@7c6a9a782d374e1c6d834b6dee1a4be3511197bf # feat/al2023-support @ 2026-04-21 — Phase 6.b: opt-in EBS encryption
         with:
           mode: start
-          github-token: ${{ secrets.GH_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           ec2-image-owner: 699717368611
           ec2-image-filters: >
             [
@@ -219,6 +225,12 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ always() && needs.start-runner.outputs.ec2-instance-id != '' }} # stop the runner only if it was actually started
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
@@ -231,6 +243,6 @@ jobs:
         uses: namecheap/ec2-github-runner@7c6a9a782d374e1c6d834b6dee1a4be3511197bf # feat/al2023-support @ 2026-04-21 — Phase 6.b: opt-in EBS encryption
         with:
           mode: stop
-          github-token: ${{ secrets.GH_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           label: ${{ needs.start-runner.outputs.label }}
           ec2-instance-id: ${{ needs.start-runner.outputs.ec2-instance-id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -227,7 +227,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,8 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
@@ -231,6 +233,8 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:


### PR DESCRIPTION
## Summary

- Replaces the user-owned `GH_TOKEN` PAT with a short-lived token generated at runtime by `actions/create-github-app-token`
- Token is derived from `APP_ID` + `APP_PRIVATE_KEY` secrets (GitHub App, not tied to any individual user)
- Applied to both `start-runner` and `stop-runner` jobs
- Action pinned by SHA (`d72941d...`, tag `v1`)

## Prerequisites

Before merging, ensure these two repo secrets are set:
- `APP_ID` — numeric ID of the GitHub App
- `APP_PRIVATE_KEY` — contents of the App's `.pem` private key

The old `GH_TOKEN` secret can be deleted after this PR is merged and CI is confirmed green.

## Test plan

- [ ] CI passes on this branch (EC2 runner starts and stops successfully)
- [ ] `GH_TOKEN` secret deleted from repo settings after green run