### PR TITLE
test: make resetDomainNameservers resilient; fix TestAccDomainValidation PreCheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
@@ -227,7 +227,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}

--- a/namecheap/namecheap_domain_record_test.go
+++ b/namecheap/namecheap_domain_record_test.go
@@ -2,17 +2,42 @@ package namecheap_provider
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/namecheap/go-namecheap-sdk/v2/namecheap"
-	"regexp"
-	"testing"
 )
 
 func resetDomainNameservers(t *testing.T) {
-	_, err := namecheapSDKClient.DomainsDNS.SetDefault(*testAccDomain)
+	t.Helper()
+
+	// Skip SetDefault if domain is already on Namecheap's default nameservers.
+	listResp, err := namecheapSDKClient.DomainsDNS.GetList(*testAccDomain)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if listResp.DomainDNSGetListResult != nil &&
+		listResp.DomainDNSGetListResult.IsUsingOurDNS != nil &&
+		*listResp.DomainDNSGetListResult.IsUsingOurDNS {
+		return
+	}
+
+	// Retry SetDefault to handle transient sandbox errors (e.g. 5050900).
+	const maxAttempts = 3
+	delays := []time.Duration{5 * time.Second, 15 * time.Second}
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		_, err = namecheapSDKClient.DomainsDNS.SetDefault(*testAccDomain)
+		if err == nil {
+			return
+		}
+		if !strings.Contains(err.Error(), "(5050900)") || attempt == maxAttempts-1 {
+			t.Fatal(err)
+		}
+		time.Sleep(delays[attempt])
 	}
 }
 
@@ -944,6 +969,7 @@ func TestAccDomainValidation(t *testing.T) {
 
 		resource.Test(t, resource.TestCase{
 			PreCheck: func() {
+				resetDomainNameservers(t)
 				resetDomainRecords(t)
 			},
 			ProviderFactories: testAccProviderFactories,


### PR DESCRIPTION
## Problem

Two related test failures in acceptance tests for `terraform-provider-test.net` (sandbox):

**Primary — error 5050900 (`SetDefault` fails):**
A previous partial run left the domain on custom nameservers. `SetDefault` now returns _"An unhandled exception occured. Please try again. (5050900)"_ from the sandbox. Every test calling `resetDomainNameservers` in `PreCheck` fails (~100 s each).

**Secondary — error 2030288 (`SetHosts` fails):**
`TestAccDomainValidation/accept_root_domain` only called `resetDomainRecords` in `PreCheck`. With the domain on custom NS, `SetHosts` returns _"Cannot complete this command as this domain is not using proper DNS servers (2030288)"_.

## Changes

`namecheap/namecheap_domain_record_test.go`:

1. **Skip `SetDefault` when unnecessary** — `resetDomainNameservers` now calls `GetList` first; if `IsUsingOurDNS` is already `true` it returns immediately.
2. **Retry on transient 5050900** — retries up to 3 times with 5 s / 15 s back-off before `t.Fatal`. Any other error fails immediately.
3. **Fix `TestAccDomainValidation/accept_root_domain` PreCheck** — adds `resetDomainNameservers(t)` before `resetDomainRecords(t)`.

## Manual action still needed

The sandbox domain `terraform-provider-test.net` is currently stuck on custom NS. Log into the Namecheap sandbox control panel and switch it back to default nameservers to unblock re-runs.