### PR TITLE
chore: add -failfast to testacc to stop on first failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ test:
 # Please set the following ENV variables for this test:
 # NAMECHEAP_USER_NAME, NAMECHEAP_API_USER, NAMECHEAP_API_KEY, NAMECHEAP_TEST_DOMAIN, NAMECHEAP_USE_SANDBOX (optional, default is false)
 testacc:
-	TF_ACC=1 go test ./namecheap -v -run=TestAcc -count=1 -timeout=30m
+	TF_ACC=1 go test ./namecheap -v -run=TestAcc -count=1 -timeout=30m -failfast
 
 build:
 	go build -o ${BINARY}


### PR DESCRIPTION
## Summary

Adds `-failfast` to `make testacc` so the acceptance test suite stops at the first failing test instead of running all remaining tests.

## Motivation

A recent failing run took **1073 s** instead of the normal ~152 s. The first ns test failed at ~100 s, but the suite continued through three more ns tests (each hitting the same timeout) plus `TestAccDomainValidation` (224 s) — all wasted time pointing at the same root cause. With `-failfast` that run would have stopped at ~100 s.

## Trade-off

On a genuine regression affecting multiple tests you only see the first failure per run. Given the suite is small and sequential (single domain), discovering failures one-at-a-time is acceptable.

## Test plan

- [ ] CI passes on this PR
- [ ] Confirm `make testacc` locally exits immediately on first failure when one test is broken