### PR TITLE
Fix duplicated "only" in equalDomainRecord comment

### DIFF
--- a/namecheap/namecheap_domain_record_test.go
+++ b/namecheap/namecheap_domain_record_test.go
@@ -193,7 +193,7 @@ func testAccDomainNameserversDefault(response *namecheap.DomainsDNSGetListComman
 	}
 }
 
-// equalDomainRecord compares only Name, Type, Address, TTL, MXPref fields only.
+// equalDomainRecord compares only Name, Type, Address, TTL, MXPref fields.
 func equalDomainRecord(sRec *namecheap.DomainsDNSHostRecordDetailed, dRec *namecheap.DomainsDNSHostRecordDetailed) bool {
 	if sRec == nil || dRec == nil {
 		return false


### PR DESCRIPTION
The doc comment on `equalDomainRecord` in `namecheap/namecheap_domain_record_test.go` used the word "only" twice ("compares only ... fields only"). This removes the redundant trailing "only".

Flagged by GitHub code quality (AI findings).