### PR TITLE
test: include actual record count in mismatch error

### DIFF
--- a/namecheap/namecheap_domain_record_test.go
+++ b/namecheap/namecheap_domain_record_test.go
@@ -103,8 +103,14 @@ func testAccDomainRecordsLength(response *namecheap.DomainsDNSGetHostsCommandRes
 				return fmt.Errorf("Expected %d records, got %d", expectedLength, len(*response.DomainDNSGetHostsResult.Hosts))
 			}
 		} else {
-			if response.DomainDNSGetHostsResult.Hosts == nil || len(*response.DomainDNSGetHostsResult.Hosts) != expectedLength {
-				return fmt.Errorf("Expected %d records", expectedLength)
+			actualLength := 0
+
+			if response.DomainDNSGetHostsResult.Hosts != nil {
+				actualLength = len(*response.DomainDNSGetHostsResult.Hosts)
+			}
+
+			if response.DomainDNSGetHostsResult.Hosts == nil || actualLength != expectedLength {
+				return fmt.Errorf("Expected %d records, got %d", expectedLength, actualLength)
 			}
 		}
 


### PR DESCRIPTION
## What

`testAccDomainRecordsLength` reported inconsistent error messages for the same logical condition:

- The `expectedLength == 0` branch returned `Expected %d records, got %d` (includes the actual count).
- The `else` branch returned `Expected %d records` (no actual count).

Flagged by GitHub code-quality AI findings on `namecheap/namecheap_domain_record_test.go`.

## Change

Compute `actualLength` once, guarding the nil `Hosts` case (the condition explicitly allows `Hosts == nil`, so the count can't be dereferenced unconditionally), and include it in the `else` branch message. Both failure paths now report `Expected %d records, got %d`.

Test-only change; no production code affected.

## Verification

- `gofmt -l` — clean
- `go vet ./namecheap/...` — passes