### PR TITLE
ci: serialize acceptance runs via workflow-queue instead of a shared concurrency group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,14 @@ on:
 permissions:
   contents: read
 
-# Only one EC2 runner can be active at a time because all runs share
-# the same whitelisted Elastic IP. Queued runs wait for the current one
-# to finish (cancel-in-progress: false).
-concurrency:
-  group: ec2-acceptance-test
-  cancel-in-progress: false
+# This workflow intentionally has NO top-level `concurrency` group. A shared
+# group serializes the whole workflow, but GitHub keeps only the newest queued
+# run per group and cancels older pending ones — so two PRs pushed seconds apart
+# silently drop each other's CI. Instead, the cheap `check`/`security` jobs run
+# in parallel across PRs (never cancelled), and only `start-runner` serializes —
+# it waits for older runs via ahmadnassri/action-workflow-queue so the single
+# whitelisted Elastic IP is never associated by two EC2 runners at once. See the
+# queue step in start-runner below.
 
 jobs:
   check:
@@ -114,10 +116,21 @@ jobs:
     # those jobs for Dependabot; the check job still runs on its PRs.
     if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read # action-workflow-queue lists workflow runs to wait on
     outputs:
       label: ${{ steps.start-ec2-runner.outputs.label }}
       ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
     steps:
+      - name: Wait for older acceptance runs to release the EIP
+        # The acceptance pipeline associates one whitelisted Elastic IP to its
+        # ephemeral EC2 runner; two runners at once would fight over that IP.
+        # Queue this run (FIFO, no cancellation) behind any older in-progress CI
+        # run, which holds the IP until its stop-runner job terminates the host.
+        uses: ahmadnassri/action-workflow-queue@542658b3a8270cac81ae15d401b0d974732808ac # v1.2.0
+        with:
+          timeout: 1800000 # 30 min cap for a backlog of queued acceptance runs
       - name: Generate GitHub App token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0

--- a/SECURITY_COMPLIANCE.md
+++ b/SECURITY_COMPLIANCE.md
@@ -97,6 +97,12 @@ self-hosted runner action:
   re-trigger the acceptance pipeline manually per the flow in
   [`CONTRIBUTING.md`](CONTRIBUTING.md#dependabot-prs-maintainers).
 - AMI comes from `DEVOPS/hardened-amazon-linux2023` (internal).
+- Only one acceptance run may hold the single whitelisted Elastic IP at a
+  time. `start-runner` serializes access with the SHA-pinned
+  `ahmadnassri/action-workflow-queue` action (MIT), which queues a newer run
+  behind older in-progress ones (FIFO, no cancellation). This replaces the
+  former shared `concurrency` group, which silently cancelled pending runs
+  when PRs were pushed close together.
 
 ## What triggers a compliance failure
 


### PR DESCRIPTION
## Problem

The CI workflow used a constant, repo-wide `concurrency` group:

```yaml
concurrency:
  group: ec2-acceptance-test   # constant — shared by every branch and master
  cancel-in-progress: false
```

That correctly serialized the EC2 acceptance pipeline (only one runner may hold the single whitelisted Elastic IP `eipalloc-1796f61b`), **but** GitHub keeps only the newest *pending* run per concurrency group and cancels older pending ones. So two PRs — or a PR and a near-simultaneous merge to `master` — silently dropped each other's CI runs. We hit this repeatedly while merging back-to-back dependency PRs.

## Change

- **Remove** the top-level `concurrency` group.
- `check` / `security` now run in parallel across PRs and are **never cancelled** (faster feedback as a bonus).
- EIP serialization moves into `start-runner` via [`ahmadnassri/action-workflow-queue`](https://github.com/ahmadnassri/action-workflow-queue) (MIT), which **waits** for older in-progress runs (FIFO) instead of cancelling. A run stays in progress until its `stop-runner` job terminates the instance and frees the IP, so the next run only proceeds once the IP is free.
- Add `actions: read` to `start-runner` (the queue step lists workflow runs).
- Documented under *Self-hosted runner supply chain* in `SECURITY_COMPLIANCE.md`.

## Why not key the group by `github.ref`?

That would let two PRs' acceptance jobs run at once and both associate the same whitelisted EIP — one steals it from the other mid-test. The single whitelisted IP makes serialization mandatory; this keeps it while eliminating cancellation.

## Supply chain

`ahmadnassri/action-workflow-queue` is SHA-pinned with a `# v<semver>` comment per repo policy and will be tracked by the `github-actions` Dependabot ecosystem:

```
ahmadnassri/action-workflow-queue@542658b3a8270cac81ae15d401b0d974732808ac # v1.2.0
```

License: MIT (not on the `trivy.yaml` denylist).

## Verification

- `actionlint` — no new findings (only pre-existing SC2016 infos in the acceptance `run:` blocks).
- YAML parses clean.
- Self-validating: this PR's own CI exercises the new `start-runner` queue step.