### PR TITLE
ci: bump ec2-github-runner pin to v3.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Start EC2 runner
         id: start-ec2-runner
-        uses: namecheap/ec2-github-runner@9f03017f8e2a25844c4be629c8221648b2bcbe8b # main @ 2026-05-15
+        uses: namecheap/ec2-github-runner@ee454b5f2ada8a0a3c6b3b5e48f3275068254428 # v3.0.0 @ 2026-06-09
         with:
           mode: start
           github-token: ${{ steps.app-token.outputs.token }}
@@ -262,7 +262,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Stop EC2 runner
-        uses: namecheap/ec2-github-runner@9f03017f8e2a25844c4be629c8221648b2bcbe8b # main @ 2026-05-15
+        uses: namecheap/ec2-github-runner@ee454b5f2ada8a0a3c6b3b5e48f3275068254428 # v3.0.0 @ 2026-06-09
         with:
           mode: stop
           github-token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Repin the `start-runner` and `stop-runner` jobs from the 2026-05-15 `main` commit (`9f03017f`) to the **v3.0.0** release (`ee454b5f`).

- Full-SHA pin with a `# v3.0.0 @ 2026-06-09` version comment preserves supply-chain pinning compliance.
- The only delta v3.0.0 carries over the previous pin is a non-functional chore (`.env.example` / `.gitignore`); this PR's acceptance run validates the released action end-to-end on the EC2 runner.

Verifying CI (incl. acceptance test) is green before merge.