### PR TITLE
ci: bump Terraform 1.14.8 -> 1.15.5 in acceptance test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,8 +214,8 @@ jobs:
 
       - name: Set up Terraform
         run: |
-          curl -fsSLo terraform.zip https://releases.hashicorp.com/terraform/1.14.8/terraform_1.14.8_linux_amd64.zip
-          expected_tf_sha="$(curl -fsSL https://releases.hashicorp.com/terraform/1.14.8/terraform_1.14.8_SHA256SUMS | awk '/terraform_1.14.8_linux_amd64.zip$/ {print $1}')"
+          curl -fsSLo terraform.zip https://releases.hashicorp.com/terraform/1.15.5/terraform_1.15.5_linux_amd64.zip
+          expected_tf_sha="$(curl -fsSL https://releases.hashicorp.com/terraform/1.15.5/terraform_1.15.5_SHA256SUMS | awk '/terraform_1.15.5_linux_amd64.zip$/ {print $1}')"
           echo "${expected_tf_sha}  terraform.zip" | sha256sum -c -
           rm -rf .terraform-bin
           mkdir .terraform-bin


### PR DESCRIPTION
Bump the Terraform version pinned in the `acceptance_test` job's manual install from **1.14.8** to **1.15.5** (current stable).

- Verified the 1.15.5 `linux_amd64` artifact and `SHA256SUMS` exist on releases.hashicorp.com (HTTP 200).
- The step fetches the checksum dynamically from HashiCorp's `SHA256SUMS`, so there is no hardcoded checksum to maintain.
- CI (incl. acceptance test on the EC2 runner) validates the new version end-to-end.