### PR TITLE
ci: fail acceptance Set up Terraform when a newer stable release exists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,8 +214,20 @@ jobs:
 
       - name: Set up Terraform
         run: |
-          curl -fsSLo terraform.zip https://releases.hashicorp.com/terraform/1.15.5/terraform_1.15.5_linux_amd64.zip
-          expected_tf_sha="$(curl -fsSL https://releases.hashicorp.com/terraform/1.15.5/terraform_1.15.5_SHA256SUMS | awk '/terraform_1.15.5_linux_amd64.zip$/ {print $1}')"
+          tf_version="1.15.5"
+          # Fail the build when a newer stable Terraform release exists so the
+          # pinned version can't silently drift. Bump tf_version to clear it.
+          # Uses HashiCorp's checkpoint API — the same source `terraform` itself
+          # queries for upgrade notifications (stable GA only, never RCs). A
+          # network hiccup (empty latest_tf) is tolerated rather than failing CI.
+          latest_tf="$(curl -fsSL https://checkpoint-api.hashicorp.com/v1/check/terraform | sed -n 's/.*"current_version":"\([^"]*\)".*/\1/p')"
+          if [ -n "${latest_tf}" ] && [ "${latest_tf}" != "${tf_version}" ] \
+            && [ "$(printf '%s\n%s\n' "${tf_version}" "${latest_tf}" | sort -V | tail -1)" = "${latest_tf}" ]; then
+            echo "::error::A newer Terraform release (${latest_tf}) exists; pinned tf_version is ${tf_version}. Bump tf_version in .github/workflows/ci.yml."
+            exit 1
+          fi
+          curl -fsSLo terraform.zip "https://releases.hashicorp.com/terraform/${tf_version}/terraform_${tf_version}_linux_amd64.zip"
+          expected_tf_sha="$(curl -fsSL "https://releases.hashicorp.com/terraform/${tf_version}/terraform_${tf_version}_SHA256SUMS" | awk -v f="terraform_${tf_version}_linux_amd64.zip" '$2==f {print $1}')"
           echo "${expected_tf_sha}  terraform.zip" | sha256sum -c -
           rm -rf .terraform-bin
           mkdir .terraform-bin


### PR DESCRIPTION
Make the `acceptance_test` job's **Set up Terraform** step hard-fail when a newer stable Terraform release exists, so the pinned version can't silently drift.

**What it does**
- Parameterizes the install via `tf_version` (single source of truth).
- Queries HashiCorp's checkpoint API (`current_version` — stable GA only, the same source `terraform` itself uses for upgrade notices) and `exit 1` if a newer release exists than `tf_version`.
- Emits a `::error::` annotation telling the maintainer to bump `tf_version`.

**Safe by design** (verified locally):
- pinned == latest → pass; older pin → fail; pin *ahead* of checkpoint → pass (no false fail right after a bump); lookup failure (empty) → pass (a network blip won't break CI).

**Blast radius:** once HashiCorp ships a newer GA, every acceptance run fails at this step until `tf_version` is bumped — after the EC2 runner has already started. Intentional per request (fail the flow), but flagging it.