### PR TITLE
ci: use latest Go patch of go.mod's minor (check-latest + manual install)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,19 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Resolve Go minor from go.mod
+        id: gomod
+        # Extract just the MAJOR.MINOR (e.g. 1.26) from go.mod's `go` directive.
+        # Passing the full patch (1.26.3) to setup-go pins it exactly even with
+        # check-latest; the minor lets check-latest float to the newest patch.
+        run: echo "minor=$(awk '/^go / {print $2; exit}' go.mod | cut -d. -f1,2)" >> "$GITHUB_OUTPUT"
+
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: go.mod
-          # Pull the latest patch of go.mod's Go minor instead of a cached
-          # older patch, so the check job tests against the newest 1.x.y.
+          # Latest patch of go.mod's Go minor (e.g. 1.26 -> 1.26.4) rather than
+          # a cached or exact-pinned patch, so the check job tests the newest.
+          go-version: ${{ steps.gomod.outputs.minor }}
           check-latest: true
 
       - name: Verify module integrity

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+          # Pull the latest patch of go.mod's Go minor instead of a cached
+          # older patch, so the check job tests against the newest 1.x.y.
+          check-latest: true
 
       - name: Verify module integrity
         run: go mod verify
@@ -190,10 +193,24 @@ jobs:
 
       - name: Set up Go
         run: |
-          # Derive the Go version from go.mod's `go` directive so this manual
-          # install (the EC2 runner lacks setup-go tooling) can never drift
-          # from the module requirement the way the release workflow did.
-          go_version="$(awk '/^go / {print $2; exit}' go.mod)"
+          # Install the latest PATCH of the Go minor pinned by go.mod's `go`
+          # directive (the EC2 runner lacks setup-go tooling), mirroring
+          # check-latest: true in the check job. Patch bumps (1.26.3 -> 1.26.4)
+          # are picked up automatically. A newer Go minor is not auto-adopted
+          # and does not fail CI: we fall back to go.mod's exact version, which
+          # is also the floor the module requires.
+          go_required="$(awk '/^go / {print $2; exit}' go.mod)"
+          go_minor="$(printf '%s' "${go_required}" | cut -d. -f1,2)"
+          # go.dev/VERSION is Go's own latest-stable endpoint (text: goX.Y.Z);
+          # when go.mod's minor is current it IS the latest patch.
+          latest_go="$(curl -fsSL https://go.dev/VERSION?m=text | head -1 | sed 's/^go//')"
+          latest_minor="$(printf '%s' "${latest_go}" | cut -d. -f1,2)"
+          if [ -n "${latest_go}" ] && [ "${latest_minor}" = "${go_minor}" ]; then
+            go_version="${latest_go}"   # latest patch in go.mod's minor series
+          else
+            go_version="${go_required}" # newer minor / lookup unavailable: use go.mod's exact version
+          fi
+          echo "Using Go ${go_version} (go.mod pins ${go_minor}.x)"
           tarball="go${go_version}.linux-amd64.tar.gz"
           curl -fsSLo "${tarball}" "https://dl.google.com/go/${tarball}"
           expected_go_sha="$(curl -fsSL "https://dl.google.com/go/${tarball}.sha256")"


### PR DESCRIPTION
Applies the Terraform-style "latest patch" behavior to Go (no failing, per request).

**check job** — add `check-latest: true` to `actions/setup-go` so it installs the newest patch of go.mod's Go minor rather than a cached older patch.

**acceptance job** (manual EC2 install) — resolve the latest patch of go.mod's minor via `go.dev/VERSION` (Go's own latest-stable endpoint). go.mod currently pins `go 1.26.3`; latest is `1.26.4`, so CI now installs 1.26.4 automatically. Behavior:
- patch bump within the minor (1.26.3 → 1.26.4) → auto-used;
- a newer Go *minor* (1.27.0) → **not** auto-adopted and does **not** fail; falls back to go.mod's exact version (also the module's required floor);
- lookup failure → same safe fallback.

No "fail on new minor" gate (unlike the Terraform guard) — intentional. Logic unit-tested for all cases; the manual step passes `bash -n`; Go 1.26.4 artifacts verified to exist.