### PR TITLE
ci: add govulncheck Go-native vulnerability gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,9 +117,49 @@ jobs:
           path: sbom.cdx.json
           retention-days: 90
 
+  govulncheck:
+    # Go-native vulnerability gate, complementary to the Trivy SCA scan above.
+    # Trivy matches go.sum module versions against advisory version ranges;
+    # govulncheck additionally does call-graph REACHABILITY analysis against the
+    # official Go vulnerability database (https://vuln.go.dev) plus the Go
+    # standard library for the toolchain in use. It fails only when a vulnerable
+    # symbol is actually reachable from this module's code, which keeps the gate
+    # low-noise (imported-but-uncalled vulns are reported but don't block) while
+    # still catching every exploitable path — including stdlib CVEs that Trivy's
+    # dependency scan doesn't cover. The advisory DB is fetched fresh each run,
+    # so detection stays current regardless of the pinned binary version.
+    name: Security scan (govulncheck)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve Go minor from go.mod
+        id: gomod
+        run: echo "minor=$(awk '/^go / {print $2; exit}' go.mod | cut -d. -f1,2)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          # Latest patch of go.mod's Go minor (matches the check job) so stdlib
+          # advisories already fixed in a newer patch aren't reported against us.
+          go-version: ${{ steps.gomod.outputs.minor }}
+          check-latest: true
+
+      - name: Run govulncheck
+        # Pin the binary so a govulncheck release can't silently change scan
+        # behavior. govulncheck is installed via `go install`, not declared in
+        # go.mod (keeping it out of the shipped module graph and the SBOM), so
+        # Dependabot's gomod ecosystem does NOT track it — bump this line by
+        # hand after reviewing https://github.com/golang/vuln/releases.
+        # Exit code 3 (a vuln in CALLED code) fails the job; imported-but-
+        # uncalled findings are informational and do not gate.
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
+          govulncheck ./...
+
   start-runner:
     name: Start self-hosted EC2 runner
-    needs: [check, security]
+    needs: [check, security, govulncheck]
     # Dependabot-triggered runs don't have access to secrets.* (GitHub
     # redacts them for dependabot[bot]), so start-runner and the
     # acceptance test would fail at "Configure AWS credentials". Skip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,12 @@ jobs:
       - name: Trivy vuln + misconfig + secret + license scan
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
+          # Pin the Trivy binary to the latest scanner release instead of
+          # floating on the action's bundled default (v0.70.0 in v0.36.0), so
+          # scan behavior is reproducible. Dependabot's github-actions ecosystem
+          # bumps the action SHA but NOT this input — bump by hand after
+          # reviewing https://github.com/aquasecurity/trivy/releases.
+          version: v0.71.1
           scan-type: fs
           scan-ref: .
           scanners: vuln,misconfig,secret,license
@@ -103,6 +109,8 @@ jobs:
         if: ${{ !cancelled() }}
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
+          # Same pinned Trivy binary as the scan step above (keep in sync).
+          version: v0.71.1
           scan-type: fs
           scan-ref: .
           format: cyclonedx

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,8 @@ jobs:
       - name: Generate CycloneDX SBOM for release
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
+          # Keep the Trivy binary in sync with the CI scan (.github/workflows/ci.yml).
+          version: v0.71.1
           scan-type: fs
           scan-ref: .
           format: cyclonedx

--- a/SECURITY_COMPLIANCE.md
+++ b/SECURITY_COMPLIANCE.md
@@ -38,6 +38,17 @@ CI gates (in [`.github/workflows/ci.yml`](.github/workflows/ci.yml), `check` job
 - Exception workflow: open a PR adding a scoped `ignored-licenses:` entry
   (package + license combination) to `trivy.yaml`, with a justification and
   a reviewer from outside the requesting team.
+- [govulncheck](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck) runs on
+  every push in the `govulncheck` job as a Go-native gate complementary to
+  Trivy (#233). It performs call-graph **reachability** analysis against the Go
+  vulnerability database (<https://vuln.go.dev>) and the standard library for
+  the pinned Go toolchain, and **fails the build when a vulnerable symbol is
+  reachable from this module's code** — catching exploitable paths (including
+  stdlib CVEs) that Trivy's version-range dependency scan does not cover.
+  Imported-but-uncalled vulnerabilities are reported but do not block, so the
+  gate stays low-noise. The binary is pinned (`@v1.3.0`) and bumped by hand
+  (it's not in `go.mod`, so Dependabot doesn't track it); the advisory DB is
+  fetched fresh on every run, so detection stays current regardless.
 
 ## Software Bill of Materials (SBOM)
 
@@ -110,6 +121,7 @@ Any of the following fails the build and blocks merge:
 
 - `go.mod` or `go.sum` not tidy.
 - HIGH/CRITICAL CVE with an available fix in any dependency.
+- Reachable Go vulnerability (dependency or stdlib) detected by govulncheck.
 - Denied license in any dependency.
 - Trivy secret scan matches a credential-shaped string.
 - Go or Terraform tarball SHA-256 mismatch on the self-hosted runner.


### PR DESCRIPTION
## What

Adds a `govulncheck` job to CI that runs [`golang.org/x/vuln`](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck) against the Go vulnerability database (vuln.go.dev) and the Go standard library, **failing the build on any vulnerability reachable from this module's code**.

## Why

`SECURITY_COMPLIANCE.md` currently relies on Trivy for SCA. Trivy matches `go.sum` module versions against advisory version ranges but does **not** do reachability analysis and does **not** cover Go **stdlib** CVEs. `govulncheck` closes both gaps:

- **Call-graph reachability** — only fails when a vulnerable symbol is actually *called*, so the gate is low-noise (imported-but-uncalled vulns are reported, not blocking).
- **Stdlib coverage** — flags CVEs in the Go runtime/stdlib for the pinned toolchain, which Trivy's dependency scan can't see.

## How

- New parallel `govulncheck` job (named **Security scan (govulncheck)**), mirroring the `check` job's "resolve Go minor from go.mod + `check-latest`" setup so stdlib advisories already fixed in a newer patch aren't reported against us.
- Binary pinned to `@v1.3.0`. It's installed via `go install` (kept out of `go.mod` so it doesn't pollute the shipped module graph or the SBOM), which means Dependabot's `gomod` ecosystem doesn't track it — bump by hand after reviewing the [release notes](https://github.com/golang/vuln/releases). The advisory DB is fetched fresh each run, so detection stays current regardless of the pinned binary.
- Wired into `start-runner`'s `needs` so vulnerable code never reaches the EC2 acceptance pipeline.
- Documented the control and its compliance-failure trigger in `SECURITY_COMPLIANCE.md`.

## Verification

- `govulncheck ./...` run locally against `master` HEAD: **No vulnerabilities found** (exit 0) — this lands green.
- `ci.yml` validated with `actionlint` (no new findings).

## Follow-up (not in this PR)

The "Protect master" ruleset currently has **no `required_status_checks` rule** — so no CI check (this one, Trivy, or `check`) is a hard merge-block today; it's enforced by reviewer convention. To make `Security scan (govulncheck)` (and ideally the existing gates) actually block merges, a maintainer should add the check context(s) to the ruleset's required status checks **after** this job has run green on `master` at least once (GitHub only lists check contexts it has already seen).

---

## Also in this PR: pin Trivy scanner to v0.71.1

The `aquasecurity/trivy-action` pin is already the latest release (v0.36.0), but its bundled Trivy **binary** defaulted to v0.70.0 and was not overridden. Pinned the binary explicitly to the latest scanner release **v0.71.1** across the CI scan, CI SBOM, and release SBOM steps for reproducibility (commit `9b947a9`). Verified green: `Security scan (Trivy)` passed on the updated commit.
