### PR TITLE
ci: post consolidated security scan summary to PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,34 @@ jobs:
           # trivy-action v0.36.0 uses actions/cache@v5 (Node 24) internally.
           cache: "true"
 
+      - name: Trivy report (JSON, all severities, non-gating)
+        # Second Trivy pass that NEVER gates (exit-code 0) and drops the
+        # CRITICAL,HIGH + ignore-unfixed filters of the gating scan above, so
+        # the PR summary can show the full picture (MEDIUM/LOW and unfixed
+        # advisories included). The merge gate stays with the table scan above;
+        # this JSON is consumed only by the security-report job to render the
+        # human summary + artifact. Same pinned Trivy binary as above.
+        if: ${{ !cancelled() }}
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          version: v0.71.1
+          scan-type: fs
+          scan-ref: .
+          scanners: vuln,misconfig,secret,license
+          exit-code: "0"
+          format: json
+          output: trivy-results.json
+          trivy-config: trivy.yaml
+          cache: "true"
+
+      - name: Upload Trivy JSON report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: trivy-json
+          path: trivy-results.json
+          retention-days: 90
+
       - name: Generate CycloneDX SBOM
         # Runs even if the scan above found HIGH/CRITICAL — the SBOM is
         # a static inventory and should be produced regardless of
@@ -164,6 +192,120 @@ jobs:
         run: |
           go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
           govulncheck ./...
+
+      - name: govulncheck JSON report (non-gating)
+        # Re-run in JSON purely to feed the PR security summary; never gates
+        # (|| true). The text run above stays the authoritative reachability
+        # gate. Invoked by absolute path in case GOPATH/bin isn't on PATH for
+        # this step. Runs even if the gate above failed so the summary can
+        # show exactly which vulnerabilities blocked the build.
+        if: ${{ !cancelled() }}
+        run: |
+          GOVULNCHECK="$(go env GOPATH)/bin/govulncheck"
+          "$GOVULNCHECK" -format json ./... > govulncheck.json || true
+
+      - name: Upload govulncheck JSON report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: govulncheck-json
+          path: govulncheck.json
+          retention-days: 90
+
+  security-report:
+    # Consolidates every security scan into ONE human-readable summary, posted
+    # as a sticky PR comment (the visibility ask) and also written to the run's
+    # job summary + uploaded as the `security-summary` artifact. REPORTING ONLY
+    # — it never gates. The authoritative merge gates remain the `security`
+    # (Trivy) and `govulncheck` jobs above; their pass/fail is surfaced verbatim
+    # in the summary via needs.*.result, so a green comment can never mask a red
+    # gate.
+    name: Security scan summary
+    needs: [security, govulncheck]
+    # Run even when a gate above failed — that's when the summary matters most.
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout + read go.mod for the dependency overview
+      pull-requests: write # post/update the sticky summary comment
+      security-events: read # read open CodeQL alerts to enrich the summary
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download scan artifacts
+        # Pulls trivy-json, sbom-cyclonedx and govulncheck-json (uploaded by the
+        # jobs above) into one directory. merge-multiple flattens them so the
+        # files land at scan-artifacts/<file> regardless of artifact name.
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          path: scan-artifacts
+          merge-multiple: true
+
+      - name: Fetch open CodeQL alerts (best effort)
+        # Default-setup CodeQL runs outside this workflow; its open alerts for
+        # this ref are pulled via the API only to enrich the summary. Never
+        # fails the job — code scanning disabled, or an analysis that hasn't
+        # finished for this ref yet, just yields an empty list.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api "repos/${GITHUB_REPOSITORY}/code-scanning/alerts?ref=${GITHUB_REF}&state=open&per_page=100" \
+            > scan-artifacts/codeql-alerts.json 2>/dev/null || echo '[]' > scan-artifacts/codeql-alerts.json
+
+      - name: Build security summary
+        env:
+          SECURITY_RESULT: ${{ needs.security.result }}
+          GOVULNCHECK_RESULT: ${{ needs.govulncheck.result }}
+          COMMIT_SHA: ${{ github.sha }}
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          bash scripts/security-summary.sh \
+            scan-artifacts/trivy-results.json \
+            scan-artifacts/govulncheck.json \
+            scan-artifacts/sbom.cdx.json \
+            go.mod \
+            scan-artifacts/codeql-alerts.json \
+            > security-summary.md
+          cat security-summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload summary artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: security-summary
+          path: security-summary.md
+          retention-days: 90
+
+      - name: Post or update PR comment
+        # Dependabot pushes get a read-only GITHUB_TOKEN (secrets redacted), so
+        # commenting would 403 — skip it for Dependabot; the job summary +
+        # artifact above are still produced on those runs. Every other CI run is
+        # an in-repo branch (this workflow has no pull_request / fork trigger),
+        # so the default token can comment. A sticky marker keeps it to one
+        # comment that updates in place instead of one per push.
+        if: ${{ github.actor != 'dependabot[bot]' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          marker='<!-- security-scan-summary -->'
+          pr="$(gh pr list --head "${GITHUB_REF_NAME}" --state open \
+                  --json number --jq '.[0].number // empty')"
+          if [ -z "${pr}" ]; then
+            echo "No open PR for branch ${GITHUB_REF_NAME}; summary is on the job summary + artifact only."
+            exit 0
+          fi
+          existing="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${pr}/comments?per_page=100" \
+                        --jq "map(select(.body | startswith(\"${marker}\"))) | .[0].id // empty")"
+          jq -Rs '{body: .}' security-summary.md > comment-payload.json
+          if [ -n "${existing}" ]; then
+            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${existing}" \
+              --input comment-payload.json >/dev/null
+            echo "Updated existing summary comment #${existing} on PR #${pr}."
+          else
+            gh api -X POST "repos/${GITHUB_REPOSITORY}/issues/${pr}/comments" \
+              --input comment-payload.json >/dev/null
+            echo "Posted new summary comment on PR #${pr}."
+          fi
 
   start-runner:
     name: Start self-hosted EC2 runner

--- a/SECURITY_COMPLIANCE.md
+++ b/SECURITY_COMPLIANCE.md
@@ -66,7 +66,7 @@ CI gates (in [`.github/workflows/ci.yml`](.github/workflows/ci.yml), `check` job
   consolidates every scan into one Markdown report and posts it as a **sticky
   PR comment** (one comment, updated in place per push), the run's **job
   summary**, and the **`security-summary`** workflow artifact (90-day
-  retention) (#PR_PLACEHOLDER).
+  retention) (#234).
 - The report covers: Trivy vulnerabilities (by severity), IaC misconfig, secret
   and license findings; govulncheck reachable vs. imported-only counts; open
   CodeQL code-scanning alerts (best-effort, via the API); and a dependency

--- a/SECURITY_COMPLIANCE.md
+++ b/SECURITY_COMPLIANCE.md
@@ -60,6 +60,30 @@ CI gates (in [`.github/workflows/ci.yml`](.github/workflows/ci.yml), `check` job
   license scans so the three views (scan report, workflow artifact,
   release asset) are consistent.
 
+## PR security summary
+
+- The `security-report` job in [`.github/workflows/ci.yml`](.github/workflows/ci.yml)
+  consolidates every scan into one Markdown report and posts it as a **sticky
+  PR comment** (one comment, updated in place per push), the run's **job
+  summary**, and the **`security-summary`** workflow artifact (90-day
+  retention) (#PR_PLACEHOLDER).
+- The report covers: Trivy vulnerabilities (by severity), IaC misconfig, secret
+  and license findings; govulncheck reachable vs. imported-only counts; open
+  CodeQL code-scanning alerts (best-effort, via the API); and a dependency
+  overview (SBOM component count, `go.mod` direct/indirect split, license
+  breakdown).
+- It is **reporting only and never gates.** The per-scan pass/fail shown in the
+  summary is taken verbatim from the `security` and `govulncheck` gate jobs
+  (`needs.*.result`), so a green comment can never mask a red gate. The merge
+  gates remain exactly as described above.
+- Source data comes from non-gating JSON passes of the same scanners
+  (`trivy-results.json`, `govulncheck.json`) plus the existing SBOM, uploaded as
+  the `trivy-json` / `govulncheck-json` / `sbom-cyclonedx` artifacts. Secret
+  findings list the rule and location only — never the matched value.
+- The comment is posted with the default `GITHUB_TOKEN` (`pull-requests: write`,
+  scoped to the `security-report` job). Dependabot runs skip the comment (their
+  token is read-only) but still produce the job summary and artifact.
+
 ## CI / supply-chain pinning
 
 - Every third-party GitHub Action is pinned by 40-char commit SHA with a

--- a/scripts/security-summary.sh
+++ b/scripts/security-summary.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# Render a consolidated security-scan summary (GitHub-flavored Markdown) from the
+# JSON outputs of the CI security jobs. Consumed by the `security-report` job in
+# .github/workflows/ci.yml: written to the run's job summary, uploaded as the
+# `security-summary` artifact, and posted as a sticky PR comment.
+#
+# Usage:
+#   security-summary.sh TRIVY_JSON GOVULN_JSON SBOM_JSON GO_MOD CODEQL_JSON
+#
+# Every input is best-effort: a missing, empty, or unparseable file degrades
+# that section gracefully rather than failing. This script is REPORTING ONLY and
+# never exits non-zero on scan content — the merge gates live in the scan jobs.
+# Pass/fail shown in the status table comes from the gate jobs' results
+# (SECURITY_RESULT / GOVULNCHECK_RESULT env), not from re-deriving it here.
+set -uo pipefail
+
+TRIVY="${1:-}"
+GOVULN="${2:-}"
+SBOM="${3:-}"
+GOMOD="${4:-go.mod}"
+CODEQL="${5:-}"
+
+MARKER='<!-- security-scan-summary -->'
+SHA_SHORT="${COMMIT_SHA:0:8}"
+BRANCH="${BRANCH:-unknown}"
+NOW="$(date -u '+%Y-%m-%d %H:%M UTC')"
+
+# jq wrapper: print the filter result, or a fallback when the file is
+# missing/empty/invalid, so one dead scan job can't break the whole report.
+# Args: <file> <filter> <fallback> [slurp-flag e.g. -s]
+jqf() {
+  local file="$1" filter="$2" fallback="$3" slurp="${4:-}"
+  if [ -s "$file" ]; then
+    jq ${slurp} -r "$filter" "$file" 2>/dev/null || printf '%s' "$fallback"
+  else
+    printf '%s' "$fallback"
+  fi
+}
+
+# success -> check, failure -> cross, anything else (skipped/unknown) -> circle
+emoji() {
+  case "$1" in
+    success) printf '✅' ;;
+    failure) printf '❌' ;;
+    *) printf '⚪' ;;
+  esac
+}
+
+# --- Trivy counts ----------------------------------------------------------
+tv_crit=$(jqf "$TRIVY" '[.Results[]?.Vulnerabilities[]? | select(.Severity=="CRITICAL")] | length' 0)
+tv_high=$(jqf "$TRIVY" '[.Results[]?.Vulnerabilities[]? | select(.Severity=="HIGH")]     | length' 0)
+tv_med=$(jqf  "$TRIVY" '[.Results[]?.Vulnerabilities[]? | select(.Severity=="MEDIUM")]   | length' 0)
+tv_low=$(jqf  "$TRIVY" '[.Results[]?.Vulnerabilities[]? | select(.Severity=="LOW")]      | length' 0)
+tv_unkn=$(jqf "$TRIVY" '[.Results[]?.Vulnerabilities[]? | select(.Severity=="UNKNOWN")]  | length' 0)
+tv_misconf=$(jqf "$TRIVY" '[.Results[]?.Misconfigurations[]? | select(.Status=="FAIL")] | length' 0)
+tv_secrets=$(jqf "$TRIVY" '[.Results[]?.Secrets[]?] | length' 0)
+tv_lic=$(jqf "$TRIVY" '[.Results[]?.Licenses[]?] | length' 0)
+
+# --- govulncheck counts (NDJSON stream -> slurp) ---------------------------
+gv_reach=$(jqf "$GOVULN" '[.[] | select(.finding!=null) | .finding | select(.trace[0].function!=null) | .osv] | unique | length' 0 -s)
+gv_total=$(jqf "$GOVULN" '[.[] | select(.finding!=null) | .finding.osv] | unique | length' 0 -s)
+gv_imported=$(( gv_total - gv_reach ))
+[ "$gv_imported" -lt 0 ] && gv_imported=0
+
+# --- SBOM / dependency overview --------------------------------------------
+sbom_comp=$(jqf "$SBOM" '[.components[]?] | length' 0)
+read -r mod_direct mod_indirect < <(awk '
+  /^require[[:space:]]*\(/ { inblk=1; next }
+  inblk && /^\)/ { inblk=0; next }
+  /^require[[:space:]]+[^(]/ { if ($0 ~ /\/\/[[:space:]]*indirect/) ind++; else dir++; next }
+  inblk && NF>=2 && $1!="//" { if ($0 ~ /\/\/[[:space:]]*indirect/) ind++; else dir++ }
+  END { printf "%d %d", dir+0, ind+0 }
+' "$GOMOD" 2>/dev/null || echo "0 0")
+
+# --- CodeQL (code scanning) open alerts ------------------------------------
+cq_total=$(jqf "$CODEQL" 'if type=="array" then length else 0 end' 0)
+cq_crit=$(jqf "$CODEQL"  'if type=="array" then [.[]|select(.rule.security_severity_level=="critical")]|length else 0 end' 0)
+cq_high=$(jqf "$CODEQL"  'if type=="array" then [.[]|select(.rule.security_severity_level=="high")]|length else 0 end' 0)
+
+# --- status from the actual gate jobs --------------------------------------
+trivy_status=$(emoji "${SECURITY_RESULT:-}")
+govuln_status=$(emoji "${GOVULNCHECK_RESULT:-}")
+
+# ===========================================================================
+# Markdown. First line is the sticky marker so the workflow can find + update
+# this exact comment instead of posting a new one each push.
+# ===========================================================================
+printf '%s\n' "$MARKER"
+printf '## 🔐 Security scan summary\n\n'
+printf '_Commit `%s` · branch `%s` · generated %s_\n\n' "$SHA_SHORT" "$BRANCH" "$NOW"
+
+printf '| Scan | Gate | Findings |\n'
+printf '|---|:---:|---|\n'
+printf '| **Trivy — vulnerabilities** (SCA) | %s | 🔴 %s critical · 🟠 %s high · 🟡 %s medium · ⚪ %s low · %s unknown |\n' \
+  "$trivy_status" "$tv_crit" "$tv_high" "$tv_med" "$tv_low" "$tv_unkn"
+printf '| **Trivy — IaC misconfig** | %s | %s failing |\n' "$trivy_status" "$tv_misconf"
+printf '| **Trivy — secrets** | %s | %s detected |\n' "$trivy_status" "$tv_secrets"
+printf '| **Trivy — licenses** | %s | %s policy finding(s) |\n' "$trivy_status" "$tv_lic"
+printf '| **govulncheck** (reachability) | %s | %s reachable · %s imported-only |\n' \
+  "$govuln_status" "$gv_reach" "$gv_imported"
+printf '| **CodeQL** (code scanning, open) | — | %s open · 🔴 %s critical · 🟠 %s high |\n' \
+  "$cq_total" "$cq_crit" "$cq_high"
+printf '\n'
+printf '> **Gate** (blocks merge): HIGH/CRITICAL **fixable** CVEs · reachable Go vulnerabilities · forbidden licenses · committed secrets. '
+printf 'Counts above are the *full* picture (incl. medium/low and unfixed), so they can exceed what actually gates. '
+printf 'CodeQL is informational here. ✅ = gate job passed, ❌ = failed, ⚪ = skipped.\n\n'
+
+# --- dependency overview ---------------------------------------------------
+printf '### 📦 Dependencies\n\n'
+printf -- '- **SBOM components (CycloneDX):** %s\n' "$sbom_comp"
+printf -- '- **Go modules in `go.mod`:** %s direct · %s indirect\n\n' "$mod_direct" "$mod_indirect"
+
+lic_breakdown=$(jqf "$SBOM" '
+  [.components[]?.licenses[]? | (.license.id // .license.name // .expression // "UNKNOWN")]
+  | group_by(.) | map({k: .[0], n: length}) | sort_by(-.n) | .[:10][]
+  | "| \(.k) | \(.n) |"' "")
+if [ -n "$lic_breakdown" ]; then
+  printf '<details><summary>License breakdown (top 10)</summary>\n\n'
+  printf '| License | Components |\n|---|---:|\n%s\n\n</details>\n\n' "$lic_breakdown"
+fi
+
+# --- detail sections (only when there is something to show) ----------------
+vuln_rows=$(jqf "$TRIVY" '
+  [.Results[]?.Vulnerabilities[]?]
+  | unique_by([.VulnerabilityID, .PkgName])
+  | sort_by({"CRITICAL":0,"HIGH":1,"MEDIUM":2,"LOW":3,"UNKNOWN":4}[.Severity] // 5)
+  | .[:50][]
+  | "| \(.Severity) | \(.VulnerabilityID) | \(.PkgName) | \(.InstalledVersion) | \((.FixedVersion // "") | if . == "" then "—" else . end) |"' "")
+if [ -n "$vuln_rows" ]; then
+  printf '<details><summary>Vulnerabilities (Trivy, top 50)</summary>\n\n'
+  printf '| Severity | ID | Package | Installed | Fixed |\n|---|---|---|---|---|\n%s\n\n</details>\n\n' "$vuln_rows"
+fi
+
+gv_rows=$(jqf "$GOVULN" '
+  [.[] | select(.finding!=null) | .finding | select(.trace[0].function!=null)
+   | {osv, module: .trace[0].module, fn: .trace[0].function}]
+  | unique_by(.osv) | .[]
+  | "| \(.osv) | \(.module // "—") | `\(.fn // "—")` |"' "" -s)
+if [ -n "$gv_rows" ]; then
+  printf '<details><summary>Reachable Go vulnerabilities (govulncheck)</summary>\n\n'
+  printf '| Advisory | Module | Called symbol |\n|---|---|---|\n%s\n\n</details>\n\n' "$gv_rows"
+fi
+
+lic_rows=$(jqf "$TRIVY" '
+  [.Results[]?.Licenses[]?] | .[]
+  | "| \(.Severity) | \(.PkgName // .FilePath // "—") | \(.Name) | \(.Category // "—") |"' "")
+if [ -n "$lic_rows" ]; then
+  printf '<details><summary>License findings (Trivy)</summary>\n\n'
+  printf '| Severity | Package/File | License | Category |\n|---|---|---|---|\n%s\n\n</details>\n\n' "$lic_rows"
+fi
+
+misconf_rows=$(jqf "$TRIVY" '
+  [.Results[]? | .Target as $t | (.Misconfigurations[]? | select(.Status=="FAIL") | {t: $t, id: .ID, sev: .Severity, title: .Title})]
+  | .[] | "| \(.sev) | \(.id) | \(.title) | \(.t) |"' "")
+if [ -n "$misconf_rows" ]; then
+  printf '<details><summary>IaC misconfigurations (Trivy)</summary>\n\n'
+  printf '| Severity | ID | Title | Target |\n|---|---|---|---|\n%s\n\n</details>\n\n' "$misconf_rows"
+fi
+
+# Secrets: report rule + location only, NEVER the matched value, to avoid
+# re-leaking a credential into the PR comment / artifact.
+secret_rows=$(jqf "$TRIVY" '
+  [.Results[]? | .Target as $t | (.Secrets[]? | {t: $t, rule: .RuleID, sev: .Severity, title: .Title, line: .StartLine})]
+  | .[] | "| \(.sev) | \(.rule) | \(.title) | \(.t):\(.line) |"' "")
+if [ -n "$secret_rows" ]; then
+  printf '<details><summary>Secret findings (Trivy — values redacted)</summary>\n\n'
+  printf '| Severity | Rule | Title | Location |\n|---|---|---|---|\n%s\n\n</details>\n\n' "$secret_rows"
+fi
+
+printf -- '---\n'
+printf '📎 Full machine-readable reports are attached to this run as artifacts: '
+printf '`security-summary`, `trivy-json`, `govulncheck-json`, `sbom-cyclonedx`.\n'


### PR DESCRIPTION
## What

Adds a reporting-only **`security-report`** CI job that consolidates every security scan into **one Markdown report**, surfaced three ways for clear visibility:

- 💬 **Sticky PR comment** — one comment, updated in place on each push (marker `<!-- security-scan-summary -->`).
- 🧾 **Job summary** — rendered on the Actions run page.
- 📎 **`security-summary` artifact** — 90-day retention.

The report covers, in a single view:

- **Trivy** vulnerabilities (by severity), IaC misconfig, secrets, license findings
- **govulncheck** reachable vs. imported-only counts (+ called symbols)
- **CodeQL** open code-scanning alerts (best-effort, via the API)
- **Dependencies** — SBOM component count, `go.mod` direct/indirect split, license breakdown

## How

- **`security` job:** added a *non-gating* Trivy JSON pass (all severities, unfixed included) → `trivy-json` artifact. The existing `CRITICAL,HIGH` + `ignore-unfixed` **gating** table scan is untouched.
- **`govulncheck` job:** added a *non-gating* `-format json` pass → `govulncheck-json` artifact. The authoritative reachability gate is untouched.
- **`security-report` job** (`needs: [security, govulncheck]`, `if: !cancelled()`): downloads the scan artifacts + existing SBOM, pulls open CodeQL alerts, renders [`scripts/security-summary.sh`](scripts/security-summary.sh), writes the job summary, uploads the artifact, and posts/updates the sticky comment.

## Safety / design notes

- **Reporting only — never gates.** Per-scan ✅/❌ is taken verbatim from the gate jobs' `needs.*.result`, so a green comment can never mask a red gate. All existing merge gates are unchanged.
- **Token:** default `GITHUB_TOKEN` with job-scoped `pull-requests: write` (this workflow has no `pull_request`/fork trigger, so the default token suffices). Commenting is **skipped for `dependabot[bot]`** (read-only token) — the job summary + artifact are still produced.
- **No secret leakage:** secret findings list rule + location only, never the matched value.
- New action `actions/download-artifact` is SHA-pinned (`v7.0.0`) to match the repo's pinning policy.
- Resilient: a missing/empty scan file degrades that section to zero/`n/a` rather than failing the job. Verified locally against synthetic fixtures (populated + fully-degraded paths) and `bash -n`.

Documented in `SECURITY_COMPLIANCE.md`.