### PR TITLE
ci: bump ec2-github-runner to v3.0.2 (actions/runner 2.335.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,7 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Start EC2 runner
         id: start-ec2-runner
-        uses: namecheap/ec2-github-runner@a9a3f477101df4477adf7b584282a4f0c75bc9cd # v3.0.0 @ 2026-06-09
+        uses: namecheap/ec2-github-runner@87bca3cd546666ad891e22973412fef14865d3ab # v3.0.2 @ 2026-06-17
         with:
           mode: start
           github-token: ${{ steps.app-token.outputs.token }}
@@ -357,7 +357,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Stop EC2 runner
-        uses: namecheap/ec2-github-runner@a9a3f477101df4477adf7b584282a4f0c75bc9cd # v3.0.0 @ 2026-06-09
+        uses: namecheap/ec2-github-runner@87bca3cd546666ad891e22973412fef14865d3ab # v3.0.2 @ 2026-06-17
         with:
           mode: stop
           github-token: ${{ steps.app-token.outputs.token }}

--- a/SECURITY_COMPLIANCE.md
+++ b/SECURITY_COMPLIANCE.md
@@ -101,7 +101,7 @@ self-hosted runner action:
 
 - Runner binary version is controlled via the SHA-pinned
   `namecheap/ec2-github-runner` action (currently bundles
-  `actions/runner v2.333.1`, `externals/node24`, and writes outputs to
+  `actions/runner v2.335.1`, `externals/node24`, and writes outputs to
   `$GITHUB_OUTPUT` rather than the deprecated `::set-output`).
 - Dependabot-triggered runs skip the EC2-backed jobs entirely because GitHub
   redacts `secrets.*` on `dependabot[bot]` events (#157). Maintainers


### PR DESCRIPTION
## Why

The acceptance pipeline's self-hosted EC2 runner was emitting:

> Runner Version 2.333.1 will no longer be able to run jobs on June 23, 2026, please update your runner version.

`actions/runner` v2.333.1 is the version bundled by the previously pinned `namecheap/ec2-github-runner`. GitHub stops allowing it to run jobs on **2026-06-23**, after which acceptance tests would break.

## What

Bumps the `namecheap/ec2-github-runner` pin (both `start-runner` and `stop-runner`, same SHA) to **v3.0.2** — [namecheap/ec2-github-runner#36](https://github.com/namecheap/ec2-github-runner/pull/36) / [release v3.0.2](https://github.com/namecheap/ec2-github-runner/releases/tag/v3.0.2) — which bumps the bundled `actions/runner` default to **2.335.1** (latest), with SHA-256 checksums verified against the upstream release body.

- `a9a3f47…` → `87bca3cd546666ad891e22973412fef14865d3ab` (`# v3.0.2 @ 2026-06-17`)
- Also updated the `actions/runner` version reference in `SECURITY_COMPLIANCE.md` (2.333.1 → 2.335.1).
- Drive-by: the old comment labeled the pin `v3.0.0`, but that SHA was actually `v3.0.1` — corrected to the new release.

## Risk / verification

- SHA pin verified to match the `v3.0.2` tag exactly.
- The `Acceptance test` job exercises this runner — green CI here confirms the new runner registers and runs jobs end-to-end.