### PR TITLE
ci: bump Trivy scanner to v0.71.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
           # scan behavior is reproducible. Dependabot's github-actions ecosystem
           # bumps the action SHA but NOT this input — bump by hand after
           # reviewing https://github.com/aquasecurity/trivy/releases.
-          version: v0.71.1
+          version: v0.71.2
           scan-type: fs
           scan-ref: .
           scanners: vuln,misconfig,secret,license
@@ -112,7 +112,7 @@ jobs:
         if: ${{ !cancelled() }}
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
-          version: v0.71.1
+          version: v0.71.2
           scan-type: fs
           scan-ref: .
           scanners: vuln,misconfig,secret,license
@@ -138,7 +138,7 @@ jobs:
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           # Same pinned Trivy binary as the scan step above (keep in sync).
-          version: v0.71.1
+          version: v0.71.2
           scan-type: fs
           scan-ref: .
           format: cyclonedx

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           # Keep the Trivy binary in sync with the CI scan (.github/workflows/ci.yml).
-          version: v0.71.1
+          version: v0.71.2
           scan-type: fs
           scan-ref: .
           format: cyclonedx


### PR DESCRIPTION
## What

Bumps the manually-pinned Trivy **scanner binary** from `v0.71.1` to `v0.71.2` (released 2026-06-19) in all four `aquasecurity/trivy-action` steps:

- `.github/workflows/ci.yml` — gating vuln/misconfig/secret/license scan, non-gating JSON report, CycloneDX SBOM
- `.github/workflows/release.yml` — release CycloneDX SBOM

## Why

The `trivy-action` run emits a notice when the pinned binary is behind the latest scanner release (`Version 0.71.2 of Trivy is now available`). The action SHA is intentionally pinned (`v0.36.0`) and Dependabot bumps that SHA but **not** the `version:` input, so the scanner binary is bumped by hand per the in-file comment. Keeping it current ensures scans use the latest detection logic and vulnerability DB schema.

## Notes

- Action SHA (`v0.36.0`) unchanged — this only changes the scanner binary the action installs.
- All four pins kept in sync per the "keep in sync" comments.
- Commit signed off (DCO).