### PR TITLE
ci: bump ec2-github-runner to v4.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,7 +347,7 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Start EC2 runner
         id: start-ec2-runner
-        uses: namecheap/ec2-github-runner@87bca3cd546666ad891e22973412fef14865d3ab # v3.0.2 @ 2026-06-17
+        uses: namecheap/ec2-github-runner@c5db9f03dff1e63a46d40c9b94a49fc5ee6feff1 # v4.0.0 @ 2026-07-02
         with:
           mode: start
           github-token: ${{ steps.app-token.outputs.token }}
@@ -499,7 +499,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Stop EC2 runner
-        uses: namecheap/ec2-github-runner@87bca3cd546666ad891e22973412fef14865d3ab # v3.0.2 @ 2026-06-17
+        uses: namecheap/ec2-github-runner@c5db9f03dff1e63a46d40c9b94a49fc5ee6feff1 # v4.0.0 @ 2026-07-02
         with:
           mode: stop
           github-token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Repins the `start-runner` and `stop-runner` steps in `ci.yml` from **v3.0.2** (`87bca3c`) to **v4.0.0** (`c5db9f0`) so CI runs on the latest [ec2-github-runner](https://github.com/namecheap/ec2-github-runner/releases/tag/v4.0.0).

This PR's own CI exercises v4 end-to-end (real EC2 acceptance test); merging then reruns **master** CI on v4.

### v4 compatibility for this workflow
- **`ec2:CreateTags` now always required** — already granted here (the workflow uses `aws-resource-tags`).
- New `ec2:DescribeTags` / `ec2:GetConsoleOutput` perms degrade gracefully when absent (start still succeeds; only diagnostics/fast-fail are skipped).
- AMI is `x86_64` = the default `x64` `architecture` (v4 validates this).
- v4 additionally stamps signature tags and arms a default 6h TTL self-destruct — both no-ops for this short-lived acceptance run; `stop-runner` still terminates explicitly.

No behavioral inputs changed — same `mode: start`/`stop`, `encrypt-ebs`, EIP, and instance shape.