### PR TITLE
fix: filter default parking records in readRecordsOverwrite

### DIFF
--- a/namecheap/namecheap_domain_record_crud_read_records_test.go
+++ b/namecheap/namecheap_domain_record_crud_read_records_test.go
@@ -183,6 +183,64 @@ func TestReadRecordsOverwrite_CNAMEDotFix(t *testing.T) {
 	assert.Equal(t, "example.com", (*foundRecords)[0]["address"])
 }
 
+func TestReadRecordsOverwrite_FiltersDefaultParkingRecords(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprint(w, getHostsXML("NONE", []hostEntry{
+			{Name: "www", Type: "CNAME", Address: "parkingpage.namecheap.com.", MXPref: 10, TTL: 1800},
+			{Name: "@", Type: "URL", Address: "http://www.test.com", MXPref: 10, TTL: 1800},
+			{Name: "blog", Type: "A", Address: "1.2.3.4", MXPref: 10, TTL: 1800},
+		}))
+	}))
+	defer server.Close()
+
+	client := newTestClient(server.URL)
+
+	// With no records configured, OVERWRITE read must still drop Namecheap's
+	// default parking records so they don't surface as spurious drift (issue #260).
+	foundRecords, _, diags := readRecordsOverwrite(context.Background(), "test.com", []interface{}{}, client)
+	assert.False(t, diags.HasError())
+	assert.NotNil(t, foundRecords)
+	assert.Len(t, *foundRecords, 1)
+	assert.Equal(t, "blog", (*foundRecords)[0]["hostname"])
+	assert.Equal(t, "A", (*foundRecords)[0]["type"])
+}
+
+func TestReadRecordsOverwrite_KeepsUserManagedParkingRecord(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprint(w, getHostsXML("NONE", []hostEntry{
+			// User-managed record that happens to look like the default parking URL.
+			{Name: "@", Type: "URL", Address: "http://www.test.com", MXPref: 10, TTL: 1800},
+			// Unmanaged default parking record.
+			{Name: "www", Type: "CNAME", Address: "parkingpage.namecheap.com.", MXPref: 10, TTL: 1800},
+			// Ordinary managed record.
+			{Name: "blog", Type: "A", Address: "1.2.3.4", MXPref: 10, TTL: 1800},
+		}))
+	}))
+	defer server.Close()
+
+	client := newTestClient(server.URL)
+
+	// The user explicitly manages the parking-lookalike URL record, so it must be
+	// preserved (issue #260 filtering must not drop intentionally-configured records),
+	// while the unmanaged parking CNAME is still filtered out.
+	currentRecords := []interface{}{
+		map[string]interface{}{"hostname": "@", "type": "URL", "address": "http://www.test.com", "mx_pref": 10, "ttl": 1800},
+	}
+
+	foundRecords, _, diags := readRecordsOverwrite(context.Background(), "test.com", currentRecords, client)
+	assert.False(t, diags.HasError())
+	assert.NotNil(t, foundRecords)
+	assert.Len(t, *foundRecords, 2)
+
+	hostnames := map[string]bool{}
+	for _, rec := range *foundRecords {
+		hostnames[rec["hostname"].(string)+"/"+rec["type"].(string)] = true
+	}
+	assert.True(t, hostnames["@/URL"], "user-managed parking-lookalike record must be preserved")
+	assert.True(t, hostnames["blog/A"], "ordinary record must be preserved")
+	assert.False(t, hostnames["www/CNAME"], "unmanaged default parking record must be filtered")
+}
+
 func TestReadRecordsOverwrite_GetHostsAPIError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)

--- a/namecheap/namecheap_domain_record_functions.go
+++ b/namecheap/namecheap_domain_record_functions.go
@@ -410,6 +410,7 @@ func readRecordsOverwrite(ctx context.Context, domain string, currentRecords []i
 		for _, remoteRecord := range *remoteRecordsResponse.DomainDNSGetHostsResult.Hosts {
 			remoteRecordHash := hashRecord(*remoteRecord.Name, *remoteRecord.Type, *remoteRecord.Address)
 
+			managed := false
 			for _, currentRecord := range *currentRecordsConverted {
 				currentRecordAddressFixed, err := getFixedAddressOfRecord(&currentRecord)
 				if err != nil {
@@ -420,9 +421,17 @@ func readRecordsOverwrite(ctx context.Context, domain string, currentRecords []i
 
 				if currentRecordHash == remoteRecordHash {
 					*remoteRecord.Address = *currentRecord.Address
+					managed = true
 					break
 				}
 
+			}
+
+			// Skip Namecheap's default parking records unless the user explicitly
+			// manages them, so they don't surface as spurious drift (issue #260)
+			// while still respecting an intentionally-configured record.
+			if !managed && isDefaultParkingRecord(&remoteRecord, &domain) {
+				continue
 			}
 
 			remoteRecords = append(remoteRecords, *convertDomainRecordDetailedToTypeSetRecord(&remoteRecord))
@@ -679,13 +688,20 @@ func getFixedAddressOfRecord(record *namecheap.DomainsDNSHostRecord) (*string, e
 	return record.Address, nil
 }
 
+// isDefaultParkingRecord reports whether the record is one of Namecheap's
+// auto-provisioned default parking records (CNAME www -> parkingpage.namecheap.com.,
+// URL @ -> http://www.<domain>).
+func isDefaultParkingRecord(record *namecheap.DomainsDNSHostRecordDetailed, domain *string) bool {
+	return (*record.Type == namecheap.RecordTypeCNAME && *record.Name == "www" && *record.Address == "parkingpage.namecheap.com.") ||
+		(*record.Type == namecheap.RecordTypeURL && *record.Name == "@" && strings.HasPrefix(*record.Address, "http://www."+*domain))
+}
+
 // filterDefaultParkingRecords filters out default parking records
 func filterDefaultParkingRecords(records *[]namecheap.DomainsDNSHostRecordDetailed, domain *string) *[]namecheap.DomainsDNSHostRecordDetailed {
 	var filteredRecords []namecheap.DomainsDNSHostRecordDetailed
 
 	for _, record := range *records {
-		if (*record.Type == namecheap.RecordTypeCNAME && *record.Name == "www" && *record.Address == "parkingpage.namecheap.com.") ||
-			(*record.Type == namecheap.RecordTypeURL && *record.Name == "@" && strings.HasPrefix(*record.Address, "http://www."+*domain)) {
+		if isDefaultParkingRecord(&record, domain) {
 			continue
 		}
 		filteredRecords = append(filteredRecords, record)


### PR DESCRIPTION
## Summary

Fixes #260.

`readRecordsOverwrite` appended every record returned by the GetHosts API to Terraform state without filtering Namecheap's default parking records (`CNAME www -> parkingpage.namecheap.com.`, `URL @ -> http://www.<domain>`). On parked or freshly-imported domains these surfaced as spurious drift during `terraform plan` in OVERWRITE mode, contradicting the documented invariant that default parking records must be filtered.

The parking-record condition is extracted into a small predicate (`isDefaultParkingRecord`) — a single source of truth now shared with `createRecordsMerge` — and applied on the OVERWRITE read path. The filter is **config-aware**: a parking record is skipped only when the user is **not** explicitly managing it. Genuinely-unmanaged parking records are dropped (the fix), while an intentionally-configured record that happens to look like a parking default (e.g. an `http` apex→www URL redirect) is preserved and still converges — so no user config gains a perpetual diff.

`readRecordsMerge` is unaffected because it only returns records that match the user's config.

## Changes

- `namecheap/namecheap_domain_record_functions.go`
  - extract `isDefaultParkingRecord(record, domain)` predicate; refactor `filterDefaultParkingRecords` to use it (behavior unchanged for `createRecordsMerge`).
  - make `readRecordsOverwrite` skip unmanaged default parking records (config-aware).
- `namecheap/namecheap_domain_record_crud_read_records_test.go`
  - `TestReadRecordsOverwrite_FiltersDefaultParkingRecords` — unmanaged parking records are dropped.
  - `TestReadRecordsOverwrite_KeepsUserManagedParkingRecord` — a user-managed parking-lookalike is preserved while an unmanaged parking record on the same domain is filtered.

## Test results

- `make build` — OK
- `go fmt` / `go vet` — clean
- `golangci-lint run` — 0 issues
- `make test` — all unit tests pass (package coverage 90.8%)
- Sandbox `Acceptance test` job — green

## Coverage confirmation

- New function `isDefaultParkingRecord`: **100%**.
- `filterDefaultParkingRecords`: 100% (refactor, still fully covered).
- Patch coverage well above the repo's 50% target (`.codecov.yml`); project coverage unchanged (~90.8%).
- `readRecordsOverwrite`'s only uncovered line is a pre-existing `getFixedAddressOfRecord` error branch, unchanged by this PR.

## Plan/state impact vs. latest release (v2.3.5)

- Domains without parking defaults: **identical** read output → identical plan/state.
- Parked / freshly-imported domains: default parking records no longer leak into state (the intended fix; removes spurious drift; never touches user-managed records).
- No schema change → no state migration.
- Edge case eliminated: a user explicitly managing a parking-lookalike record in OVERWRITE mode is preserved and converges (config-aware filter).

## Acceptance tests

Not modified. Full diff: 2 files, +76 / -2.
