### PR TITLE
feat: map Namecheap API errors to actionable diagnostics (#247)

### DIFF
--- a/namecheap/diagnostics.go
+++ b/namecheap/diagnostics.go
@@ -1,0 +1,79 @@
+package namecheap_provider
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/namecheap/go-namecheap-sdk/v2/namecheap"
+)
+
+// diagFromClientError converts an error returned by a go-namecheap-sdk call
+// into diag.Diagnostics.
+//
+// When err wraps a *namecheap.APIError whose Number matches one of the
+// codes below, it returns a targeted diagnostic with remediation text so a
+// Terraform user can tell auth/permission/not-found failures apart instead
+// of reading a raw SDK error string.
+//
+// Every other error - including any *namecheap.APIError code that is not
+// explicitly mapped - falls through unchanged to diag.FromErr(err), which is
+// exactly what every call site did before this mapping existed. This keeps
+// the change strictly additive: no caller can regress by adopting it.
+//
+// Mapped codes are sourced two ways: the per-method "Error Codes" tables of
+// docs/namecheap-api-v2.md in namecheap/go-namecheap-sdk (2019166, 2016166,
+// 3016166), and Namecheap's global auth response code 1011102 ("API Key is
+// invalid or API access has not been enabled"), the single most common failure
+// for CI users, which covers a wrong key, disabled API access, a
+// sandbox/production credential mismatch, or a calling IP that is not
+// whitelisted. Rate limiting is intentionally NOT mapped here: the API
+// surfaces it as a pre-request HTTP 405 that go-namecheap-sdk absorbs in its
+// transport retry layer, so it never reaches this function as an *APIError
+// (set the requests_per_minute provider option to avoid it).
+func diagFromClientError(err error) diag.Diagnostics {
+	var apiErr *namecheap.APIError
+	if errors.As(err, &apiErr) {
+		switch apiErr.Number {
+		case 1011102:
+			// Namecheap global response code 1011102: "API Key is invalid or
+			// API access has not been enabled" - deliberately ambiguous on
+			// Namecheap's side, so list every remediation.
+			return diag.Diagnostics{{
+				Severity: diag.Error,
+				Summary:  "Namecheap API authentication failed (invalid credentials or IP not whitelisted)",
+				Detail: fmt.Sprintf(
+					"Namecheap API error %d: %s. This one error covers several causes - check each: "+
+						"(1) api_user/api_key are correct for the target environment (sandbox credentials differ from production; set use_sandbox to match); "+
+						"(2) API access is enabled for the account; "+
+						"(3) the public IP this provider calls from is whitelisted at "+
+						"https://ap.www.namecheap.com/settings/tools/apiaccess/whitelisted-ips - the most common cause in CI, where the runner's egress IP changes (set client_ip to that egress IP).",
+					apiErr.Number, apiErr.Message,
+				),
+			}}
+		case 2019166:
+			// docs/namecheap-api-v2.md § Error Codes: "Domain not found".
+			return diag.Diagnostics{{
+				Severity: diag.Error,
+				Summary:  "Domain not found",
+				Detail: fmt.Sprintf(
+					"Namecheap API error %d: %s. Verify the domain name is spelled correctly and is present in the Namecheap account associated with the configured ApiUser.",
+					apiErr.Number, apiErr.Message,
+				),
+			}}
+		case 2016166, 3016166:
+			// docs/namecheap-api-v2.md § Error Codes: "Domain is not associated
+			// with your account" (2016166) / "...with Enom" (3016166).
+			return diag.Diagnostics{{
+				Severity: diag.Error,
+				Summary:  "Domain not associated with this account",
+				Detail: fmt.Sprintf(
+					"Namecheap API error %d: %s. The domain is not associated with the Namecheap account used to authenticate (ApiUser/ApiKey). Confirm you are using the API credentials for the account that owns this domain.",
+					apiErr.Number, apiErr.Message,
+				),
+			}}
+		}
+	}
+
+	return diag.FromErr(err)
+}

--- a/namecheap/diagnostics_test.go
+++ b/namecheap/diagnostics_test.go
@@ -1,0 +1,84 @@
+package namecheap_provider
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/namecheap/go-namecheap-sdk/v2/namecheap"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDiagFromClientError(t *testing.T) {
+	cases := []struct {
+		name           string
+		err            error
+		wantSummary    string
+		wantDetailPart string
+	}{
+		{
+			name:           "domain not found",
+			err:            &namecheap.APIError{Number: 2019166, Message: "Domain not found", Command: "namecheap.domains.dns.getHosts"},
+			wantSummary:    "Domain not found",
+			wantDetailPart: "Verify the domain name is spelled correctly and is present in the Namecheap account",
+		},
+		{
+			name:           "domain not associated with account",
+			err:            &namecheap.APIError{Number: 2016166, Message: "Domain is not associated with your account", Command: "namecheap.domains.dns.getHosts"},
+			wantSummary:    "Domain not associated with this account",
+			wantDetailPart: "Confirm you are using the API credentials for the account that owns this domain",
+		},
+		{
+			name:           "domain not associated with Enom",
+			err:            &namecheap.APIError{Number: 3016166, Message: "Domain is not associated with Enom", Command: "namecheap.domains.dns.setHosts"},
+			wantSummary:    "Domain not associated with this account",
+			wantDetailPart: "Confirm you are using the API credentials for the account that owns this domain",
+		},
+		{
+			name:           "auth failure or IP not whitelisted",
+			err:            &namecheap.APIError{Number: 1011102, Message: "API Key is invalid or API access has not been enabled", Command: "namecheap.domains.dns.getHosts"},
+			wantSummary:    "Namecheap API authentication failed (invalid credentials or IP not whitelisted)",
+			wantDetailPart: "whitelisted-ips",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			diags := diagFromClientError(c.err)
+
+			assert.True(t, diags.HasError())
+			assert.Len(t, diags, 1)
+			assert.Equal(t, c.wantSummary, diags[0].Summary)
+			assert.Contains(t, diags[0].Detail, c.wantDetailPart)
+		})
+	}
+}
+
+// TestDiagFromClientError_Fallthrough locks in the non-breaking guarantee:
+// any error that is not a mapped *namecheap.APIError code - including an
+// unmapped APIError code and a plain error - must produce exactly the same
+// diagnostics as diag.FromErr(err) did before this mapping existed.
+func TestDiagFromClientError_Fallthrough(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "plain unmapped error",
+			err:  errors.New("boom"),
+		},
+		{
+			name: "unmapped APIError code",
+			err:  &namecheap.APIError{Number: 9999999, Message: "Some other failure", Command: "namecheap.domains.dns.setHosts"},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			diags := diagFromClientError(c.err)
+
+			assert.True(t, diags.HasError())
+			assert.Len(t, diags, 1)
+			assert.Equal(t, c.err.Error(), diags[0].Summary)
+		})
+	}
+}

--- a/namecheap/namecheap_domain_record.go
+++ b/namecheap/namecheap_domain_record.go
@@ -225,7 +225,7 @@ func resourceRecordRead(ctx context.Context, data *schema.ResourceData, meta int
 	// the domain behaviour.
 	nsResponse, err := client.DomainsDNS.GetListWithContext(ctx, domain)
 	if err != nil {
-		return diag.FromErr(err)
+		return diagFromClientError(err)
 	}
 
 	if nsResponse == nil || nsResponse.DomainDNSGetListResult == nil || nsResponse.DomainDNSGetListResult.IsUsingOurDNS == nil {
@@ -321,7 +321,7 @@ func resourceRecordUpdate(ctx context.Context, data *schema.ResourceData, meta i
 
 	nsResponse, err := client.DomainsDNS.GetListWithContext(ctx, domain)
 	if err != nil {
-		return diag.FromErr(err)
+		return diagFromClientError(err)
 	}
 
 	if nsResponse == nil || nsResponse.DomainDNSGetListResult == nil || nsResponse.DomainDNSGetListResult.IsUsingOurDNS == nil {
@@ -338,7 +338,7 @@ func resourceRecordUpdate(ctx context.Context, data *schema.ResourceData, meta i
 		(!*nsResponse.DomainDNSGetListResult.IsUsingOurDNS && newNameserversLen == 0) {
 		_, err := client.DomainsDNS.SetDefaultWithContext(ctx, domain)
 		if err != nil {
-			return diag.FromErr(err)
+			return diagFromClientError(err)
 		}
 	}
 

--- a/namecheap/namecheap_domain_record_functions.go
+++ b/namecheap/namecheap_domain_record_functions.go
@@ -32,17 +32,17 @@ func validateGetHostsResponse(response *namecheap.DomainsDNSGetHostsCommandRespo
 func createNameserversMerge(ctx context.Context, domain string, nameservers []string, client *namecheap.Client) diag.Diagnostics {
 	nsResponse, err := client.DomainsDNS.GetListWithContext(ctx, domain)
 	if err != nil {
-		return diag.FromErr(err)
+		return diagFromClientError(err)
 	}
 
 	if err := validateGetListResponse(nsResponse); err != nil {
-		return diag.FromErr(err)
+		return diagFromClientError(err)
 	}
 
 	if *nsResponse.DomainDNSGetListResult.IsUsingOurDNS {
 		_, err := client.DomainsDNS.SetCustomWithContext(ctx, domain, nameservers)
 		if err != nil {
-			return diag.FromErr(err)
+			return diagFromClientError(err)
 		}
 	} else {
 		var newNameservers []string
@@ -72,7 +72,7 @@ func createNameserversMerge(ctx context.Context, domain string, nameservers []st
 
 		_, err := client.DomainsDNS.SetCustomWithContext(ctx, domain, newNameservers)
 		if err != nil {
-			return diag.FromErr(err)
+			return diagFromClientError(err)
 		}
 	}
 
@@ -83,7 +83,7 @@ func createNameserversMerge(ctx context.Context, domain string, nameservers []st
 func createNameserversOverwrite(ctx context.Context, domain string, nameservers []string, client *namecheap.Client) diag.Diagnostics {
 	_, err := client.DomainsDNS.SetCustomWithContext(ctx, domain, nameservers)
 	if err != nil {
-		return diag.FromErr(err)
+		return diagFromClientError(err)
 	}
 
 	return nil
@@ -94,11 +94,11 @@ func createNameserversOverwrite(ctx context.Context, domain string, nameservers 
 func readNameserversMerge(ctx context.Context, domain string, currentNameservers []string, client *namecheap.Client) (*[]string, diag.Diagnostics) {
 	nsResponse, err := client.DomainsDNS.GetListWithContext(ctx, domain)
 	if err != nil {
-		return nil, diag.FromErr(err)
+		return nil, diagFromClientError(err)
 	}
 
 	if err := validateGetListResponse(nsResponse); err != nil {
-		return nil, diag.FromErr(err)
+		return nil, diagFromClientError(err)
 	}
 
 	var foundNameservers []string
@@ -121,11 +121,11 @@ func readNameserversMerge(ctx context.Context, domain string, currentNameservers
 func readNameserversOverwrite(ctx context.Context, domain string, client *namecheap.Client) (*[]string, diag.Diagnostics) {
 	nsResponse, err := client.DomainsDNS.GetListWithContext(ctx, domain)
 	if err != nil {
-		return nil, diag.FromErr(err)
+		return nil, diagFromClientError(err)
 	}
 
 	if err := validateGetListResponse(nsResponse); err != nil {
-		return nil, diag.FromErr(err)
+		return nil, diagFromClientError(err)
 	}
 
 	if *nsResponse.DomainDNSGetListResult.IsUsingOurDNS || nsResponse.DomainDNSGetListResult.Nameservers == nil {
@@ -140,11 +140,11 @@ func readNameserversOverwrite(ctx context.Context, domain string, client *namech
 func updateNameserversMerge(ctx context.Context, domain string, previousNameservers []string, currentNameservers []string, client *namecheap.Client) diag.Diagnostics {
 	nsResponse, err := client.DomainsDNS.GetListWithContext(ctx, domain)
 	if err != nil {
-		return diag.FromErr(err)
+		return diagFromClientError(err)
 	}
 
 	if err := validateGetListResponse(nsResponse); err != nil {
-		return diag.FromErr(err)
+		return diagFromClientError(err)
 	}
 
 	var newNameservers []string
@@ -174,14 +174,14 @@ func updateNameserversMerge(ctx context.Context, domain string, previousNameserv
 	if len(newNameservers) == 0 {
 		_, err := client.DomainsDNS.SetDefaultWithContext(ctx, domain)
 		if err != nil {
-			return diag.FromErr(err)
+			return diagFromClientError(err)
 		}
 		return nil
 	}
 
 	_, err = client.DomainsDNS.SetCustomWithContext(ctx, domain, newNameservers)
 	if err != nil {
-		return diag.FromErr(err)
+		return diagFromClientError(err)
 	}
 
 	return nil
@@ -193,11 +193,11 @@ func updateNameserversMerge(ctx context.Context, domain string, previousNameserv
 func deleteNameserversMerge(ctx context.Context, domain string, previousNameservers []string, client *namecheap.Client) diag.Diagnostics {
 	nsResponse, err := client.DomainsDNS.GetListWithContext(ctx, domain)
 	if err != nil {
-		return diag.FromErr(err)
+		return diagFromClientError(err)
 	}
 
 	if err := validateGetListResponse(nsResponse); err != nil {
-		return diag.FromErr(err)
+		return diagFromClientError(err)
 	}
 
 	if *nsResponse.DomainDNSGetListResult.IsUsingOurDNS {
@@ -232,14 +232,14 @@ func deleteNameserversMerge(ctx context.Context, domain string, previousNameserv
 	if len(remainNameservers) == 0 {
 		_, err := client.DomainsDNS.SetDefaultWithContext(ctx, domain)
 		if err != nil {
-			return diag.FromErr(err)
+			return diagFromClientError(err)
 		}
 		return nil
 	}
 
 	_, err = client.DomainsDNS.SetCustomWithContext(ctx, domain, remainNameservers)
 	if err != nil {
-		return diag.FromErr(err)
+		return diagFromClientError(err)
 	}
 
 	return nil
@@ -249,7 +249,7 @@ func deleteNameserversMerge(ctx context.Context, domain string, previousNameserv
 func deleteNameserversOverwrite(ctx context.Context, domain string, client *namecheap.Client) diag.Diagnostics {
 	_, err := client.DomainsDNS.SetDefaultWithContext(ctx, domain)
 	if err != nil {
-		return diag.FromErr(err)
+		return diagFromClientError(err)
 	}
 
 	return nil
@@ -259,11 +259,11 @@ func deleteNameserversOverwrite(ctx context.Context, domain string, client *name
 func createRecordsMerge(ctx context.Context, domain string, emailType *string, records []interface{}, client *namecheap.Client) diag.Diagnostics {
 	remoteRecordsResponse, err := client.DomainsDNS.GetHostsWithContext(ctx, domain)
 	if err != nil {
-		return diag.FromErr(err)
+		return diagFromClientError(err)
 	}
 
 	if err := validateGetHostsResponse(remoteRecordsResponse); err != nil {
-		return diag.FromErr(err)
+		return diagFromClientError(err)
 	}
 
 	recordsConverted := convertRecordTypeSetToDomainRecords(&records)
@@ -289,7 +289,7 @@ func createRecordsMerge(ctx context.Context, domain string, emailType *string, r
 	for _, record := range *recordsConverted {
 		fixedAddress, err := getFixedAddressOfRecord(&record)
 		if err != nil {
-			return diag.FromErr(err)
+			return diagFromClientError(err)
 		}
 		recordHash := hashRecord(*record.HostName, *record.RecordType, *fixedAddress)
 
@@ -323,7 +323,7 @@ func createRecordsMerge(ctx context.Context, domain string, emailType *string, r
 		Tag:       nil,
 	})
 	if err != nil {
-		return diag.FromErr(err)
+		return diagFromClientError(err)
 	}
 
 	return nil
@@ -346,7 +346,7 @@ func createRecordsOverwrite(ctx context.Context, domain string, emailType *strin
 		Tag:       nil,
 	})
 	if err != nil {
-		return diag.FromErr(err)
+		return diagFromClientError(err)
 	}
 
 	return diag.Diagnostics{}
@@ -357,11 +357,11 @@ func createRecordsOverwrite(ctx context.Context, domain string, emailType *strin
 func readRecordsMerge(ctx context.Context, domain string, currentRecords []interface{}, client *namecheap.Client) (*[]map[string]interface{}, *string, diag.Diagnostics) {
 	remoteRecordsResponse, err := client.DomainsDNS.GetHostsWithContext(ctx, domain)
 	if err != nil {
-		return nil, nil, diag.FromErr(err)
+		return nil, nil, diagFromClientError(err)
 	}
 
 	if err := validateGetHostsResponse(remoteRecordsResponse); err != nil {
-		return nil, nil, diag.FromErr(err)
+		return nil, nil, diagFromClientError(err)
 	}
 
 	currentRecordsConverted := convertRecordTypeSetToDomainRecords(&currentRecords)
@@ -372,7 +372,7 @@ func readRecordsMerge(ctx context.Context, domain string, currentRecords []inter
 		for _, currentRecord := range *currentRecordsConverted {
 			currentRecordAddressFixed, err := getFixedAddressOfRecord(&currentRecord)
 			if err != nil {
-				return nil, nil, diag.FromErr(err)
+				return nil, nil, diagFromClientError(err)
 			}
 
 			currentRecordHash := hashRecord(*currentRecord.HostName, *currentRecord.RecordType, *currentRecordAddressFixed)
@@ -395,11 +395,11 @@ func readRecordsMerge(ctx context.Context, domain string, currentRecords []inter
 func readRecordsOverwrite(ctx context.Context, domain string, currentRecords []interface{}, client *namecheap.Client) (*[]map[string]interface{}, *string, diag.Diagnostics) {
 	remoteRecordsResponse, err := client.DomainsDNS.GetHostsWithContext(ctx, domain)
 	if err != nil {
-		return nil, nil, diag.FromErr(err)
+		return nil, nil, diagFromClientError(err)
 	}
 
 	if err := validateGetHostsResponse(remoteRecordsResponse); err != nil {
-		return nil, nil, diag.FromErr(err)
+		return nil, nil, diagFromClientError(err)
 	}
 
 	currentRecordsConverted := convertRecordTypeSetToDomainRecords(&currentRecords)
@@ -414,7 +414,7 @@ func readRecordsOverwrite(ctx context.Context, domain string, currentRecords []i
 			for _, currentRecord := range *currentRecordsConverted {
 				currentRecordAddressFixed, err := getFixedAddressOfRecord(&currentRecord)
 				if err != nil {
-					return nil, nil, diag.FromErr(err)
+					return nil, nil, diagFromClientError(err)
 				}
 
 				currentRecordHash := hashRecord(*currentRecord.HostName, *currentRecord.RecordType, *currentRecordAddressFixed)
@@ -446,11 +446,11 @@ func readRecordsOverwrite(ctx context.Context, domain string, currentRecords []i
 func updateRecordsMerge(ctx context.Context, domain string, emailType *string, previousRecords []interface{}, currentRecords []interface{}, client *namecheap.Client) diag.Diagnostics {
 	remoteRecordsResponse, err := client.DomainsDNS.GetHostsWithContext(ctx, domain)
 	if err != nil {
-		return diag.FromErr(err)
+		return diagFromClientError(err)
 	}
 
 	if err := validateGetHostsResponse(remoteRecordsResponse); err != nil {
-		return diag.FromErr(err)
+		return diagFromClientError(err)
 	}
 
 	var newRecordList []namecheap.DomainsDNSHostRecord
@@ -465,7 +465,7 @@ func updateRecordsMerge(ctx context.Context, domain string, emailType *string, p
 			for _, prevRecord := range *previousRecordsMapped {
 				prevRecordAddressFixed, err := getFixedAddressOfRecord(&prevRecord)
 				if err != nil {
-					return diag.FromErr(err)
+					return diagFromClientError(err)
 				}
 				prevRecordHash := hashRecord(*prevRecord.HostName, *prevRecord.RecordType, *prevRecordAddressFixed)
 				if strings.EqualFold(remoteRecordHash, prevRecordHash) {
@@ -500,7 +500,7 @@ func updateRecordsMerge(ctx context.Context, domain string, emailType *string, p
 		Tag:       nil,
 	})
 	if err != nil {
-		return diag.FromErr(err)
+		return diagFromClientError(err)
 	}
 
 	return nil
@@ -511,11 +511,11 @@ func updateRecordsMerge(ctx context.Context, domain string, emailType *string, p
 func deleteRecordsMerge(ctx context.Context, domain string, previousRecords []interface{}, client *namecheap.Client) diag.Diagnostics {
 	remoteRecordsResponse, err := client.DomainsDNS.GetHostsWithContext(ctx, domain)
 	if err != nil {
-		return diag.FromErr(err)
+		return diagFromClientError(err)
 	}
 
 	if err := validateGetHostsResponse(remoteRecordsResponse); err != nil {
-		return diag.FromErr(err)
+		return diagFromClientError(err)
 	}
 
 	var remainedRecords []namecheap.DomainsDNSHostRecord
@@ -529,7 +529,7 @@ func deleteRecordsMerge(ctx context.Context, domain string, previousRecords []in
 			for _, prevRecord := range *previousRecordsMapped {
 				prevRecordAddressFixed, err := getFixedAddressOfRecord(&prevRecord)
 				if err != nil {
-					return diag.FromErr(err)
+					return diagFromClientError(err)
 				}
 				prevRecordHash := hashRecord(*prevRecord.HostName, *prevRecord.RecordType, *prevRecordAddressFixed)
 				if strings.EqualFold(remoteRecordHash, prevRecordHash) {
@@ -560,7 +560,7 @@ func deleteRecordsMerge(ctx context.Context, domain string, previousRecords []in
 		Tag:       nil,
 	})
 	if err != nil {
-		return diag.FromErr(err)
+		return diagFromClientError(err)
 	}
 
 	return nil
@@ -578,7 +578,7 @@ func deleteRecordsOverwrite(ctx context.Context, domain string, client *namechea
 		Tag:       nil,
 	})
 	if err != nil {
-		return diag.FromErr(err)
+		return diagFromClientError(err)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

Part of #247. Maps `go-namecheap-sdk` typed errors to targeted Terraform diagnostics with remediation text, so users can tell auth / IP-whitelist / not-found / permission failures apart instead of reading a raw SDK error string.

## Mapped error classes

| Class | Code(s) | Source | Remediation |
|---|---|---|---|
| **Auth failure / IP not whitelisted** | `1011102` | Namecheap global auth response code — "API Key is invalid or API access has not been enabled" | Lists all causes (deliberately ambiguous API message): credentials correct, sandbox↔prod match, API access enabled, and IP whitelisted (whitelist URL + set `client_ip`) — the #1 CI failure |
| Domain not found | `2019166` | `docs/namecheap-api-v2.md` § Error Codes | Check spelling / that it's in the account |
| Domain not associated | `2016166`, `3016166` | `docs/namecheap-api-v2.md` § Error Codes | Use credentials for the owning account |

**Rate limiting is intentionally not mapped:** the API surfaces it as a pre-request HTTP 405 absorbed by the SDK transport retry layer, so it never reaches the provider as an `*APIError`. The companion PR #265 adds a `requests_per_minute` option to *prevent* it.

## Non-breaking

Every unmapped error — including unmapped `*APIError` codes and plain errors — falls through to the previous `diag.FromErr(err)`, so no call site can regress.

## Files changed

- `namecheap/diagnostics.go` (new) — `diagFromClientError`
- `namecheap/diagnostics_test.go` (new) — table-driven per class + fallthrough guarantee
- `namecheap/namecheap_domain_record.go`, `namecheap/namecheap_domain_record_functions.go` — mechanical `diag.FromErr(err)` → `diagFromClientError(err)` at SDK-call error sites (no control-flow change)

## Validation

`go build` / `go vet` / `golangci-lint` (0 issues) / `make test` all green. Acceptance tests not modified. `provider.go` not touched (owned by #265).
