### PR TITLE
feat: add retry, rate-limit and timeout provider options (#247)

### DIFF
--- a/namecheap/provider.go
+++ b/namecheap/provider.go
@@ -2,12 +2,30 @@ package namecheap_provider
 
 import (
 	"context"
+	"fmt"
+	"net/http"
 	"strings"
+	"time"
 
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/namecheap/go-namecheap-sdk/v2/namecheap"
 	"github.com/namecheap/terraform-provider-namecheap/namecheap/internal/mutexkv"
+)
+
+// Defaults for the client resilience options below. They intentionally match
+// the go-namecheap-sdk v2.7.0 documented defaults (see RateLimitOptions and
+// RetryOptions in that module) so that a provider configuration which does not
+// set any of these four fields behaves exactly as it did before they existed.
+const (
+	defaultRequestsPerMinute = 20
+	defaultMaxRetries        = 4
+	defaultRetryMaxElapsed   = "2m"
+	defaultRequestTimeout    = "30s"
+
+	minRequestsPerMinute = 1
+	maxRequestsPerMinute = 20
 )
 
 func Provider() *schema.Provider {
@@ -51,6 +69,38 @@ func Provider() *schema.Provider {
 				Description: "Use sandbox API endpoints",
 				DefaultFunc: schema.EnvDefaultFunc("NAMECHEAP_USE_SANDBOX", false),
 			},
+
+			"requests_per_minute": {
+				Type:             schema.TypeInt,
+				Optional:         true,
+				Description:      "Client-side rate limit applied to the Namecheap API, in requests per minute. Must be between 1 and 20 (Namecheap's documented primary quota). Defaults to 20, matching the SDK's built-in limiter.",
+				DefaultFunc:      schema.EnvDefaultFunc("NAMECHEAP_REQUESTS_PER_MINUTE", defaultRequestsPerMinute),
+				ValidateDiagFunc: validateRequestsPerMinute,
+			},
+
+			"max_retries": {
+				Type:             schema.TypeInt,
+				Optional:         true,
+				Description:      "Total number of attempts (including the first) for a single API call before giving up. Must be >= 0. Defaults to 4, matching the SDK's built-in retry policy. Note: because the underlying SDK treats a zero value as \"unset\", setting this to 0 falls back to the SDK default of 4 attempts rather than disabling retries.",
+				DefaultFunc:      schema.EnvDefaultFunc("NAMECHEAP_MAX_RETRIES", defaultMaxRetries),
+				ValidateDiagFunc: validateMaxRetries,
+			},
+
+			"retry_max_elapsed": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Description:      "Maximum total wall-clock time to spend retrying a single API call, as a Go duration string (e.g. \"2m\", \"90s\"). Must parse and be greater than zero. Defaults to \"2m\", matching the SDK's built-in retry policy.",
+				DefaultFunc:      schema.EnvDefaultFunc("NAMECHEAP_RETRY_MAX_ELAPSED", defaultRetryMaxElapsed),
+				ValidateDiagFunc: validatePositiveDuration,
+			},
+
+			"request_timeout": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Description:      "Timeout applied to the underlying HTTP client for a single request to the Namecheap API, as a Go duration string (e.g. \"30s\", \"1m\"). Must parse and be greater than zero. Defaults to \"30s\".",
+				DefaultFunc:      schema.EnvDefaultFunc("NAMECHEAP_REQUEST_TIMEOUT", defaultRequestTimeout),
+				ValidateDiagFunc: validatePositiveDuration,
+			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"namecheap_domain_records": resourceNamecheapDomainRecords(),
@@ -86,15 +136,110 @@ func configureContext(ctx context.Context, data *schema.ResourceData) (interface
 		}
 	}
 
+	requestsPerMinute := data.Get("requests_per_minute").(int)
+	maxRetries := data.Get("max_retries").(int)
+
+	retryMaxElapsedRaw := data.Get("retry_max_elapsed").(string)
+	retryMaxElapsed, err := time.ParseDuration(retryMaxElapsedRaw)
+	if err != nil {
+		return nil, diag.Diagnostics{
+			{
+				Severity:      diag.Error,
+				Summary:       "Invalid retry_max_elapsed",
+				Detail:        fmt.Sprintf("retry_max_elapsed %q is not a valid Go duration string: %s", retryMaxElapsedRaw, err),
+				AttributePath: cty.Path{cty.GetAttrStep{Name: "retry_max_elapsed"}},
+			},
+		}
+	}
+
+	requestTimeoutRaw := data.Get("request_timeout").(string)
+	requestTimeout, err := time.ParseDuration(requestTimeoutRaw)
+	if err != nil {
+		return nil, diag.Diagnostics{
+			{
+				Severity:      diag.Error,
+				Summary:       "Invalid request_timeout",
+				Detail:        fmt.Sprintf("request_timeout %q is not a valid Go duration string: %s", requestTimeoutRaw, err),
+				AttributePath: cty.Path{cty.GetAttrStep{Name: "request_timeout"}},
+			},
+		}
+	}
+
 	client := namecheap.NewClient(&namecheap.ClientOptions{
 		UserName:   userName,
 		ApiUser:    apiUser,
 		ApiKey:     apiKey,
 		ClientIp:   clientIp,
 		UseSandbox: useSandbox,
+		HTTPClient: &http.Client{Timeout: requestTimeout},
+		RateLimit: &namecheap.RateLimitOptions{
+			PerMinute: requestsPerMinute,
+		},
+		Retry: &namecheap.RetryOptions{
+			MaxAttempts: maxRetries,
+			MaxElapsed:  retryMaxElapsed,
+		},
 	})
 
 	return client, diag.Diagnostics{}
+}
+
+// validateRequestsPerMinute enforces that requests_per_minute stays within
+// Namecheap's documented primary quota (1-20 requests/minute).
+func validateRequestsPerMinute(v interface{}, _ cty.Path) diag.Diagnostics {
+	value := v.(int)
+	if value < minRequestsPerMinute || value > maxRequestsPerMinute {
+		return diag.Diagnostics{
+			{
+				Severity: diag.Error,
+				Summary:  "Invalid requests_per_minute",
+				Detail:   fmt.Sprintf("requests_per_minute must be between %d and %d, got %d", minRequestsPerMinute, maxRequestsPerMinute, value),
+			},
+		}
+	}
+	return nil
+}
+
+// validateMaxRetries enforces that max_retries is not negative.
+func validateMaxRetries(v interface{}, _ cty.Path) diag.Diagnostics {
+	value := v.(int)
+	if value < 0 {
+		return diag.Diagnostics{
+			{
+				Severity: diag.Error,
+				Summary:  "Invalid max_retries",
+				Detail:   fmt.Sprintf("max_retries must be >= 0, got %d", value),
+			},
+		}
+	}
+	return nil
+}
+
+// validatePositiveDuration enforces that a duration-typed string field both
+// parses as a Go duration and is strictly greater than zero. It backs both
+// retry_max_elapsed and request_timeout.
+func validatePositiveDuration(v interface{}, _ cty.Path) diag.Diagnostics {
+	value := v.(string)
+	d, err := time.ParseDuration(value)
+	if err != nil {
+		return diag.Diagnostics{
+			{
+				Severity: diag.Error,
+				Summary:  "Invalid duration",
+				Detail:   fmt.Sprintf("%q is not a valid Go duration string: %s", value, err),
+			},
+		}
+	}
+	if d <= 0 {
+		return diag.Diagnostics{
+			{
+				Severity: diag.Error,
+				Summary:  "Invalid duration",
+				Detail:   fmt.Sprintf("duration must be greater than zero, got %q", value),
+			},
+		}
+	}
+	return nil
 }
 
 var ncMutexKV = mutexkv.NewMutexKV()

--- a/namecheap/provider_test.go
+++ b/namecheap/provider_test.go
@@ -7,7 +7,9 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -185,6 +187,237 @@ func TestProviderConfigureWhitespaceOnlyCredentials(t *testing.T) {
 	assert.Contains(t, diags[0].Detail, "user_name")
 	assert.Contains(t, diags[0].Detail, "api_user")
 	assert.Contains(t, diags[0].Detail, "api_key")
+}
+
+// Resilience config options: requests_per_minute, max_retries,
+// retry_max_elapsed, request_timeout.
+
+const (
+	testEnvRequestsPerMinute = "NAMECHEAP_REQUESTS_PER_MINUTE"
+	testEnvMaxRetries        = "NAMECHEAP_MAX_RETRIES"
+	testEnvRetryMaxElapsed   = "NAMECHEAP_RETRY_MAX_ELAPSED"
+	testEnvRequestTimeout    = "NAMECHEAP_REQUEST_TIMEOUT"
+)
+
+// clearResilienceEnvVars ensures the four new env vars are unset for the
+// duration of a test, so an ambient developer/CI environment cannot leak in.
+func clearResilienceEnvVars(t *testing.T) {
+	t.Helper()
+	for _, k := range []string{testEnvRequestsPerMinute, testEnvMaxRetries, testEnvRetryMaxElapsed, testEnvRequestTimeout} {
+		t.Setenv(k, "")
+	}
+}
+
+// baseProviderConfig sets the three required credential env vars to test
+// values and returns the raw config map other resilience-option tests build on.
+func baseProviderConfig(t *testing.T) map[string]interface{} {
+	t.Helper()
+	t.Setenv("NAMECHEAP_USER_NAME", "test-user")
+	t.Setenv("NAMECHEAP_API_USER", "test-api-user")
+	t.Setenv("NAMECHEAP_API_KEY", "test-api-key")
+	return map[string]interface{}{
+		"client_ip":   testPlaceholderClientIP,
+		"use_sandbox": false,
+	}
+}
+
+func TestProviderResilienceFieldsAreOptional(t *testing.T) {
+	p := Provider()
+	for _, field := range []string{"requests_per_minute", "max_retries", "retry_max_elapsed", "request_timeout"} {
+		s, ok := p.Schema[field]
+		assert.True(t, ok, "field %s should exist", field)
+		assert.True(t, s.Optional, "field %s should be Optional", field)
+		assert.False(t, s.Required, "field %s should not be Required", field)
+	}
+}
+
+func TestProviderResilienceDefaultsPreserveCurrentBehavior(t *testing.T) {
+	clearResilienceEnvVars(t)
+	raw := baseProviderConfig(t)
+
+	rawProvider := Provider()
+	diags := rawProvider.Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
+	assert.False(t, diags.HasError(), "expected no errors with only required fields set, got: %v", diags)
+
+	client, ok := rawProvider.Meta().(*namecheap.Client)
+	assert.True(t, ok, "expected provider meta to be *namecheap.Client")
+	assert.Equal(t, defaultRequestsPerMinute, client.ClientOptions.RateLimit.PerMinute)
+	assert.Equal(t, defaultMaxRetries, client.ClientOptions.Retry.MaxAttempts)
+	assert.Equal(t, 2*time.Minute, client.ClientOptions.Retry.MaxElapsed)
+	assert.Equal(t, 30*time.Second, client.ClientOptions.HTTPClient.Timeout)
+}
+
+func TestProviderResilienceFieldsFromInlineConfig(t *testing.T) {
+	clearResilienceEnvVars(t)
+	raw := baseProviderConfig(t)
+	raw["requests_per_minute"] = 5
+	raw["max_retries"] = 10
+	raw["retry_max_elapsed"] = "90s"
+	raw["request_timeout"] = "45s"
+
+	rawProvider := Provider()
+	diags := rawProvider.Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
+	assert.False(t, diags.HasError(), "expected no errors, got: %v", diags)
+
+	client := rawProvider.Meta().(*namecheap.Client)
+	assert.Equal(t, 5, client.ClientOptions.RateLimit.PerMinute)
+	assert.Equal(t, 10, client.ClientOptions.Retry.MaxAttempts)
+	assert.Equal(t, 90*time.Second, client.ClientOptions.Retry.MaxElapsed)
+	assert.Equal(t, 45*time.Second, client.ClientOptions.HTTPClient.Timeout)
+}
+
+func TestProviderResilienceFieldsFromEnvVars(t *testing.T) {
+	clearResilienceEnvVars(t)
+	raw := baseProviderConfig(t)
+	t.Setenv(testEnvRequestsPerMinute, "7")
+	t.Setenv(testEnvMaxRetries, "6")
+	t.Setenv(testEnvRetryMaxElapsed, "3m")
+	t.Setenv(testEnvRequestTimeout, "20s")
+
+	rawProvider := Provider()
+	diags := rawProvider.Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
+	assert.False(t, diags.HasError(), "expected no errors, got: %v", diags)
+
+	client := rawProvider.Meta().(*namecheap.Client)
+	assert.Equal(t, 7, client.ClientOptions.RateLimit.PerMinute)
+	assert.Equal(t, 6, client.ClientOptions.Retry.MaxAttempts)
+	assert.Equal(t, 3*time.Minute, client.ClientOptions.Retry.MaxElapsed)
+	assert.Equal(t, 20*time.Second, client.ClientOptions.HTTPClient.Timeout)
+}
+
+func TestProviderConfigureInvalidRetryMaxElapsedDuration(t *testing.T) {
+	clearResilienceEnvVars(t)
+	raw := baseProviderConfig(t)
+	raw["retry_max_elapsed"] = "not-a-duration"
+
+	rawProvider := Provider()
+	diags := rawProvider.Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
+	assert.True(t, diags.HasError(), "expected error for unparseable retry_max_elapsed")
+	assert.Contains(t, diags[0].Summary, "retry_max_elapsed")
+}
+
+func TestProviderConfigureInvalidRequestTimeoutDuration(t *testing.T) {
+	clearResilienceEnvVars(t)
+	raw := baseProviderConfig(t)
+	raw["request_timeout"] = "not-a-duration"
+
+	rawProvider := Provider()
+	diags := rawProvider.Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
+	assert.True(t, diags.HasError(), "expected error for unparseable request_timeout")
+	assert.Contains(t, diags[0].Summary, "request_timeout")
+}
+
+// Plan-time validation (ValidateDiagFunc), exercised via Provider().Validate,
+// mirroring how Terraform core invokes it during `terraform validate`/plan.
+
+func TestProviderValidateRequestsPerMinuteBounds(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   int
+		wantErr bool
+	}{
+		{"below minimum", 0, true},
+		{"negative", -1, true},
+		{"above maximum", 21, true},
+		{"minimum boundary", 1, false},
+		{"maximum boundary", 20, false},
+		{"typical value", 10, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := Provider()
+			raw := map[string]interface{}{"requests_per_minute": tt.value}
+			diags := p.Validate(terraform.NewResourceConfigRaw(raw))
+			assert.Equal(t, tt.wantErr, diags.HasError(), "requests_per_minute=%d diags=%v", tt.value, diags)
+		})
+	}
+}
+
+func TestProviderValidateMaxRetriesBounds(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   int
+		wantErr bool
+	}{
+		{"negative", -1, true},
+		{"zero is allowed by validation", 0, false},
+		{"typical value", 4, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := Provider()
+			raw := map[string]interface{}{"max_retries": tt.value}
+			diags := p.Validate(terraform.NewResourceConfigRaw(raw))
+			assert.Equal(t, tt.wantErr, diags.HasError(), "max_retries=%d diags=%v", tt.value, diags)
+		})
+	}
+}
+
+func TestProviderValidateRetryMaxElapsedBounds(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{"unparseable", "not-a-duration", true},
+		{"zero", "0s", true},
+		{"negative", "-5s", true},
+		{"valid", "2m", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := Provider()
+			raw := map[string]interface{}{"retry_max_elapsed": tt.value}
+			diags := p.Validate(terraform.NewResourceConfigRaw(raw))
+			assert.Equal(t, tt.wantErr, diags.HasError(), "retry_max_elapsed=%q diags=%v", tt.value, diags)
+		})
+	}
+}
+
+func TestProviderValidateRequestTimeoutBounds(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{"unparseable", "not-a-duration", true},
+		{"zero", "0s", true},
+		{"negative", "-5s", true},
+		{"valid", "30s", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := Provider()
+			raw := map[string]interface{}{"request_timeout": tt.value}
+			diags := p.Validate(terraform.NewResourceConfigRaw(raw))
+			assert.Equal(t, tt.wantErr, diags.HasError(), "request_timeout=%q diags=%v", tt.value, diags)
+		})
+	}
+}
+
+// Direct unit tests for the new validation functions, exercised outside the
+// schema/provider machinery for full branch coverage.
+
+func TestValidateRequestsPerMinuteFunc(t *testing.T) {
+	assert.Empty(t, validateRequestsPerMinute(1, cty.Path{}))
+	assert.Empty(t, validateRequestsPerMinute(20, cty.Path{}))
+	assert.NotEmpty(t, validateRequestsPerMinute(0, cty.Path{}))
+	assert.NotEmpty(t, validateRequestsPerMinute(21, cty.Path{}))
+	assert.NotEmpty(t, validateRequestsPerMinute(-1, cty.Path{}))
+}
+
+func TestValidateMaxRetriesFunc(t *testing.T) {
+	assert.Empty(t, validateMaxRetries(0, cty.Path{}))
+	assert.Empty(t, validateMaxRetries(4, cty.Path{}))
+	assert.NotEmpty(t, validateMaxRetries(-1, cty.Path{}))
+}
+
+func TestValidatePositiveDurationFunc(t *testing.T) {
+	assert.Empty(t, validatePositiveDuration("2m", cty.Path{}))
+	assert.Empty(t, validatePositiveDuration("30s", cty.Path{}))
+	assert.NotEmpty(t, validatePositiveDuration("not-a-duration", cty.Path{}))
+	assert.NotEmpty(t, validatePositiveDuration("0s", cty.Path{}))
+	assert.NotEmpty(t, validatePositiveDuration("-5s", cty.Path{}))
 }
 
 // Acceptance tests


### PR DESCRIPTION
Part of #247

## What

Adds four new **optional** provider configuration fields that expose the client resilience knobs already built into go-namecheap-sdk v2.7.0, each with environment-variable support and plan-time validation:

| Field | Env var | Type | Default | Validation |
|---|---|---|---|---|
| `requests_per_minute` | `NAMECHEAP_REQUESTS_PER_MINUTE` | int | `20` | 1–20 |
| `max_retries` | `NAMECHEAP_MAX_RETRIES` | int | `4` | >= 0 |
| `retry_max_elapsed` | `NAMECHEAP_RETRY_MAX_ELAPSED` | string (Go duration) | `"2m"` | parses via `time.ParseDuration`, > 0 |
| `request_timeout` | `NAMECHEAP_REQUEST_TIMEOUT` | string (Go duration) | `"30s"` | parses via `time.ParseDuration`, > 0 |

`requests_per_minute` and `max_retries` are wired into `namecheap.RateLimitOptions` / `namecheap.RetryOptions.MaxAttempts` / `MaxElapsed`; `request_timeout` is applied via `ClientOptions.HTTPClient = &http.Client{Timeout: d}`. Invalid values surface as plan-time attribute diagnostics via `ValidateDiagFunc`.

**Non-breaking**: existing configs behave identically. The default values (20 req/min, 4 attempts, 2m retry budget) exactly match the SDK's own built-in defaults (`defaultPerMinute`, `defaultMaxAttempts`, `defaultMaxElapsed` in go-namecheap-sdk v2.7.0's `transport.go`), so a configuration that does not set any of these four fields produces the same client behavior as before this PR.

One caveat worth flagging for reviewers: `request_timeout` introduces a new bounded per-request HTTP timeout (default 30s) where previously none existed — the client's underlying `http.Client` had no `Timeout` set (relying only on the SDK's own retry/elapsed budget and context deadlines). In practice Namecheap API calls complete well under 30s, so this should not affect real-world usage, but it is technically a new constraint rather than a byte-for-byte behavioral no-op. Also, because `namecheap.RetryOptions.MaxAttempts` treats a zero field as "unset" and falls back to the SDK default of 4, setting `max_retries = 0` does **not** disable retries — it is documented as such in the field description.

## Testing

- New unit tests in `namecheap/provider_test.go` cover: default values, inline-config values, env-var overrides, invalid/unparseable durations, and bounds validation for all four fields (including direct tests of the new `validateRequestsPerMinute` / `validateMaxRetries` / `validatePositiveDuration` functions for full coverage).
- `make build && make format && make check && make lint && make test` all pass; the three new validation functions plus `configureContext` and `Provider` report 100% function coverage.
- **Acceptance tests not modified.**

## Files changed

- `namecheap/provider.go`
- `namecheap/provider_test.go`