### PR TITLE
feat: auto-detect client_ip when unset (#247)

### DIFF
--- a/namecheap/clientip.go
+++ b/namecheap/clientip.go
@@ -1,0 +1,60 @@
+package namecheap_provider
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+)
+
+// ipDetectionURL is the endpoint queried to auto-detect the caller's public IP
+// when client_ip is left unset. It is a fixed, provider-controlled constant
+// (never derived from user input) and is always fetched over HTTPS with the
+// caller-supplied *http.Client, whose transport performs standard TLS
+// certificate verification. It is a package-level var only so tests can point
+// detectClientIP at an httptest server; it is not exposed as configuration.
+var ipDetectionURL = "https://api.ipify.org"
+
+// maxDetectionBodyBytes caps how many bytes are read from the IP-detection
+// response. Any valid IPv4/IPv6 text form fits comfortably under this; the cap
+// guards against a misbehaving endpoint streaming an unbounded body within the
+// request timeout (which bounds elapsed time but not bytes).
+const maxDetectionBodyBytes = 512
+
+// detectClientIP fetches this machine's public IP address from ipDetectionURL
+// using the provided httpClient and returns it as a string.
+//
+// The response body is trimmed and validated with net.ParseIP. A non-200
+// status, an unreadable body, or a body that is not a valid IP address each
+// produce an error. TLS verification is never disabled; the transport of the
+// supplied httpClient is used as-is.
+func detectClientIP(ctx context.Context, httpClient *http.Client) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ipDetectionURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("building public IP detection request for %s: %w", ipDetectionURL, err)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("requesting public IP from %s: %w", ipDetectionURL, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("public IP detection from %s returned HTTP status %d", ipDetectionURL, resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxDetectionBodyBytes))
+	if err != nil {
+		return "", fmt.Errorf("reading public IP detection response from %s: %w", ipDetectionURL, err)
+	}
+
+	ip := strings.TrimSpace(string(body))
+	if net.ParseIP(ip) == nil {
+		return "", fmt.Errorf("public IP detection from %s returned %q, which is not a valid IP address", ipDetectionURL, ip)
+	}
+
+	return ip, nil
+}

--- a/namecheap/clientip_test.go
+++ b/namecheap/clientip_test.go
@@ -1,0 +1,92 @@
+package namecheap_provider
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// withDetectionURL points ipDetectionURL at url for the duration of the test
+// and restores the original value afterwards.
+func withDetectionURL(t *testing.T, url string) {
+	t.Helper()
+	original := ipDetectionURL
+	ipDetectionURL = url
+	t.Cleanup(func() { ipDetectionURL = original })
+}
+
+func TestDetectClientIPSuccess(t *testing.T) {
+	// A valid IP, padded with surrounding whitespace, must be trimmed and
+	// returned verbatim.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("  203.0.113.7\n"))
+	}))
+	defer server.Close()
+	withDetectionURL(t, server.URL)
+
+	ip, err := detectClientIP(context.Background(), server.Client())
+	require.NoError(t, err)
+	assert.Equal(t, "203.0.113.7", ip)
+}
+
+func TestDetectClientIPInvalidBody(t *testing.T) {
+	// A 200 response whose body is not an IP address must be rejected.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("not-an-ip-address"))
+	}))
+	defer server.Close()
+	withDetectionURL(t, server.URL)
+
+	ip, err := detectClientIP(context.Background(), server.Client())
+	require.Error(t, err)
+	assert.Empty(t, ip)
+	assert.Contains(t, err.Error(), "not a valid IP address")
+}
+
+func TestDetectClientIPEmptyBody(t *testing.T) {
+	// An empty body is likewise not a valid IP address.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	withDetectionURL(t, server.URL)
+
+	ip, err := detectClientIP(context.Background(), server.Client())
+	require.Error(t, err)
+	assert.Empty(t, ip)
+}
+
+func TestDetectClientIPNon200(t *testing.T) {
+	// A non-200 status must produce an error even if the body looks like an IP.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("203.0.113.7"))
+	}))
+	defer server.Close()
+	withDetectionURL(t, server.URL)
+
+	ip, err := detectClientIP(context.Background(), server.Client())
+	require.Error(t, err)
+	assert.Empty(t, ip)
+	assert.Contains(t, err.Error(), "HTTP status 500")
+}
+
+func TestDetectClientIPTransportFailure(t *testing.T) {
+	// A server that has been shut down makes the request fail at the transport
+	// layer (connection refused), exercising the httpClient.Do error path.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("203.0.113.7"))
+	}))
+	client := server.Client()
+	url := server.URL
+	server.Close()
+	withDetectionURL(t, url)
+
+	ip, err := detectClientIP(context.Background(), client)
+	require.Error(t, err)
+	assert.Empty(t, ip)
+}

--- a/namecheap/provider.go
+++ b/namecheap/provider.go
@@ -3,6 +3,7 @@ package namecheap_provider
 import (
 	"context"
 	"fmt"
+	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -58,9 +59,8 @@ func Provider() *schema.Provider {
 			"client_ip": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "Client IP address",
+				Description: "The public IP address the Namecheap API sees as the caller; it must be whitelisted at https://ap.www.namecheap.com/settings/tools/apiaccess/whitelisted-ips. Leaving it unset now auto-detects this machine's public IP address via an outbound HTTPS request to api.ipify.org (previously it defaulted to the non-functional 0.0.0.0); if that request fails (for example on a host with no outbound network access), provider configuration fails with guidance to set client_ip explicitly.",
 				DefaultFunc: schema.EnvDefaultFunc("NAMECHEAP_CLIENT_IP", nil),
-				Default:     "0.0.0.0",
 			},
 
 			"use_sandbox": {
@@ -113,7 +113,7 @@ func configureContext(ctx context.Context, data *schema.ResourceData) (interface
 	userName := strings.TrimSpace(data.Get("user_name").(string))
 	apiUser := strings.TrimSpace(data.Get("api_user").(string))
 	apiKey := strings.TrimSpace(data.Get("api_key").(string))
-	clientIp := data.Get("client_ip").(string)
+	clientIp := strings.TrimSpace(data.Get("client_ip").(string))
 	useSandbox := data.Get("use_sandbox").(bool)
 
 	var missing []string
@@ -163,6 +163,41 @@ func configureContext(ctx context.Context, data *schema.ResourceData) (interface
 				AttributePath: cty.Path{cty.GetAttrStep{Name: "request_timeout"}},
 			},
 		}
+	}
+
+	// client_ip is only meaningful when it names the public IP the Namecheap
+	// API sees as the caller (and which the account has whitelisted). When it
+	// is left unset we auto-detect that public IP rather than sending the old
+	// non-functional 0.0.0.0 default. An explicitly-set value (inline or via
+	// NAMECHEAP_CLIENT_IP) is always honored unchanged, so this stays
+	// non-breaking.
+	if clientIp == "" {
+		baseCtx := ctx
+		if baseCtx == nil {
+			baseCtx = context.Background()
+		}
+		detectCtx, cancel := context.WithTimeout(baseCtx, 5*time.Second)
+		defer cancel()
+
+		ip, detectErr := detectClientIP(detectCtx, &http.Client{})
+		if detectErr != nil {
+			return nil, diag.Diagnostics{
+				{
+					Severity: diag.Error,
+					Summary:  "Unable to auto-detect client_ip",
+					Detail: fmt.Sprintf(
+						"client_ip is unset and the provider could not auto-detect this machine's public IP address: %s. "+
+							"To resolve, either set the client_ip argument (or the NAMECHEAP_CLIENT_IP environment variable) to the "+
+							"public IP this provider calls from, and make sure that IP is whitelisted at "+
+							"https://ap.www.namecheap.com/settings/tools/apiaccess/whitelisted-ips.",
+						detectErr,
+					),
+					AttributePath: cty.Path{cty.GetAttrStep{Name: "client_ip"}},
+				},
+			}
+		}
+		clientIp = ip
+		log.Printf("[INFO] namecheap: auto-detected client_ip %s", ip)
 	}
 
 	client := namecheap.NewClient(&namecheap.ClientOptions{

--- a/namecheap/provider_test.go
+++ b/namecheap/provider_test.go
@@ -3,6 +3,8 @@ package namecheap_provider
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"regexp"
 	"strings"
@@ -187,6 +189,105 @@ func TestProviderConfigureWhitespaceOnlyCredentials(t *testing.T) {
 	assert.Contains(t, diags[0].Detail, "user_name")
 	assert.Contains(t, diags[0].Detail, "api_user")
 	assert.Contains(t, diags[0].Detail, "api_key")
+}
+
+// client_ip auto-detection: the configureContext `if clientIp == ""` branch.
+
+// setRequiredCredentialsWithoutClientIP sets the three required credential env
+// vars and clears NAMECHEAP_CLIENT_IP so that an ambient value cannot leak in
+// and suppress the auto-detect branch under test.
+func setRequiredCredentialsWithoutClientIP(t *testing.T) {
+	t.Helper()
+	t.Setenv("NAMECHEAP_USER_NAME", "test-user")
+	t.Setenv("NAMECHEAP_API_USER", "test-api-user")
+	t.Setenv("NAMECHEAP_API_KEY", "test-api-key")
+	t.Setenv("NAMECHEAP_CLIENT_IP", "")
+}
+
+func TestProviderConfigureAutoDetectsClientIPWhenUnset(t *testing.T) {
+	setRequiredCredentialsWithoutClientIP(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("203.0.113.7"))
+	}))
+	defer server.Close()
+	withDetectionURL(t, server.URL)
+
+	rawProvider := Provider()
+	raw := map[string]interface{}{
+		"use_sandbox": false,
+	}
+	diags := rawProvider.Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
+	assert.False(t, diags.HasError(), "expected no errors on successful auto-detect, got: %v", diags)
+
+	client := rawProvider.Meta().(*namecheap.Client)
+	assert.Equal(t, "203.0.113.7", client.ClientOptions.ClientIp)
+}
+
+func TestProviderConfigureAutoDetectClientIPFailure(t *testing.T) {
+	setRequiredCredentialsWithoutClientIP(t)
+
+	// A server that has been shut down makes detection fail at the transport
+	// layer (connection refused), exercising the diag.Error path.
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+	url := server.URL
+	server.Close()
+	withDetectionURL(t, url)
+
+	rawProvider := Provider()
+	raw := map[string]interface{}{
+		"use_sandbox": false,
+	}
+	diags := rawProvider.Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
+	assert.True(t, diags.HasError(), "expected error when auto-detect fails")
+	assert.Equal(t, "Unable to auto-detect client_ip", diags[0].Summary)
+	assert.Equal(t, cty.Path{cty.GetAttrStep{Name: "client_ip"}}, diags[0].AttributePath)
+}
+
+func TestProviderConfigureExplicitClientIPHonored(t *testing.T) {
+	setRequiredCredentialsWithoutClientIP(t)
+
+	// Point detection at a server that would return a different IP, to prove the
+	// resolver is never consulted when client_ip is explicitly set.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("203.0.113.7"))
+	}))
+	defer server.Close()
+	withDetectionURL(t, server.URL)
+
+	rawProvider := Provider()
+	raw := map[string]interface{}{
+		"client_ip":   "198.51.100.42",
+		"use_sandbox": false,
+	}
+	diags := rawProvider.Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
+	assert.False(t, diags.HasError(), "expected no errors when client_ip is set inline, got: %v", diags)
+
+	client := rawProvider.Meta().(*namecheap.Client)
+	assert.Equal(t, "198.51.100.42", client.ClientOptions.ClientIp)
+}
+
+func TestProviderConfigureWhitespaceClientIPTriggersDetection(t *testing.T) {
+	setRequiredCredentialsWithoutClientIP(t)
+
+	// A whitespace-only client_ip is trimmed to "" and must trigger auto-detect
+	// rather than being passed through to the SDK verbatim.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("203.0.113.7"))
+	}))
+	defer server.Close()
+	withDetectionURL(t, server.URL)
+
+	rawProvider := Provider()
+	raw := map[string]interface{}{
+		"client_ip":   "   ",
+		"use_sandbox": false,
+	}
+	diags := rawProvider.Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
+	assert.False(t, diags.HasError(), "expected no errors, got: %v", diags)
+
+	client := rawProvider.Meta().(*namecheap.Client)
+	assert.Equal(t, "203.0.113.7", client.ClientOptions.ClientIp)
 }
 
 // Resilience config options: requests_per_minute, max_retries,


### PR DESCRIPTION
Part of #247

## Summary

When `client_ip` is left unset (and `NAMECHEAP_CLIENT_IP` is not provided), the provider now auto-detects this machine's public IP address via an outbound HTTPS request to `api.ipify.org`, bounded by a 5s timeout. The detected IP is passed to the Namecheap SDK as `ClientIp`.

On detection failure the provider returns a clear diagnostic anchored on the `client_ip` attribute, guiding the user to set `client_ip` (or `NAMECHEAP_CLIENT_IP`) explicitly and to whitelist that IP at the Namecheap API access settings page.

## Behavior change

Previously, an unset `client_ip` defaulted to the non-functional `0.0.0.0`, which the Namecheap API never accepts. That default is replaced by auto-detection.

## Non-breaking

Explicit `client_ip` is honored; only unset triggers detection. An explicitly-set `client_ip` (inline or via `NAMECHEAP_CLIENT_IP`) is passed through to the SDK unchanged. A whitespace-only value is trimmed to empty and therefore also triggers detection.

## Hardening

- Detection is fetched over HTTPS with standard TLS verification; the detection URL is a fixed, provider-controlled constant (never user input).
- The response body read is bounded with `io.LimitReader` (512-byte cap) and the result is validated with `net.ParseIP`.

## Tests

- `make build && make format && make check && make lint && make test` all pass locally.
- Added unit tests for the auto-detect branch in `configureContext`: successful detection sets `ClientOptions.ClientIp`; detection failure returns a `diag.Error` with summary `Unable to auto-detect client_ip` and an `AttributePath` on `client_ip`; explicit `client_ip` is honored unchanged; whitespace-only `client_ip` triggers detection.
- Existing `detectClientIP` unit tests continue to cover the resolver (success, invalid body, empty body, non-200, transport failure).

Acceptance tests not modified.
