### PR TITLE
feat: bridge SDK request logging into tflog (#247)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/namecheap/terraform-provider-namecheap
 
 require (
 	github.com/hashicorp/go-cty v1.5.0
+	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1
 	github.com/namecheap/go-namecheap-sdk/v2 v2.7.0
 	github.com/stretchr/testify v1.11.1
@@ -32,7 +33,6 @@ require (
 	github.com/hashicorp/terraform-exec v0.25.2 // indirect
 	github.com/hashicorp/terraform-json v0.27.2 // indirect
 	github.com/hashicorp/terraform-plugin-go v0.31.0 // indirect
-	github.com/hashicorp/terraform-plugin-log v0.10.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.4.0 // indirect
 	github.com/hashicorp/terraform-svchost v0.2.1 // indirect
 	github.com/hashicorp/yamux v0.1.2 // indirect

--- a/namecheap/logging.go
+++ b/namecheap/logging.go
@@ -1,0 +1,181 @@
+package namecheap_provider
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// bridgeHandler is a slog.Handler that forwards records emitted by the
+// go-namecheap-sdk (via ClientOptions.Logger) into Terraform's tflog. The SDK
+// invokes the logger as logger.LogAttrs(ctx, level, msg, attrs...), threading
+// the per-operation context that tflog needs to route output to the right
+// provider log stream. Enabling it is what surfaces per-API-call entries
+// (command, attempt, duration, status, error_code) under
+// TF_LOG_PROVIDER_NAMECHEAP=DEBUG.
+//
+// The SDK already redacts secret parameters (ApiKey, passwords, EPPCode, ...)
+// to "***" before logging, and this bridge introduces no credentials of its
+// own. As a backstop it additionally redacts the account identifiers the
+// provider marks Sensitive (Username/ApiUser) inside any forwarded parameter
+// map, because the SDK forwards those in cleartext (see sensitiveParamKeys).
+type bridgeHandler struct {
+	// groups is the open group path; it prefixes the keys of record attrs and
+	// of any attrs added after the group was opened.
+	groups []string
+	// fields holds attrs accumulated via WithAttrs, already resolved and
+	// qualified with the group path that was active when they were added.
+	fields map[string]any
+}
+
+// newBridgeHandler returns a slog.Handler that bridges slog records to tflog.
+func newBridgeHandler() *bridgeHandler {
+	return &bridgeHandler{}
+}
+
+// Enabled always returns true so that tflog (driven by TF_LOG / the
+// TF_LOG_PROVIDER_NAMECHEAP level) does the level filtering rather than the
+// bridge dropping records early.
+func (h *bridgeHandler) Enabled(_ context.Context, _ slog.Level) bool {
+	return true
+}
+
+// Handle maps the slog record's level to the matching tflog function and
+// forwards the message plus a flattened field map. The context carries the
+// tflog logger, so it must be the SDK's per-operation context.
+func (h *bridgeHandler) Handle(ctx context.Context, record slog.Record) error {
+	fields := make(map[string]any, len(h.fields)+record.NumAttrs())
+	for k, v := range h.fields {
+		fields[k] = v
+	}
+	record.Attrs(func(a slog.Attr) bool {
+		addAttr(fields, h.groups, a)
+		return true
+	})
+
+	msg := record.Message
+	switch {
+	case record.Level >= slog.LevelError:
+		tflog.Error(ctx, msg, fields)
+	case record.Level >= slog.LevelWarn:
+		tflog.Warn(ctx, msg, fields)
+	case record.Level >= slog.LevelInfo:
+		tflog.Info(ctx, msg, fields)
+	default:
+		tflog.Debug(ctx, msg, fields)
+	}
+	return nil
+}
+
+// WithAttrs returns a handler that also emits the given attrs on every record.
+// The attrs are resolved and qualified with the current group path up front,
+// so later WithGroup calls do not retroactively re-prefix them.
+func (h *bridgeHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	if len(attrs) == 0 {
+		return h
+	}
+	fields := make(map[string]any, len(h.fields)+len(attrs))
+	for k, v := range h.fields {
+		fields[k] = v
+	}
+	for _, a := range attrs {
+		addAttr(fields, h.groups, a)
+	}
+	return &bridgeHandler{groups: h.groups, fields: fields}
+}
+
+// WithGroup returns a handler that prefixes the keys of subsequently added
+// attrs (and record attrs) with name, dot-separated. Already-accumulated
+// fields keep their existing keys.
+func (h *bridgeHandler) WithGroup(name string) slog.Handler {
+	if name == "" {
+		return h
+	}
+	groups := make([]string, 0, len(h.groups)+1)
+	groups = append(groups, h.groups...)
+	groups = append(groups, name)
+	return &bridgeHandler{groups: groups, fields: h.fields}
+}
+
+// addAttr resolves a single attr and writes it into fields under a key that is
+// prefixed by the group path. Group-valued attrs are flattened recursively; an
+// empty group key inlines its children without adding a prefix, and empty
+// attrs are dropped, matching slog.Handler semantics.
+func addAttr(fields map[string]any, groups []string, a slog.Attr) {
+	a.Value = a.Value.Resolve()
+	if a.Equal(slog.Attr{}) {
+		return
+	}
+
+	if a.Value.Kind() == slog.KindGroup {
+		children := a.Value.Group()
+		if len(children) == 0 {
+			return
+		}
+		childGroups := groups
+		if a.Key != "" {
+			childGroups = make([]string, 0, len(groups)+1)
+			childGroups = append(childGroups, groups...)
+			childGroups = append(childGroups, a.Key)
+		}
+		for _, child := range children {
+			addAttr(fields, childGroups, child)
+		}
+		return
+	}
+
+	key := a.Key
+	if len(groups) > 0 {
+		key = strings.Join(groups, ".") + "." + a.Key
+	}
+	fields[key] = redactSensitive(a.Value.Any())
+}
+
+// redactedValue is the placeholder written in place of a redacted value; it
+// matches the placeholder the SDK uses for its own secret redaction.
+const redactedValue = "***"
+
+// sensitiveParamKeys are request-parameter keys whose values are account
+// credentials or identifiers the provider marks Sensitive: user_name ->
+// Username, api_user -> ApiUser, api_key -> ApiKey. The SDK already redacts
+// ApiKey, but it forwards Username and ApiUser in cleartext inside the "params"
+// attr; the bridge redacts them here so Sensitive account identifiers never
+// reach the Terraform debug log. Re-redacting ApiKey is a harmless backstop.
+var sensitiveParamKeys = map[string]struct{}{
+	"Username": {},
+	"ApiUser":  {},
+	"ApiKey":   {},
+}
+
+// redactSensitive returns v with the values of any sensitiveParamKeys replaced
+// by "***" when v is a string-keyed parameter map (the shape the SDK uses for
+// the forwarded "params" attr). Non-map values, and maps carrying no sensitive
+// keys, are returned unchanged. It never mutates the input.
+func redactSensitive(v any) any {
+	switch m := v.(type) {
+	case map[string]string:
+		out := make(map[string]string, len(m))
+		for k, val := range m {
+			if _, secret := sensitiveParamKeys[k]; secret {
+				out[k] = redactedValue
+			} else {
+				out[k] = val
+			}
+		}
+		return out
+	case map[string]any:
+		out := make(map[string]any, len(m))
+		for k, val := range m {
+			if _, secret := sensitiveParamKeys[k]; secret {
+				out[k] = redactedValue
+			} else {
+				out[k] = val
+			}
+		}
+		return out
+	default:
+		return v
+	}
+}

--- a/namecheap/logging_test.go
+++ b/namecheap/logging_test.go
@@ -1,0 +1,313 @@
+package namecheap_provider
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-log/tflogtest"
+)
+
+// decodeOne runs fn against a bridge-backed slog.Logger whose tflog output is
+// captured, then decodes and returns the single log entry it produced.
+func decodeOne(t *testing.T, fn func(ctx context.Context, logger *slog.Logger)) map[string]interface{} {
+	t.Helper()
+
+	var buf bytes.Buffer
+	ctx := tflogtest.RootLogger(context.Background(), &buf)
+	logger := slog.New(newBridgeHandler())
+
+	fn(ctx, logger)
+
+	entries, err := tflogtest.MultilineJSONDecode(&buf)
+	if err != nil {
+		t.Fatalf("failed to decode tflog output: %s\nraw: %q", err, buf.String())
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected exactly 1 log entry, got %d: %v", len(entries), entries)
+	}
+	return entries[0]
+}
+
+func TestBridgeHandler_Handle_ForwardsMessageAndFields(t *testing.T) {
+	var buf bytes.Buffer
+	ctx := tflogtest.RootLogger(context.Background(), &buf)
+	logger := slog.New(newBridgeHandler())
+
+	logger.LogAttrs(ctx, slog.LevelInfo, "namecheap request completed",
+		slog.String("command", "namecheap.domains.getInfo"),
+		slog.Int("status", 200),
+	)
+
+	entries, err := tflogtest.MultilineJSONDecode(&buf)
+	if err != nil {
+		t.Fatalf("failed to decode tflog output: %s\nraw: %q", err, buf.String())
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 log entry, got %d: %v", len(entries), entries)
+	}
+	entry := entries[0]
+
+	if got := entry["@message"]; got != "namecheap request completed" {
+		t.Errorf("@message = %v, want %q", got, "namecheap request completed")
+	}
+	if got := entry["@level"]; got != "info" {
+		t.Errorf("@level = %v, want %q", got, "info")
+	}
+	if got := entry["command"]; got != "namecheap.domains.getInfo" {
+		t.Errorf("command = %v, want %q", got, "namecheap.domains.getInfo")
+	}
+	// JSON numbers decode as float64.
+	if got := entry["status"]; got != float64(200) {
+		t.Errorf("status = %v (%T), want 200", got, got)
+	}
+}
+
+// TestBridgeHandler_Handle_RedactsSensitiveParams feeds a real credential value
+// through the exact shape the SDK forwards (a "params" map that carries
+// cleartext account identifiers) and asserts the bridge redacts the
+// provider-Sensitive keys (Username, ApiUser, ApiKey) before anything reaches
+// the log, while leaving non-sensitive params intact. This guards the
+// security-sensitive path: the SDK does NOT redact Username/ApiUser, so without
+// the bridge's backstop these Sensitive identifiers would leak into
+// TF_LOG_PROVIDER_NAMECHEAP=DEBUG output.
+func TestBridgeHandler_Handle_RedactsSensitiveParams(t *testing.T) {
+	const (
+		secretUser   = "super-secret-account-user"
+		secretApiKey = "super-secret-api-key-value"
+	)
+
+	var buf bytes.Buffer
+	ctx := tflogtest.RootLogger(context.Background(), &buf)
+	logger := slog.New(newBridgeHandler())
+
+	logger.LogAttrs(ctx, slog.LevelDebug, "namecheap request start",
+		slog.String("command", "namecheap.domains.getInfo"),
+		slog.Any("params", map[string]string{
+			"Command":    "namecheap.domains.getInfo",
+			"DomainName": "example.com",
+			"Username":   secretUser,
+			"ApiUser":    secretUser,
+			"ApiKey":     secretApiKey,
+		}),
+	)
+
+	raw := buf.String()
+	if strings.Contains(raw, secretUser) {
+		t.Fatalf("Sensitive account identifier leaked into log output: %q", raw)
+	}
+	if strings.Contains(raw, secretApiKey) {
+		t.Fatalf("Sensitive api key leaked into log output: %q", raw)
+	}
+
+	entries, err := tflogtest.MultilineJSONDecode(&buf)
+	if err != nil {
+		t.Fatalf("failed to decode tflog output: %s\nraw: %q", err, raw)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 log entry, got %d: %v", len(entries), entries)
+	}
+	params, ok := entries[0]["params"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("params = %v (%T), want a map", entries[0]["params"], entries[0]["params"])
+	}
+
+	for _, k := range []string{"Username", "ApiUser", "ApiKey"} {
+		if got := params[k]; got != "***" {
+			t.Errorf("params[%q] = %v, want redacted %q", k, got, "***")
+		}
+	}
+	// Non-sensitive params must survive untouched so the log stays useful.
+	if got := params["DomainName"]; got != "example.com" {
+		t.Errorf("params[DomainName] = %v, want %q (non-sensitive, must not be redacted)", got, "example.com")
+	}
+	if got := params["Command"]; got != "namecheap.domains.getInfo" {
+		t.Errorf("params[Command] = %v, want %q", got, "namecheap.domains.getInfo")
+	}
+}
+
+func TestBridgeHandler_Handle_LevelMapping(t *testing.T) {
+	cases := []struct {
+		name  string
+		level slog.Level
+		want  string
+	}{
+		{"debug", slog.LevelDebug, "debug"},
+		{"info", slog.LevelInfo, "info"},
+		{"warn", slog.LevelWarn, "warn"},
+		{"error", slog.LevelError, "error"},
+		// Levels between the named ones round down to the lower tflog level.
+		{"below-warn", slog.LevelInfo + 1, "info"},
+		{"above-error", slog.LevelError + 4, "error"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			entry := decodeOne(t, func(ctx context.Context, logger *slog.Logger) {
+				logger.LogAttrs(ctx, tc.level, "msg")
+			})
+			if got := entry["@level"]; got != tc.want {
+				t.Errorf("@level = %v, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBridgeHandler_Enabled(t *testing.T) {
+	h := newBridgeHandler()
+	for _, lvl := range []slog.Level{slog.LevelDebug, slog.LevelInfo, slog.LevelWarn, slog.LevelError} {
+		if !h.Enabled(context.Background(), lvl) {
+			t.Errorf("Enabled(%v) = false, want true (tflog should do the filtering)", lvl)
+		}
+	}
+}
+
+func TestBridgeHandler_WithAttrs(t *testing.T) {
+	entry := decodeOne(t, func(ctx context.Context, logger *slog.Logger) {
+		logger.With(slog.String("command", "namecheap.domains.getList")).
+			LogAttrs(ctx, slog.LevelWarn, "namecheap request failed",
+				slog.Int("status", 420),
+			)
+	})
+
+	if got := entry["command"]; got != "namecheap.domains.getList" {
+		t.Errorf("command = %v, want preset attr to be forwarded", got)
+	}
+	if got := entry["status"]; got != float64(420) {
+		t.Errorf("status = %v, want 420 (record attr alongside preset)", got)
+	}
+	if got := entry["@level"]; got != "warn" {
+		t.Errorf("@level = %v, want warn", got)
+	}
+}
+
+func TestBridgeHandler_WithGroup(t *testing.T) {
+	entry := decodeOne(t, func(ctx context.Context, logger *slog.Logger) {
+		logger.WithGroup("req").
+			LogAttrs(ctx, slog.LevelInfo, "msg",
+				slog.String("command", "namecheap.domains.getInfo"),
+			)
+	})
+
+	if got := entry["req.command"]; got != "namecheap.domains.getInfo" {
+		t.Errorf("req.command = %v, want group-prefixed key", got)
+	}
+	if _, ok := entry["command"]; ok {
+		t.Errorf("unexpected unprefixed command key in %v", entry)
+	}
+}
+
+func TestBridgeHandler_WithGroupThenAttrs(t *testing.T) {
+	// Attrs set after a group opens are prefixed; attrs set before it are not.
+	entry := decodeOne(t, func(ctx context.Context, logger *slog.Logger) {
+		logger.With(slog.String("top", "a")).
+			WithGroup("g").
+			With(slog.String("inner", "b")).
+			LogAttrs(ctx, slog.LevelInfo, "msg",
+				slog.Int("status", 200),
+			)
+	})
+
+	if got := entry["top"]; got != "a" {
+		t.Errorf("top = %v, want %q (pre-group attr keeps bare key)", got, "a")
+	}
+	if got := entry["g.inner"]; got != "b" {
+		t.Errorf("g.inner = %v, want %q (post-group attr is prefixed)", got, "b")
+	}
+	if got := entry["g.status"]; got != float64(200) {
+		t.Errorf("g.status = %v, want 200 (record attr prefixed by open group)", got)
+	}
+}
+
+// TestBridgeHandler_NoOpEdges covers the shortcut branches: WithAttrs with no
+// attrs and WithGroup with an empty name both return the same handler.
+func TestBridgeHandler_NoOpEdges(t *testing.T) {
+	h := newBridgeHandler()
+	if h.WithAttrs(nil) != h {
+		t.Error("WithAttrs(nil) should return the receiver unchanged")
+	}
+	if h.WithGroup("") != h {
+		t.Error("WithGroup(\"\") should return the receiver unchanged")
+	}
+}
+
+// TestBridgeHandler_Handle_GroupValuedAttrs exercises addAttr's group handling:
+// a named group is flattened under a dotted prefix, an empty-key group inlines
+// its children without a prefix, an empty group is dropped, and an empty attr
+// is dropped. These are defensive branches (the SDK emits only flat attrs), so
+// without this test a regression in the recursive flattening would go
+// unnoticed.
+func TestBridgeHandler_Handle_GroupValuedAttrs(t *testing.T) {
+	entry := decodeOne(t, func(ctx context.Context, logger *slog.Logger) {
+		logger.LogAttrs(ctx, slog.LevelInfo, "msg",
+			// Named group: children flattened under "req.<key>".
+			slog.Group("req",
+				slog.String("command", "namecheap.domains.getInfo"),
+				slog.Int("attempt", 1),
+			),
+			// Empty-key group: children inlined without a prefix.
+			slog.Group("", slog.String("inline", "v")),
+			// Empty group: dropped entirely, no key emitted.
+			slog.Group("dropme"),
+			// Empty attr: dropped entirely.
+			slog.Attr{},
+		)
+	})
+
+	if got := entry["req.command"]; got != "namecheap.domains.getInfo" {
+		t.Errorf("req.command = %v, want group child flattened under group prefix", got)
+	}
+	if got := entry["req.attempt"]; got != float64(1) {
+		t.Errorf("req.attempt = %v, want 1", got)
+	}
+	if got := entry["inline"]; got != "v" {
+		t.Errorf("inline = %v, want %q (empty-key group inlines children)", got, "v")
+	}
+	if _, ok := entry["dropme"]; ok {
+		t.Errorf("empty group should be dropped, but key present in %v", entry)
+	}
+}
+
+// TestRedactSensitive covers the bridge's credential backstop directly: it
+// redacts the provider-Sensitive keys (Username/ApiUser/ApiKey) in both the
+// map[string]string shape the SDK forwards and the defensive map[string]any
+// shape, preserves non-sensitive entries, and passes non-map values through.
+func TestRedactSensitive(t *testing.T) {
+	gotStr, ok := redactSensitive(map[string]string{
+		"Username":   "u",
+		"ApiUser":    "au",
+		"ApiKey":     "k",
+		"DomainName": "example.com",
+	}).(map[string]string)
+	if !ok {
+		t.Fatal("redactSensitive(map[string]string) did not return map[string]string")
+	}
+	for _, k := range []string{"Username", "ApiUser", "ApiKey"} {
+		if gotStr[k] != "***" {
+			t.Errorf("map[string]string[%q] = %q, want redacted %q", k, gotStr[k], "***")
+		}
+	}
+	if gotStr["DomainName"] != "example.com" {
+		t.Errorf("DomainName = %q, want preserved", gotStr["DomainName"])
+	}
+
+	gotAny, ok := redactSensitive(map[string]any{
+		"ApiUser": "au",
+		"count":   3,
+	}).(map[string]any)
+	if !ok {
+		t.Fatal("redactSensitive(map[string]any) did not return map[string]any")
+	}
+	if gotAny["ApiUser"] != "***" {
+		t.Errorf("map[string]any[ApiUser] = %v, want redacted %q", gotAny["ApiUser"], "***")
+	}
+	if gotAny["count"] != 3 {
+		t.Errorf("count = %v, want 3 (non-sensitive preserved)", gotAny["count"])
+	}
+
+	if got := redactSensitive("plain"); got != "plain" {
+		t.Errorf("redactSensitive(string) = %v, want passthrough", got)
+	}
+}

--- a/namecheap/provider.go
+++ b/namecheap/provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -214,6 +215,12 @@ func configureContext(ctx context.Context, data *schema.ResourceData) (interface
 			MaxAttempts: maxRetries,
 			MaxElapsed:  retryMaxElapsed,
 		},
+		// Bridge the SDK's structured slog events into Terraform's tflog so
+		// that TF_LOG_PROVIDER_NAMECHEAP=DEBUG surfaces per-API-call entries
+		// (command, attempt, duration, status, error_code). The SDK redacts
+		// secret parameters before logging; the bridge forwards only, adding
+		// no credentials. Purely additive: it does not affect API behavior.
+		Logger: slog.New(newBridgeHandler()),
 	})
 
 	return client, diag.Diagnostics{}


### PR DESCRIPTION
Part of #247

## Summary
Wires a `slog.Handler` bridge as the go-namecheap-sdk v2.7.0 `ClientOptions.Logger`, so `TF_LOG_PROVIDER_NAMECHEAP=DEBUG` now surfaces per-API-call structured log entries: `command`, `attempt`, `duration`, `status`, and (on failure) `error_code` / `error`. slog levels map to the matching tflog level (Debug/Info/Warn/Error), and the SDK's per-operation context is threaded through so entries route to the provider log stream. `WithAttrs`/`WithGroup` are supported (group keys flatten to dotted paths).

## Non-breaking: additive logging only
The bridge forwards attributes and adds no credentials of its own; it does not touch request/response behavior, retries, rate limiting, or timeouts. With logging off, nothing changes.

## Credential handling
The SDK redacts its secret parameters (`ApiKey`, `NewPassword`, `OldPassword`, `ResetCode`, `EPPCode`) to `***` before logging. However, the SDK forwards the account identifiers `Username` and `ApiUser` in **cleartext** inside the request `params` attr, and the provider marks `user_name`/`api_user` as `Sensitive`. To prevent those Sensitive identifiers from leaking into the Terraform debug log, the bridge redacts `Username`/`ApiUser` (plus `ApiKey` as a backstop) in any forwarded parameter map before it reaches tflog. Non-sensitive params (e.g. `DomainName`, `Command`) are preserved.

## go.mod
`github.com/hashicorp/terraform-plugin-log` is promoted from an indirect (transitive) dependency to a direct one; no other dependency changes and `go.sum` is unchanged.

## Tests
`make build && make format && make check && make lint && make test` all pass locally (lint: 0 issues; package coverage 92.0%).

- `TestBridgeHandler_Handle_RedactsSensitiveParams` feeds a real credential value through the exact `params`-map shape the SDK forwards and asserts the raw output does **not** contain the secret, the Sensitive keys are redacted to `***`, and non-sensitive params survive — a load-bearing redaction assertion (the prior test logged only a pre-redacted placeholder and could never fail).
- `TestBridgeHandler_Handle_GroupValuedAttrs` and `TestRedactSensitive` cover group flattening / empty-group / empty-attr drop branches and the redaction helper; `addAttr` coverage rose from 36.8% to 94.7%.

## Acceptance tests not modified
No `TestAcc*` changes; they remain skipped without `TF_ACC`.