### PR TITLE
docs: document provider config options and add CI-environments guide (#247)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A Terraform Provider for Namecheap domain DNS configuration.
 - [Namecheap Provider Documentation](https://registry.terraform.io/providers/namecheap/namecheap/latest/docs)
 - [Guide: Migration to v2.0.0 new major release](https://registry.terraform.io/providers/namecheap/namecheap/latest/docs/guides/namecheap_provider_migration_v2.0.0)
 - [Guide: Namecheap domain records](https://registry.terraform.io/providers/namecheap/namecheap/latest/docs/guides/namecheap_domain_records_guide)
+- [Guide: Running in CI and automation environments](https://registry.terraform.io/providers/namecheap/namecheap/latest/docs/guides/ci-environments)
 
 ## Prerequisites
 
@@ -23,6 +24,8 @@ Next, find out your IP address and add that IP (or any other IPs accessing this 
 this [whitelist admin page](https://ap.www.namecheap.com/settings/tools/apiaccess/whitelisted-ips) on Namecheap.
 
 Once you've done that, make note of the API key, your IP address, and your username to fill into our `provider` block.
+
+`client_ip` is optional: when it is left unset the provider auto-detects the caller's public IP over HTTPS. Set it explicitly (or via `NAMECHEAP_CLIENT_IP`) when running on hosts with restricted egress or split routing. For running from CI runners, containers, and other automation, see the [Running in CI and automation environments](https://registry.terraform.io/providers/namecheap/namecheap/latest/docs/guides/ci-environments) guide.
 
 ## Usage Example
 
@@ -46,6 +49,12 @@ provider "namecheap" {
   api_key = "your_api_key"
   client_ip = "your.ip.address.here"
   use_sandbox = false
+
+  # Optional client resilience tuning (defaults shown):
+  # requests_per_minute = 20      # client-side rate limit (1-20)
+  # max_retries         = 4       # attempts per call (>= 0; 0 means SDK default of 4)
+  # retry_max_elapsed   = "2m"    # max total retry time (Go duration)
+  # request_timeout     = "30s"   # per-request HTTP timeout (Go duration)
 }
 
 

--- a/docs/guides/ci-environments.md
+++ b/docs/guides/ci-environments.md
@@ -1,0 +1,133 @@
+---
+page_title: Running in CI and automation environments
+---
+
+# Running in CI and automation environments
+
+This guide collects the recurring answers for running the Namecheap provider
+from CI pipelines, container runners, and other automation where there is no
+interactive operator. It covers IP whitelisting, when to set `client_ip`
+explicitly, tuning the client so parallel jobs do not collide with Namecheap's
+rate limit, and enabling structured debug logs.
+
+For the full list of provider arguments and their defaults, see the
+[provider configuration reference](../index.md#argument-reference).
+
+## Whitelist the runner's egress IP
+
+Every Namecheap API call is authorized against the **public IP address the
+Namecheap API sees as the caller**, and that IP must be whitelisted for your
+account at the
+[API access whitelisted IPs page](https://ap.www.namecheap.com/settings/tools/apiaccess/whitelisted-ips).
+
+In CI this is the runner's **egress** IP (the address traffic leaves from),
+which is not necessarily the runner's own interface address:
+
+- **Self-hosted runners** behind a NAT gateway share the gateway's public IP.
+  Whitelist that gateway IP, and pin egress to it (for example a NAT Gateway or
+  a fixed egress node) so it does not change.
+- **Cloud-hosted / ephemeral runners** (e.g. hosted CI, autoscaling fleets)
+  often draw from large, changing IP pools. Route their outbound traffic
+  through a fixed egress (NAT gateway, proxy, or a small static-IP bastion) and
+  whitelist that single address, rather than trying to whitelist an entire pool.
+
+~> **Important:** If the calling IP is not whitelisted, the Namecheap API rejects
+requests regardless of whether the credentials are correct. When a pipeline that
+worked yesterday starts failing on auth, an IP change is the most common cause.
+
+## Setting `client_ip` explicitly vs. auto-detection
+
+When `client_ip` (or `NAMECHEAP_CLIENT_IP`) is left unset, the provider
+auto-detects the caller's public IP via an outbound HTTPS request to
+`api.ipify.org` with a 5 second timeout. If that request fails, provider
+configuration fails with an error telling you to set `client_ip` explicitly.
+
+**Rely on auto-detection when** the runner has straightforward outbound HTTPS
+access and its egress IP is already whitelisted. This keeps the configuration
+free of a hard-coded address.
+
+**Set `client_ip` explicitly when** any of the following apply:
+
+- The runner has **no outbound access to `api.ipify.org`** (locked-down egress,
+  no general internet, or `api.ipify.org` is blocked). Auto-detection cannot
+  succeed and configuration will fail.
+- Traffic to Namecheap leaves through a **different address** than a generic
+  detection request would report (for example split egress, or Namecheap
+  traffic is forced through a specific proxy/NAT). Auto-detection could return
+  an IP that is not the one Namecheap sees, and calls would fail whitelisting.
+- You want deterministic, auditable configuration that does not depend on a
+  third-party detection endpoint being reachable.
+
+```terraform
+provider "namecheap" {
+  # Pin the whitelisted egress IP so configuration never depends on api.ipify.org.
+  client_ip = "203.0.113.10"
+}
+```
+
+-> You can supply the value without touching HCL by exporting
+`NAMECHEAP_CLIENT_IP` in the job environment. An explicitly set value is always
+honored unchanged; the provider never overrides it with a detected address.
+
+## Avoiding rate-limit collisions
+
+Namecheap enforces a documented primary quota (per-minute request limit) at the
+account level. When several CI jobs — or several `terraform apply` runs — hit
+the API for the **same account** concurrently, their requests are counted
+together and can trip the limit. Four provider arguments control how the client
+paces and recovers from this:
+
+- `requests_per_minute` (default `20`, valid range `1`–`20`) — the client-side
+  rate limit, in requests per minute. If you run **N** jobs against one account
+  in parallel, lower this so the combined rate stays within quota (roughly
+  `20 / N` per job).
+- `max_retries` (default `4`, must be `>= 0`) — total attempts, including the
+  first, before giving up. Note that `0` falls back to the SDK default of `4`
+  rather than disabling retries.
+- `retry_max_elapsed` (default `"2m"`) — the maximum total wall-clock time spent
+  retrying a single call, as a [Go duration string](https://pkg.go.dev/time#ParseDuration).
+  Keep this comfortably under your CI step timeout so a retry storm does not
+  cause the job to be killed mid-call.
+- `request_timeout` (default `"30s"`) — the per-request HTTP timeout, as a Go
+  duration string.
+
+```terraform
+# Example: four parallel pipelines sharing one Namecheap account.
+provider "namecheap" {
+  requests_per_minute = 5     # 20 / 4 jobs
+  max_retries         = 6     # ride out brief bursts from sibling jobs
+  retry_max_elapsed   = "3m"  # keep below the CI step timeout
+  request_timeout     = "30s"
+}
+```
+
+~> Prefer **serializing** Terraform runs for the same account where you can
+(for example a job concurrency group), and use `requests_per_minute` as a
+safety net rather than the only defense.
+
+Each argument also has a `NAMECHEAP_*` environment variable
+(`NAMECHEAP_REQUESTS_PER_MINUTE`, `NAMECHEAP_MAX_RETRIES`,
+`NAMECHEAP_RETRY_MAX_ELAPSED`, `NAMECHEAP_REQUEST_TIMEOUT`), which is often more
+convenient to set per pipeline.
+
+## Debug logging
+
+Set the `TF_LOG_PROVIDER_NAMECHEAP` environment variable to `DEBUG` to emit
+structured, per-API-call log entries. Each entry includes the API command, the
+attempt number, the call duration, the HTTP status, and the Namecheap error
+code:
+
+```sh
+export TF_LOG_PROVIDER_NAMECHEAP=DEBUG
+terraform apply
+```
+
+This is the fastest way to diagnose the failures most common in automation —
+missing/incorrect credentials, an un-whitelisted `client_ip`, and rate-limit
+throttling (visible as retries and error codes). The provider forwards only the
+SDK's structured events; secret parameters are redacted by the SDK before
+logging, so no credentials are added to the output.
+
+-> `TF_LOG_PROVIDER_NAMECHEAP` scopes verbose logging to just this provider. Use
+the broader `TF_LOG=DEBUG` only when you also need core Terraform and other
+providers' logs, since it is far noisier.

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,7 @@ access for your account and whitelisted your static IP address where the terrafo
 
 - [Namecheap API documentation](https://www.namecheap.com/support/api/intro/)
 - [Namecheap domain records guide](guides/namecheap_domain_records_guide.md)
+- [Running in CI and automation environments guide](guides/ci-environments.md)
 
 ## Example Usage
 
@@ -34,6 +35,12 @@ provider "namecheap" {
   api_key = "key"
   client_ip = "123.123.123.123"
   use_sandbox = false
+
+  # Optional client resilience tuning (defaults shown):
+  # requests_per_minute = 20
+  # max_retries         = 4
+  # retry_max_elapsed   = "2m"
+  # request_timeout     = "30s"
 }
 
 resource "namecheap_domain_records" "domain-com" {
@@ -43,14 +50,29 @@ resource "namecheap_domain_records" "domain-com" {
 
 ## Argument Reference
 
-- `user_name` (`NAMECHEAP_USER_NAME`) - (Optional, Sensitive) A registered user name for Namecheap. Can be set via the environment variable.
-- `api_user` (`NAMECHEAP_API_USER`) - (Optional, Sensitive) A registered api user for Namecheap. Can be set via the environment variable.
-- `api_key` (`NAMECHEAP_API_KEY`) - (Optional, Sensitive) The Namecheap API key. Can be set via the environment variable.
-- `client_ip` (`NAMECHEAP_CLIENT_IP`) - (Optional) Client IP address
-- `use_sandbox` (`NAMECHEAP_USE_SANDBOX`) - (Optional) Use sandbox API endpoints. If `true`, all API requests will be
-  made through `sandbox.namecheap.com` endpoint. You can [sign up](https://www.sandbox.namecheap.com/myaccount/signup/)
-  a free sandbox account
+Every argument can be provided inline in the `provider` block or via its
+`NAMECHEAP_*` environment variable. When both are set, the inline value takes
+precedence.
+
+### Credentials
+
+- `user_name` (`NAMECHEAP_USER_NAME`) - (Required, Sensitive) A registered user name for Namecheap. Must be supplied inline or via the environment variable.
+- `api_user` (`NAMECHEAP_API_USER`) - (Required, Sensitive) A registered API user for Namecheap. Must be supplied inline or via the environment variable.
+- `api_key` (`NAMECHEAP_API_KEY`) - (Required, Sensitive) The Namecheap API key. Must be supplied inline or via the environment variable.
+- `client_ip` (`NAMECHEAP_CLIENT_IP`) - (Optional, String) The public IP address the Namecheap API sees as the caller. It must be whitelisted at the [API access whitelisted IPs page](https://ap.www.namecheap.com/settings/tools/apiaccess/whitelisted-ips). When left unset, the provider auto-detects this machine's public IP via an outbound HTTPS request to `api.ipify.org` (5 second timeout). If detection fails (for example on a host with no outbound network access), provider configuration fails with guidance to set `client_ip` explicitly. An explicitly set value is always honored unchanged. See the [CI and automation environments guide](guides/ci-environments.md) for guidance on when to set this explicitly.
+- `use_sandbox` (`NAMECHEAP_USE_SANDBOX`) - (Optional, Bool) Use sandbox API endpoints. Defaults to `false`. If `true`, all API requests are
+  made through the `sandbox.namecheap.com` endpoint. You can [sign up](https://www.sandbox.namecheap.com/myaccount/signup/)
+  for a free sandbox account.
+
+### Client behavior and resilience
+
+- `requests_per_minute` (`NAMECHEAP_REQUESTS_PER_MINUTE`) - (Optional, Int) Client-side rate limit applied to the Namecheap API, in requests per minute. Must be between `1` and `20` (Namecheap's documented primary quota). Defaults to `20`.
+- `max_retries` (`NAMECHEAP_MAX_RETRIES`) - (Optional, Int) Total number of attempts (including the first) for a single API call before giving up. Must be `>= 0`. Defaults to `4`. Note: the underlying SDK treats a zero value as "unset", so setting this to `0` falls back to the SDK default of `4` attempts rather than disabling retries.
+- `retry_max_elapsed` (`NAMECHEAP_RETRY_MAX_ELAPSED`) - (Optional, String) Maximum total wall-clock time to spend retrying a single API call, as a [Go duration string](https://pkg.go.dev/time#ParseDuration) (e.g. `"2m"`, `"90s"`). Must parse and be greater than zero. Defaults to `"2m"`.
+- `request_timeout` (`NAMECHEAP_REQUEST_TIMEOUT`) - (Optional, String) Timeout applied to the underlying HTTP client for a single request to the Namecheap API, as a [Go duration string](https://pkg.go.dev/time#ParseDuration) (e.g. `"30s"`, `"1m"`). Must parse and be greater than zero. Defaults to `"30s"`.
 
 -> You can set up arguments via environment variables `NAMECHEAP_*`
+
+-> **Debug logging:** set `TF_LOG_PROVIDER_NAMECHEAP=DEBUG` to emit structured, per-API-call log entries (command, attempt, duration, status, and error code). This is the recommended way to diagnose credential, whitelisting, and rate-limit issues. See the [CI and automation environments guide](guides/ci-environments.md#debug-logging).
 
 ~> **Important:** The `namecheap_domain_records` resource supports two modes: `MERGE` (default) and `OVERWRITE`. Be careful with `OVERWRITE` mode — it replaces the entire DNS zone and **permanently deletes** all records not in the Terraform configuration. See the [domain records guide](guides/namecheap_domain_records_guide.md#overwrite) for details.


### PR DESCRIPTION
## Summary

Documentation-only change for the provider configuration work under #247.

### docs/index.md — Argument Reference
- Documents every provider argument alongside its `NAMECHEAP_*` environment variable, with the inline-vs-env precedence rule.
- Credentials (`user_name`, `api_user`, `api_key`): labeled runtime-required, sensitive, settable inline or via env var.
- `client_ip`: documents the new auto-detect-when-unset behavior (outbound HTTPS to api.ipify.org, 5s timeout; config fails with guidance if detection fails) and that an explicit value is always honored unchanged.
- Client resilience tuning: `requests_per_minute` (1–20, default 20), `max_retries` (>=0, default 4; 0 falls back to SDK default of 4), `retry_max_elapsed` (Go duration, default "2m"), `request_timeout` (Go duration, default "30s").
- Adds a note that `TF_LOG_PROVIDER_NAMECHEAP=DEBUG` emits structured per-API-call tflog entries.

### docs/guides/ci-environments.md (new Registry guide)
- Whitelisting the runner's egress IP (self-hosted NAT vs ephemeral cloud runners).
- When to rely on `client_ip` auto-detection vs. setting it explicitly.
- Avoiding rate-limit collisions across parallel jobs sharing one account.
- Enabling structured debug logging.

### README.md
- Cross-links the new CI guide and notes `client_ip` auto-detection.

No code changes; acceptance tests not modified.

Part of #247