### PR TITLE
test: add build-tag-gated NAMECHEAP_API_URL endpoint override

### DIFF
--- a/namecheap/endpoint_override.go
+++ b/namecheap/endpoint_override.go
@@ -1,0 +1,16 @@
+//go:build !testacc
+
+package namecheap_provider
+
+import "github.com/namecheap/go-namecheap-sdk/v2/namecheap"
+
+// applyTestEndpointOverride is a no-op in normal (released) builds.
+//
+// The acceptance-test endpoint override — which reads NAMECHEAP_API_URL to
+// point the SDK client at a local mock server — is compiled only under the
+// `testacc` build tag (see endpoint_override_testacc.go). Keeping the real
+// implementation behind that tag guarantees the released provider binary
+// contains no code path that could redirect API traffic (and the credentials
+// it carries) to an arbitrary host, even if NAMECHEAP_API_URL is set in the
+// environment.
+func applyTestEndpointOverride(_ *namecheap.Client) {}

--- a/namecheap/endpoint_override_test.go
+++ b/namecheap/endpoint_override_test.go
@@ -1,0 +1,49 @@
+//go:build !testacc
+
+package namecheap_provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/namecheap/go-namecheap-sdk/v2/namecheap"
+	"github.com/stretchr/testify/assert"
+)
+
+// In a normal (non-testacc) build the endpoint override must be a no-op so the
+// released provider cannot be redirected to an arbitrary API host, even when
+// NAMECHEAP_API_URL is set in the environment. This drives the real
+// configureContext path (via Configure) and inspects the constructed client.
+func TestProviderConfigureIgnoresEndpointOverrideInReleaseBuild(t *testing.T) {
+	// A loopback URL is deliberately used: it is exactly what the testacc build
+	// WOULD honor, so observing that it is ignored proves the override code is
+	// absent from this build rather than merely being rejected by validation.
+	t.Setenv("NAMECHEAP_API_URL", "http://127.0.0.1:65535")
+	clearResilienceEnvVars(t)
+	raw := baseProviderConfig(t)
+
+	rawProvider := Provider()
+	diags := rawProvider.Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
+	assert.False(t, diags.HasError(), "unexpected diags: %v", diags)
+
+	client, ok := rawProvider.Meta().(*namecheap.Client)
+	assert.True(t, ok, "expected provider meta to be *namecheap.Client")
+
+	// Assert the exact default endpoint (production, since use_sandbox=false) so
+	// this catches a redirect to ANY other host, not merely a loopback one.
+	wantDefault := namecheap.NewClient(&namecheap.ClientOptions{UseSandbox: false}).BaseURL
+	assert.Equal(t, wantDefault, client.BaseURL,
+		"release build must leave BaseURL at the default endpoint, ignoring NAMECHEAP_API_URL")
+}
+
+// applyTestEndpointOverride must not mutate the client in a release build.
+func TestApplyTestEndpointOverrideNoopInReleaseBuild(t *testing.T) {
+	t.Setenv("NAMECHEAP_API_URL", "http://127.0.0.1:65535")
+	client := namecheap.NewClient(&namecheap.ClientOptions{
+		UserName: "u", ApiUser: "u", ApiKey: "k", ClientIp: "203.0.113.1",
+	})
+	want := client.BaseURL
+	applyTestEndpointOverride(client)
+	assert.Equal(t, want, client.BaseURL, "release build must leave BaseURL unchanged")
+}

--- a/namecheap/endpoint_override_testacc.go
+++ b/namecheap/endpoint_override_testacc.go
@@ -1,0 +1,60 @@
+//go:build testacc
+
+package namecheap_provider
+
+import (
+	"log"
+	"net"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/namecheap/go-namecheap-sdk/v2/namecheap"
+)
+
+// testEndpointOverrideEnv names the environment variable that, in `testacc`
+// builds only, redirects the Namecheap SDK client at an alternate base URL.
+// It exists solely so acceptance tests can point the provider at a local
+// httptest mock server; it is never compiled into a released provider binary.
+const testEndpointOverrideEnv = "NAMECHEAP_API_URL"
+
+// applyTestEndpointOverride overrides the SDK client's BaseURL from
+// NAMECHEAP_API_URL when that variable names a loopback http(s) URL.
+//
+// Only loopback hosts are honored: even in a test binary this prevents the
+// override from being abused to divert real API traffic (and the credentials
+// it carries) to an external host. A non-loopback or malformed value is
+// ignored with a warning rather than silently trusted.
+func applyTestEndpointOverride(client *namecheap.Client) {
+	raw := strings.TrimSpace(os.Getenv(testEndpointOverrideEnv))
+	if raw == "" {
+		return
+	}
+	if !isLoopbackHTTPURL(raw) {
+		log.Printf("[WARN] namecheap: ignoring %s=%q; only http(s) loopback URLs are honored", testEndpointOverrideEnv, raw)
+		return
+	}
+	client.BaseURL = raw
+}
+
+// isLoopbackHTTPURL reports whether raw is an http or https URL whose host is a
+// loopback address (127.0.0.0/8, ::1) or the literal "localhost".
+//
+// The "localhost" match is exact and case-sensitive with no trailing dot, so
+// harness authors should use a lowercase "localhost" or a 127.x.x.x / [::1]
+// literal; any other spelling falls through to the default endpoint.
+func isLoopbackHTTPURL(raw string) bool {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return false
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return false
+	}
+	host := u.Hostname()
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}

--- a/namecheap/endpoint_override_testacc_test.go
+++ b/namecheap/endpoint_override_testacc_test.go
@@ -1,0 +1,108 @@
+//go:build testacc
+
+package namecheap_provider
+
+import (
+	"testing"
+
+	"github.com/namecheap/go-namecheap-sdk/v2/namecheap"
+	"github.com/stretchr/testify/assert"
+)
+
+// newClientForOverrideTest returns a client whose BaseURL is the SDK default so
+// tests can assert whether applyTestEndpointOverride changed it.
+func newClientForOverrideTest() *namecheap.Client {
+	return namecheap.NewClient(&namecheap.ClientOptions{
+		UserName: "u", ApiUser: "u", ApiKey: "k", ClientIp: "203.0.113.1",
+	})
+}
+
+// With NAMECHEAP_API_URL unset — or whitespace-only, which TrimSpace reduces to
+// empty — the override must leave BaseURL at the endpoint selected by
+// use_sandbox.
+func TestApplyTestEndpointOverrideUnset(t *testing.T) {
+	for _, v := range []string{"", "   ", "\t\n"} {
+		t.Run(v, func(t *testing.T) {
+			t.Setenv(testEndpointOverrideEnv, v)
+			client := newClientForOverrideTest()
+			want := client.BaseURL
+			applyTestEndpointOverride(client)
+			assert.Equal(t, want, client.BaseURL, "empty/whitespace override must not change BaseURL")
+		})
+	}
+}
+
+// A loopback http(s) URL must be honored so the acceptance harness can point
+// the provider at a local mock server.
+func TestApplyTestEndpointOverrideLoopbackHonored(t *testing.T) {
+	for _, u := range []string{
+		"http://127.0.0.1:8080",
+		"http://127.0.0.1:8080/xml.response",
+		"http://localhost:9000",
+		"https://127.0.0.1:7000",
+		"https://[::1]:7000",
+	} {
+		t.Run(u, func(t *testing.T) {
+			t.Setenv(testEndpointOverrideEnv, u)
+			client := newClientForOverrideTest()
+			applyTestEndpointOverride(client)
+			assert.Equal(t, u, client.BaseURL, "loopback override must be applied")
+		})
+	}
+}
+
+// Whitespace around a loopback URL must be trimmed and the URL still honored.
+func TestApplyTestEndpointOverrideTrimsWhitespace(t *testing.T) {
+	t.Setenv(testEndpointOverrideEnv, "  http://127.0.0.1:8080  ")
+	client := newClientForOverrideTest()
+	applyTestEndpointOverride(client)
+	assert.Equal(t, "http://127.0.0.1:8080", client.BaseURL)
+}
+
+// A non-loopback host, wrong scheme, or malformed value must be ignored so the
+// override cannot divert real API traffic to an external host.
+func TestApplyTestEndpointOverrideNonLoopbackIgnored(t *testing.T) {
+	for _, u := range []string{
+		"http://example.com",
+		"https://api.namecheap.com/xml.response",
+		"http://8.8.8.8",
+		"ftp://127.0.0.1",
+		"127.0.0.1:8080", // no scheme
+		"not-a-url",
+		"://bad",
+	} {
+		t.Run(u, func(t *testing.T) {
+			t.Setenv(testEndpointOverrideEnv, u)
+			client := newClientForOverrideTest()
+			want := client.BaseURL
+			applyTestEndpointOverride(client)
+			assert.Equal(t, want, client.BaseURL, "non-loopback override must be ignored")
+		})
+	}
+}
+
+// isLoopbackHTTPURL classification, exercised directly for full branch coverage.
+func TestIsLoopbackHTTPURL(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"http://127.0.0.1", true},
+		{"http://127.0.0.1:8080/path", true},
+		{"https://127.0.0.53", true},
+		{"http://localhost:9000", true},
+		{"https://[::1]:7000", true},
+		{"http://example.com", false},
+		{"https://8.8.8.8", false},
+		{"ftp://127.0.0.1", false},
+		{"127.0.0.1:8080", false},
+		{"not-a-url", false},
+		{"://bad", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			assert.Equal(t, c.want, isLoopbackHTTPURL(c.in))
+		})
+	}
+}

--- a/namecheap/provider.go
+++ b/namecheap/provider.go
@@ -223,6 +223,14 @@ func configureContext(ctx context.Context, data *schema.ResourceData) (interface
 		Logger: slog.New(newBridgeHandler()),
 	})
 
+	// Test-only endpoint override. In normal (released) builds this is a no-op
+	// (see endpoint_override.go), so the shipped provider contains no code path
+	// that can redirect API traffic away from the sandbox/production endpoint
+	// selected above. Only under the `testacc` build tag is it compiled to read
+	// NAMECHEAP_API_URL and point the client at a local mock server
+	// (see endpoint_override_testacc.go), which the acceptance-test harness uses.
+	applyTestEndpointOverride(client)
+
 	return client, diag.Diagnostics{}
 }
 


### PR DESCRIPTION
## Summary

First slice of #246 (acceptance-test infrastructure). Adds the injection seam every mock-backed acceptance test needs: a way to point the provider's internally-constructed Namecheap SDK client at a local mock HTTP server.

`resource.Test` builds the client via `configureContext` and never hands it back to the test, and the SDK's `ClientOptions` has no endpoint field — so today no acceptance test can run against a mock. This PR adds `applyTestEndpointOverride`, which overrides the already-public `client.BaseURL` from a `NAMECHEAP_API_URL` env var.

## Security design (build-tag gated + loopback-only)

The override is the **only** security-sensitive change in the #246 epic, so it ships alone for isolated review, hardened two ways:

1. **Build-tag gated.** The real override compiles **only** under `//go:build testacc` (`endpoint_override_testacc.go`). In normal builds the symbol resolves to a no-op (`endpoint_override.go`, `//go:build !testacc`). GoReleaser builds untagged (`flags: [-trimpath]`), so **released binaries contain no code path that reads `NAMECHEAP_API_URL`** and cannot be redirected.
2. **Loopback-only, even in test builds.** `isLoopbackHTTPURL` honors only http/https URLs to `127.0.0.0/8`, `::1`, or literal `localhost`. External hosts, wrong schemes, malformed values, userinfo tricks (`http://127.0.0.1@evil.com`), decimal/octal/hex IP forms, and DNS-rebind shapes are all ignored with a warning — so the override cannot divert real API traffic (and credentials) to an external host.

## Changes

- `provider.go` — one `applyTestEndpointOverride(client)` call after `NewClient`.
- `endpoint_override.go` (`!testacc`) — no-op stub shipped in releases.
- `endpoint_override_testacc.go` (`testacc`) — override + loopback classifier.
- `endpoint_override_test.go` (`!testacc`) — asserts the release build ignores the env var (proves the code path is *absent*, not merely rejected), via the real `Configure` path and directly.
- `endpoint_override_testacc_test.go` (`testacc`) — loopback honored / non-loopback ignored / whitespace trim-to-empty / classifier branch table.

## Testing

- [x] `make test` passes (release build; new no-op path covered)
- [x] `go test -tags testacc` passes; `applyTestEndpointOverride` and `isLoopbackHTTPURL` at **100%** statement coverage
- [x] `go vet` and `golangci-lint run` (v2.12.2) clean in **both** build variants
- [x] `go build` clean in both variants; GoReleaser config confirmed untagged

## Notes

- Titled `test:` — this is test-only scaffolding with **zero user-facing behavior change**, so it intentionally does not trigger a release-please version bump. TF plan/state are unchanged.
- No `go.mod`, CI, or provider-schema changes. `ci.yml` is untouched until a later slice (fork-safe mock job).
- An independent adversarial review attempted the SSRF/exfil bypasses listed above and could not refute the release-binary or loopback-only guarantees.

Refs #246