### PR TITLE
test: add stateful Namecheap API mock and mock acceptance harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,13 @@ test:
 testacc:
 	TF_ACC=1 go test ./namecheap -v -run=TestAcc -count=1 -timeout=30m -failfast
 
+# Mock-backed acceptance tests: run the acceptance suite against an in-process
+# stateful mock of the Namecheap API (no credentials, no network). Requires the
+# `testacc` build tag so the NAMECHEAP_API_URL endpoint override is compiled in,
+# and a terraform binary (uses the one on PATH; falls back to auto-download).
+testacc-mock:
+	TF_ACC=1 TF_ACC_TERRAFORM_PATH=$$(command -v terraform) go test -tags testacc ./namecheap -v -run='^TestAccMock' -count=1 -timeout=10m
+
 build:
 	go build -o ${BINARY}
 
@@ -52,4 +59,4 @@ lint:
 docs:
 	tfplugindocs
 
-.PHONY: format check test testacc build release install_darwin_amd64 install_linux_amd64 lint docs
+.PHONY: format check test testacc testacc-mock build release install_darwin_amd64 install_linux_amd64 lint docs

--- a/namecheap/mock_acceptance_test.go
+++ b/namecheap/mock_acceptance_test.go
@@ -1,0 +1,125 @@
+//go:build testacc
+
+package namecheap_provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+// mockProviderFactories returns ProviderFactories that build the real
+// Provider(). Combined with mockPreCheck (which points NAMECHEAP_API_URL at the
+// mock server), resource.Test exercises the real configureContext path but with
+// the SDK client redirected to the in-process mock rather than the live API.
+func mockProviderFactories() map[string]func() (*schema.Provider, error) {
+	return map[string]func() (*schema.Provider, error){
+		"namecheap": func() (*schema.Provider, error) { return Provider(), nil },
+	}
+}
+
+// mockPreCheck wires the provider to a mock server: it points the testacc-build
+// endpoint override at the mock URL and supplies dummy credentials plus an
+// explicit client_ip so configureContext neither fails its required-field check
+// nor attempts to auto-detect a public IP over the network.
+func mockPreCheck(t *testing.T, m *namecheapMock) {
+	t.Helper()
+	t.Setenv("NAMECHEAP_API_URL", m.url())
+	t.Setenv("NAMECHEAP_USER_NAME", "mock-user")
+	t.Setenv("NAMECHEAP_API_USER", "mock-user")
+	t.Setenv("NAMECHEAP_API_KEY", "mock-key")
+	t.Setenv("NAMECHEAP_CLIENT_IP", "127.0.0.1")
+}
+
+// mockCheckHostCount asserts the mock persisted exactly n host records for the
+// domain — proving reads reflect prior writes end-to-end through the provider.
+func mockCheckHostCount(m *namecheapMock, domain string, n int) resource.TestCheckFunc {
+	return func(*terraform.State) error {
+		st := m.state(domain)
+		if st == nil {
+			return fmt.Errorf("mock has no state for %q", domain)
+		}
+		if len(st.hosts) != n {
+			return fmt.Errorf("mock host count for %q = %d, want %d", domain, len(st.hosts), n)
+		}
+		return nil
+	}
+}
+
+// mockCheckHostsCleared is a CheckDestroy that asserts the domain's records were
+// removed from the backend when the resource was destroyed.
+func mockCheckHostsCleared(m *namecheapMock, domain string) resource.TestCheckFunc {
+	return func(*terraform.State) error {
+		st := m.state(domain)
+		if st != nil && len(st.hosts) != 0 {
+			return fmt.Errorf("expected records for %q to be cleared on destroy, mock still has %d", domain, len(st.hosts))
+		}
+		return nil
+	}
+}
+
+// TestAccMockDomainRecordsLifecycle drives a full create -> update -> destroy
+// lifecycle for namecheap_domain_records against the stateful mock, asserting
+// both Terraform state and the mock backend at each step. It proves the mock
+// harness end-to-end; the broader scenario matrix is added in a follow-up.
+func TestAccMockDomainRecordsLifecycle(t *testing.T) {
+	m := newNamecheapMock(t)
+	const domain = "mock-example.com"
+	const resourceName = "namecheap_domain_records.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { mockPreCheck(t, m) },
+		ProviderFactories: mockProviderFactories(),
+		CheckDestroy:      mockCheckHostsCleared(m, domain),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "namecheap_domain_records" "test" {
+  domain = "%s"
+  mode   = "OVERWRITE"
+
+  record {
+    hostname = "www"
+    type     = "A"
+    address  = "10.0.0.1"
+    ttl      = 3600
+  }
+}
+`, domain),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "record.#", "1"),
+					mockCheckHostCount(m, domain, 1),
+				),
+			},
+			{
+				Config: fmt.Sprintf(`
+resource "namecheap_domain_records" "test" {
+  domain = "%s"
+  mode   = "OVERWRITE"
+
+  record {
+    hostname = "www"
+    type     = "A"
+    address  = "10.0.0.1"
+    ttl      = 3600
+  }
+
+  record {
+    hostname = "mail"
+    type     = "A"
+    address  = "10.0.0.2"
+    ttl      = 3600
+  }
+}
+`, domain),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "record.#", "2"),
+					mockCheckHostCount(m, domain, 2),
+				),
+			},
+		},
+	})
+}

--- a/namecheap/mock_server_test.go
+++ b/namecheap/mock_server_test.go
@@ -1,0 +1,213 @@
+//go:build testacc
+
+package namecheap_provider
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// mockDefaultNameservers are the registrar nameservers the Namecheap API reports
+// (with IsUsingOurDNS="true") for a domain that has not been switched to custom
+// nameservers. They mirror the real API's default response.
+var mockDefaultNameservers = []string{"dns1.registrar-servers.com", "dns2.registrar-servers.com"}
+
+// mockDomainState is the persisted per-domain state of the mock API: the DNS
+// host records, the email type, and any custom nameservers. An empty
+// nameservers slice means the domain is using Namecheap's DNS.
+type mockDomainState struct {
+	hosts       []hostEntry
+	emailType   string
+	nameservers []string
+}
+
+// namecheapMock is a minimal STATEFUL mock of the Namecheap DNS API, sufficient
+// to drive a resource.Test lifecycle (create -> refresh -> update -> destroy)
+// for namecheap_domain_records without touching the real API.
+//
+// Unlike the stateless per-command fixtures the CRUD unit tests use, this mock
+// persists per-domain state across requests so that GetHosts/GetList reflect
+// prior SetHosts/SetCustom/SetDefault calls — which is what a full Terraform
+// lifecycle requires. It is a complement to, not a replacement for, the live
+// sandbox suite: the live suite remains the source of truth for API-contract
+// behavior.
+type namecheapMock struct {
+	server  *httptest.Server
+	mu      sync.Mutex
+	domains map[string]*mockDomainState
+}
+
+// newNamecheapMock starts a stateful mock server and registers its shutdown
+// with t.Cleanup. The returned mock's server URL is what NAMECHEAP_API_URL must
+// point at (via the testacc-build endpoint override) for the provider to talk
+// to it.
+func newNamecheapMock(t *testing.T) *namecheapMock {
+	t.Helper()
+	m := &namecheapMock{domains: map[string]*mockDomainState{}}
+	m.server = httptest.NewServer(http.HandlerFunc(m.handler))
+	t.Cleanup(m.server.Close)
+	return m
+}
+
+// url returns the base URL of the running mock server.
+func (m *namecheapMock) url() string { return m.server.URL }
+
+// state returns the current mock state for a domain, or nil if the domain has
+// never been touched. Callers must not mutate the returned pointer.
+func (m *namecheapMock) state(domain string) *mockDomainState {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.domains[domain]
+}
+
+// stateFor returns the state for a domain, creating it on first use.
+func (m *namecheapMock) stateFor(domain string) *mockDomainState {
+	st := m.domains[domain]
+	if st == nil {
+		st = &mockDomainState{emailType: "NONE"}
+		m.domains[domain] = st
+	}
+	return st
+}
+
+func (m *namecheapMock) handler(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	command := r.FormValue("Command")
+	domain := r.FormValue("SLD") + "." + r.FormValue("TLD")
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	st := m.stateFor(domain)
+
+	w.Header().Set("Content-Type", "text/xml")
+	var resp string
+	switch command {
+	case "namecheap.domains.dns.getHosts":
+		resp = renderGetHostsXML(domain, st)
+	case "namecheap.domains.dns.setHosts":
+		st.hosts = parseSetHostsRequest(r)
+		if et := r.FormValue("EmailType"); et != "" {
+			st.emailType = et
+		}
+		resp = renderResultXML("DomainDNSSetHostsResult", domain, `IsSuccess="true"`)
+	case "namecheap.domains.dns.getList":
+		resp = renderGetListXML(domain, st)
+	case "namecheap.domains.dns.setCustom":
+		st.nameservers = splitNameservers(r.FormValue("Nameservers"))
+		resp = renderResultXML("DomainDNSSetCustomResult", domain, `Updated="true"`)
+	case "namecheap.domains.dns.setDefault":
+		st.nameservers = nil
+		resp = renderResultXML("DomainDNSSetDefaultResult", domain, `Updated="true"`)
+	default:
+		resp = apiErrorXML("1010101", "mock: unsupported command "+command)
+	}
+	// Write failures reach only the in-process test client and are not
+	// actionable in a mock, so the error is intentionally discarded.
+	_, _ = io.WriteString(w, resp)
+}
+
+// parseSetHostsRequest extracts the 1-indexed HostNameN/RecordTypeN/AddressN/
+// MXPrefN/TTLN parameters the SDK sends for SetHosts into hostEntry values.
+func parseSetHostsRequest(r *http.Request) []hostEntry {
+	var hosts []hostEntry
+	for i := 1; ; i++ {
+		idx := strconv.Itoa(i)
+		name := r.FormValue("HostName" + idx)
+		recordType := r.FormValue("RecordType" + idx)
+		if name == "" && recordType == "" {
+			break
+		}
+		mxPref, _ := strconv.Atoi(r.FormValue("MXPref" + idx))
+		ttl, _ := strconv.Atoi(r.FormValue("TTL" + idx))
+		hosts = append(hosts, hostEntry{
+			Name:    name,
+			Type:    recordType,
+			Address: r.FormValue("Address" + idx),
+			MXPref:  mxPref,
+			TTL:     ttl,
+		})
+	}
+	return hosts
+}
+
+// splitNameservers parses the comma-separated Nameservers parameter, trimming
+// whitespace and dropping empty entries.
+func splitNameservers(raw string) []string {
+	var out []string
+	for _, ns := range strings.Split(raw, ",") {
+		if ns = strings.TrimSpace(ns); ns != "" {
+			out = append(out, ns)
+		}
+	}
+	return out
+}
+
+func renderGetHostsXML(domain string, st *mockDomainState) string {
+	var lines []string
+	for i, h := range st.hosts {
+		lines = append(lines, fmt.Sprintf(
+			`<host HostId="%d" Name="%s" Type="%s" Address="%s" MXPref="%d" TTL="%d" AssociatedAppTitle="" FriendlyName="" IsActive="true" IsDDNSEnabled="false" />`,
+			i+1, h.Name, h.Type, h.Address, h.MXPref, h.TTL))
+	}
+	emailType := st.emailType
+	if emailType == "" {
+		emailType = "NONE"
+	}
+	return fmt.Sprintf(`<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+  <Errors />
+  <CommandResponse>
+    <DomainDNSGetHostsResult Domain="%s" EmailType="%s" IsUsingOurDNS="true">
+      %s
+    </DomainDNSGetHostsResult>
+  </CommandResponse>
+</ApiResponse>`, domain, emailType, strings.Join(lines, "\n      "))
+}
+
+func renderGetListXML(domain string, st *mockDomainState) string {
+	usingOurDNS := len(st.nameservers) == 0
+	nameservers := st.nameservers
+	if usingOurDNS {
+		nameservers = mockDefaultNameservers
+	}
+	var lines []string
+	for _, ns := range nameservers {
+		lines = append(lines, fmt.Sprintf(`<Nameserver>%s</Nameserver>`, ns))
+	}
+	usingStr := "false"
+	if usingOurDNS {
+		usingStr = "true"
+	}
+	return fmt.Sprintf(`<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+  <Errors />
+  <CommandResponse>
+    <DomainDNSGetListResult Domain="%s" IsUsingOurDNS="%s" IsPremiumDNS="false" IsUsingFreeDNS="false">
+      %s
+    </DomainDNSGetListResult>
+  </CommandResponse>
+</ApiResponse>`, domain, usingStr, strings.Join(lines, "\n      "))
+}
+
+// renderResultXML renders a generic success CommandResponse for write commands
+// (SetHosts/SetCustom/SetDefault), which return a single self-closing result
+// element carrying the domain and a status attribute.
+func renderResultXML(element, domain, statusAttr string) string {
+	return fmt.Sprintf(`<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+  <Errors />
+  <CommandResponse>
+    <%s Domain="%s" %s />
+  </CommandResponse>
+</ApiResponse>`, element, domain, statusAttr)
+}


### PR DESCRIPTION
## Summary

Third slice of #246. Adds the first **mock-backed acceptance test** for `namecheap_domain_records`, built on the `NAMECHEAP_API_URL` endpoint override (#272) and the `terraform-plugin-testing` migration (#273). All new code is compiled **only** under the `testacc` build tag, so `make test` (the CI `check` job) and released binaries are unchanged.

## Changes

- **`mock_server_test.go`** — a stateful, **stdlib-only** `httptest` mock of the Namecheap DNS API. It persists per-domain hosts, email type, and nameservers across requests so `GetHosts`/`GetList` reflect prior `SetHosts`/`SetCustom`/`SetDefault` — which a full Terraform lifecycle requires (the existing CRUD-unit fixtures are stateless per-command responders). Reuses the existing `hostEntry` type and `apiErrorXML` helper; responses echo the requested domain. Dispatches on `Command`, parses the 1-indexed `HostNameN`/`RecordTypeN`/… params and comma-separated `Nameservers`.
- **`mock_acceptance_test.go`** — mock `ProviderFactories` + a `PreCheck` that points `NAMECHEAP_API_URL` at the mock and supplies dummy credentials plus an explicit `client_ip` (so `configureContext` neither fails its required-field check nor auto-detects a public IP over the network). `TestAccMockDomainRecordsLifecycle` drives **create → update → destroy** for an `OVERWRITE` resource, asserting both Terraform state (`record.#`) and the mock backend (host count) at each step, with a `CheckDestroy` that verifies records are cleared.
- **`Makefile`** — `make testacc-mock` runs the mock suite (`TF_ACC=1`, `testacc` tag, terraform from PATH). No credentials, no network.

## Testing

- [x] `make testacc-mock` passes end-to-end against **real Terraform v1.15.1** (create→update→destroy, ~1.1s); the post-apply plan is empty (clean round-trip, no perpetual diff) and `CheckDestroy` confirms deletion.
- [x] `make test` (release build) unchanged — mock files are `testacc`-tagged and excluded.
- [x] `go vet` + `golangci-lint run` (v2.12.2) clean in **both** build variants.
- Since all new files are `testacc`-tagged `_test.go`, they don't run in the `check` job; they're exercised by the fork-safe CI job added in a later slice.

## Fidelity note

A hand-rolled mock can drift from real API semantics (default parking-record filtering, `MXPref *int` vs `*uint8`, `GetHosts` error shape, trailing-dot address normalization). The **live sandbox suite remains the source of truth** for API-contract behavior; this mock suite is a fast, credential-free *complement*. The broader MERGE/OVERWRITE scenario matrix (email types, parallel applies, conflict detection, nameservers) and the named regression cases (#71/#68/#37/#73) follow in later slices, and will stress these paths.

## Notes

- Titled `test:` — test-only, no production code / schema / CI / `go.mod` change; no release-please bump, no TF plan/state impact.

Refs #246