### PR TITLE
test: port MERGE/OVERWRITE scenario matrix onto the mock

### DIFF
--- a/namecheap/mock_acceptance_test.go
+++ b/namecheap/mock_acceptance_test.go
@@ -61,6 +61,76 @@ func mockCheckHostsCleared(m *namecheapMock, domain string) resource.TestCheckFu
 	}
 }
 
+// mockCheckHostContains asserts the mock persisted a host with the given name,
+// type and address for the domain.
+func mockCheckHostContains(m *namecheapMock, domain, name, recordType, address string) resource.TestCheckFunc {
+	return func(*terraform.State) error {
+		st := m.state(domain)
+		if st == nil {
+			return fmt.Errorf("mock has no state for %q", domain)
+		}
+		for _, h := range st.hosts {
+			if h.Name == name && h.Type == recordType && h.Address == address {
+				return nil
+			}
+		}
+		return fmt.Errorf("mock state for %q missing host %s/%s/%s (have %+v)", domain, name, recordType, address, st.hosts)
+	}
+}
+
+// mockCheckEmailType asserts the mock persisted the given email type for the domain.
+func mockCheckEmailType(m *namecheapMock, domain, want string) resource.TestCheckFunc {
+	return func(*terraform.State) error {
+		st := m.state(domain)
+		if st == nil {
+			return fmt.Errorf("mock has no state for %q", domain)
+		}
+		if st.emailType != want {
+			return fmt.Errorf("mock email type for %q = %q, want %q", domain, st.emailType, want)
+		}
+		return nil
+	}
+}
+
+// mockCheckNameservers asserts the mock persisted exactly the given set of
+// custom nameservers for the domain (order-independent).
+func mockCheckNameservers(m *namecheapMock, domain string, want ...string) resource.TestCheckFunc {
+	return func(*terraform.State) error {
+		st := m.state(domain)
+		if st == nil {
+			return fmt.Errorf("mock has no state for %q", domain)
+		}
+		if len(st.nameservers) != len(want) {
+			return fmt.Errorf("mock nameserver count for %q = %d, want %d (have %v)", domain, len(st.nameservers), len(want), st.nameservers)
+		}
+		for _, w := range want {
+			found := false
+			for _, ns := range st.nameservers {
+				if ns == w {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return fmt.Errorf("mock nameservers for %q missing %q (have %v)", domain, w, st.nameservers)
+			}
+		}
+		return nil
+	}
+}
+
+// mockCheckNameserversDefault is a CheckDestroy that asserts the domain was
+// returned to Namecheap's default nameservers (no custom nameservers) on destroy.
+func mockCheckNameserversDefault(m *namecheapMock, domain string) resource.TestCheckFunc {
+	return func(*terraform.State) error {
+		st := m.state(domain)
+		if st != nil && len(st.nameservers) != 0 {
+			return fmt.Errorf("expected nameservers for %q to be reset to default on destroy, mock still has %v", domain, st.nameservers)
+		}
+		return nil
+	}
+}
+
 // TestAccMockDomainRecordsLifecycle drives a full create -> update -> destroy
 // lifecycle for namecheap_domain_records against the stateful mock, asserting
 // both Terraform state and the mock backend at each step. It proves the mock

--- a/namecheap/mock_scenarios_test.go
+++ b/namecheap/mock_scenarios_test.go
@@ -1,0 +1,342 @@
+//go:build testacc
+
+package namecheap_provider
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// This file ports the representative MERGE/OVERWRITE record and nameserver
+// scenarios from the live acceptance suite (TestAccNamecheapDomainRecords) onto
+// the stateful mock, so they run fast and without credentials on every PR. Each
+// subtest gets its own mock (isolated state). The live sandbox suite remains the
+// source of truth for API-contract fidelity.
+
+const mockScenarioDomain = "mock-example.com"
+
+// TestAccMockRecords covers the DNS-record MERGE/OVERWRITE code paths.
+func TestAccMockRecords(t *testing.T) {
+	const resourceName = "namecheap_domain_records.test"
+
+	// MERGE onto an empty zone, then a MERGE update that replaces the managed
+	// set. Exercises createRecordsMerge / updateRecordsMerge and the domain mutex.
+	t.Run("merge_on_empty", func(t *testing.T) {
+		m := newNamecheapMock(t)
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { mockPreCheck(t, m) },
+			ProviderFactories: mockProviderFactories(),
+			CheckDestroy:      mockCheckHostsCleared(m, mockScenarioDomain),
+			Steps: []resource.TestStep{
+				{
+					Config: fmt.Sprintf(`
+resource "namecheap_domain_records" "test" {
+  domain = "%s"
+  mode   = "MERGE"
+
+  record {
+    hostname = "sub1"
+    type     = "A"
+    address  = "11.11.11.11"
+    ttl      = 300
+  }
+
+  record {
+    hostname = "sub2"
+    type     = "A"
+    address  = "22.22.22.22"
+  }
+}
+`, mockScenarioDomain),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(resourceName, "record.#", "2"),
+						mockCheckHostCount(m, mockScenarioDomain, 2),
+						mockCheckHostContains(m, mockScenarioDomain, "sub1", "A", "11.11.11.11"),
+						mockCheckHostContains(m, mockScenarioDomain, "sub2", "A", "22.22.22.22"),
+					),
+				},
+				{
+					Config: fmt.Sprintf(`
+resource "namecheap_domain_records" "test" {
+  domain = "%s"
+  mode   = "MERGE"
+
+  record {
+    hostname = "sub11"
+    type     = "A"
+    address  = "111.111.111.111"
+    ttl      = 1800
+  }
+}
+`, mockScenarioDomain),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(resourceName, "record.#", "1"),
+						mockCheckHostCount(m, mockScenarioDomain, 1),
+						mockCheckHostContains(m, mockScenarioDomain, "sub11", "A", "111.111.111.111"),
+					),
+				},
+			},
+		})
+	})
+
+	// MERGE must leave pre-existing, unmanaged records intact — on both apply
+	// and destroy.
+	t.Run("merge_preserves_existing", func(t *testing.T) {
+		m := newNamecheapMock(t)
+		m.seed(mockScenarioDomain, []hostEntry{
+			{Name: "sub1", Type: "A", Address: "22.22.22.22", MXPref: 10, TTL: 1800},
+		}, "NONE", nil)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { mockPreCheck(t, m) },
+			ProviderFactories: mockProviderFactories(),
+			CheckDestroy: resource.ComposeTestCheckFunc(
+				mockCheckHostCount(m, mockScenarioDomain, 1),
+				mockCheckHostContains(m, mockScenarioDomain, "sub1", "A", "22.22.22.22"),
+			),
+			Steps: []resource.TestStep{
+				{
+					Config: fmt.Sprintf(`
+resource "namecheap_domain_records" "test" {
+  domain = "%s"
+  mode   = "MERGE"
+
+  record {
+    hostname = "sub2"
+    type     = "A"
+    address  = "33.33.33.33"
+  }
+}
+`, mockScenarioDomain),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(resourceName, "record.#", "1"),
+						mockCheckHostCount(m, mockScenarioDomain, 2),
+						mockCheckHostContains(m, mockScenarioDomain, "sub1", "A", "22.22.22.22"),
+						mockCheckHostContains(m, mockScenarioDomain, "sub2", "A", "33.33.33.33"),
+					),
+				},
+			},
+		})
+	})
+
+	// OVERWRITE replaces the whole zone with the configured records and sets the
+	// email type; pre-existing records are dropped.
+	t.Run("overwrite_replaces_all", func(t *testing.T) {
+		m := newNamecheapMock(t)
+		m.seed(mockScenarioDomain, []hostEntry{
+			{Name: "old1", Type: "A", Address: "1.1.1.1", MXPref: 10, TTL: 1800},
+			{Name: "old2", Type: "A", Address: "2.2.2.2", MXPref: 10, TTL: 1800},
+		}, "NONE", nil)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { mockPreCheck(t, m) },
+			ProviderFactories: mockProviderFactories(),
+			CheckDestroy:      mockCheckHostsCleared(m, mockScenarioDomain),
+			Steps: []resource.TestStep{
+				{
+					Config: fmt.Sprintf(`
+resource "namecheap_domain_records" "test" {
+  domain     = "%s"
+  mode       = "OVERWRITE"
+  email_type = "FWD"
+
+  record {
+    hostname = "www"
+    type     = "A"
+    address  = "5.5.5.5"
+    ttl      = 1800
+  }
+}
+`, mockScenarioDomain),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(resourceName, "record.#", "1"),
+						resource.TestCheckResourceAttr(resourceName, "email_type", "FWD"),
+						mockCheckHostCount(m, mockScenarioDomain, 1),
+						mockCheckHostContains(m, mockScenarioDomain, "www", "A", "5.5.5.5"),
+						mockCheckEmailType(m, mockScenarioDomain, "FWD"),
+					),
+				},
+			},
+		})
+	})
+
+	// Two MERGE resources declaring the same record must be rejected by the
+	// provider's duplicate detection.
+	t.Run("duplicate_conflict", func(t *testing.T) {
+		m := newNamecheapMock(t)
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { mockPreCheck(t, m) },
+			ProviderFactories: mockProviderFactories(),
+			Steps: []resource.TestStep{
+				{
+					Config: fmt.Sprintf(`
+resource "namecheap_domain_records" "test" {
+  domain = "%[1]s"
+  mode   = "MERGE"
+
+  record {
+    hostname = "sub1"
+    type     = "A"
+    address  = "22.22.22.22"
+  }
+}
+
+resource "namecheap_domain_records" "test_two" {
+  domain = "%[1]s"
+  mode   = "MERGE"
+
+  record {
+    hostname = "sub1"
+    type     = "A"
+    address  = "22.22.22.22"
+  }
+}
+`, mockScenarioDomain),
+					ExpectError: regexp.MustCompile("Error: Duplicate record"),
+				},
+			},
+		})
+	})
+
+	// MX record with an email type: the provider appends a trailing dot to the
+	// MX address on write, so the mock persists the dotted form (as the real API
+	// does) while the round-trip stays diff-free.
+	t.Run("mx_email_type", func(t *testing.T) {
+		m := newNamecheapMock(t)
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { mockPreCheck(t, m) },
+			ProviderFactories: mockProviderFactories(),
+			CheckDestroy:      mockCheckHostsCleared(m, mockScenarioDomain),
+			Steps: []resource.TestStep{
+				{
+					Config: fmt.Sprintf(`
+resource "namecheap_domain_records" "test" {
+  domain     = "%s"
+  mode       = "OVERWRITE"
+  email_type = "MX"
+
+  record {
+    hostname = "@"
+    type     = "MX"
+    address  = "mail.example.com"
+    mx_pref  = 10
+  }
+}
+`, mockScenarioDomain),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(resourceName, "record.#", "1"),
+						resource.TestCheckResourceAttr(resourceName, "email_type", "MX"),
+						mockCheckEmailType(m, mockScenarioDomain, "MX"),
+						mockCheckHostContains(m, mockScenarioDomain, "@", "MX", "mail.example.com."),
+					),
+				},
+			},
+		})
+	})
+}
+
+// TestAccMockNameservers covers the custom-nameserver MERGE/OVERWRITE code paths.
+func TestAccMockNameservers(t *testing.T) {
+	const resourceName = "namecheap_domain_records.test"
+
+	t.Run("merge", func(t *testing.T) {
+		m := newNamecheapMock(t)
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { mockPreCheck(t, m) },
+			ProviderFactories: mockProviderFactories(),
+			CheckDestroy:      mockCheckNameserversDefault(m, mockScenarioDomain),
+			Steps: []resource.TestStep{
+				{
+					Config: mockNameserversConfig("MERGE",
+						"dns1.namecheaphosting.com", "dns2.namecheaphosting.com"),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(resourceName, "nameservers.#", "2"),
+						mockCheckNameservers(m, mockScenarioDomain,
+							"dns1.namecheaphosting.com", "dns2.namecheaphosting.com"),
+					),
+				},
+			},
+		})
+	})
+
+	t.Run("overwrite_update", func(t *testing.T) {
+		m := newNamecheapMock(t)
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { mockPreCheck(t, m) },
+			ProviderFactories: mockProviderFactories(),
+			CheckDestroy:      mockCheckNameserversDefault(m, mockScenarioDomain),
+			Steps: []resource.TestStep{
+				{
+					Config: mockNameserversConfig("OVERWRITE",
+						"dns1.namecheaphosting.com", "dns2.namecheaphosting.com"),
+					Check: resource.ComposeTestCheckFunc(
+						mockCheckNameservers(m, mockScenarioDomain,
+							"dns1.namecheaphosting.com", "dns2.namecheaphosting.com"),
+					),
+				},
+				{
+					Config: mockNameserversConfig("OVERWRITE",
+						"ns-1467.awsdns-55.org", "ns-1076.awsdns-06.org"),
+					Check: resource.ComposeTestCheckFunc(
+						mockCheckNameservers(m, mockScenarioDomain,
+							"ns-1467.awsdns-55.org", "ns-1076.awsdns-06.org"),
+					),
+				},
+			},
+		})
+	})
+
+	// Two MERGE resources sharing a nameserver must be rejected. Both declare two
+	// nameservers (satisfying the minimum-two rule) with one overlapping, so the
+	// duplicate — not the minimum-count — check is what fires.
+	t.Run("duplicate_conflict", func(t *testing.T) {
+		m := newNamecheapMock(t)
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { mockPreCheck(t, m) },
+			ProviderFactories: mockProviderFactories(),
+			Steps: []resource.TestStep{
+				{
+					Config: fmt.Sprintf(`
+resource "namecheap_domain_records" "test" {
+  domain      = "%[1]s"
+  mode        = "MERGE"
+  nameservers = ["ns-1467.awsdns-55.org", "ns-1076.awsdns-06.org"]
+}
+
+resource "namecheap_domain_records" "test_two" {
+  domain      = "%[1]s"
+  mode        = "MERGE"
+  nameservers = ["ns-1467.awsdns-55.org", "ns-2000.awsdns-99.org"]
+}
+`, mockScenarioDomain),
+					ExpectError: regexp.MustCompile("Error: Duplicate nameserver"),
+				},
+			},
+		})
+	})
+}
+
+// mockNameserversConfig builds a resource managing the given nameservers.
+func mockNameserversConfig(mode string, nameservers ...string) string {
+	quoted := make([]string, 0, len(nameservers))
+	for _, ns := range nameservers {
+		quoted = append(quoted, fmt.Sprintf("%q", ns))
+	}
+	list := ""
+	for i, s := range quoted {
+		if i > 0 {
+			list += ", "
+		}
+		list += s
+	}
+	return fmt.Sprintf(`
+resource "namecheap_domain_records" "test" {
+  domain      = "%s"
+  mode        = "%s"
+  nameservers = [%s]
+}
+`, mockScenarioDomain, mode, list)
+}

--- a/namecheap/mock_server_test.go
+++ b/namecheap/mock_server_test.go
@@ -76,6 +76,20 @@ func (m *namecheapMock) stateFor(domain string) *mockDomainState {
 	return st
 }
 
+// seed sets the initial backend state for a domain, simulating records,
+// nameservers, or an email type that already exist before Terraform manages the
+// domain. Call it before the provider issues any request (e.g. in a PreCheck).
+func (m *namecheapMock) seed(domain string, hosts []hostEntry, emailType string, nameservers []string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	st := m.stateFor(domain)
+	st.hosts = hosts
+	st.nameservers = nameservers
+	if emailType != "" {
+		st.emailType = emailType
+	}
+}
+
 func (m *namecheapMock) handler(w http.ResponseWriter, r *http.Request) {
 	if err := r.ParseForm(); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -132,12 +146,26 @@ func parseSetHostsRequest(r *http.Request) []hostEntry {
 		hosts = append(hosts, hostEntry{
 			Name:    name,
 			Type:    recordType,
-			Address: r.FormValue("Address" + idx),
+			Address: mockNormalizeAddress(recordType, r.FormValue("Address"+idx)),
 			MXPref:  mxPref,
 			TTL:     ttl,
 		})
 	}
 	return hosts
+}
+
+// mockNormalizeAddress mimics the Namecheap server, which stores a trailing dot
+// on the address of hostname-valued records (CNAME/ALIAS/NS/MX). Replicating it
+// here exercises the provider's read-time address reconciliation — the same path
+// that must round-trip cleanly against the real API.
+func mockNormalizeAddress(recordType, address string) string {
+	switch recordType {
+	case "CNAME", "ALIAS", "NS", "MX":
+		if address != "" && !strings.HasSuffix(address, ".") {
+			return address + "."
+		}
+	}
+	return address
 }
 
 // splitNameservers parses the comma-separated Nameservers parameter, trimming


### PR DESCRIPTION
## Summary

Fourth slice of #246. Ports the representative record and nameserver MERGE/OVERWRITE scenarios from the live acceptance suite (`TestAccNamecheapDomainRecords`) onto the stateful mock (#274), so they run **fast and without credentials** on every PR. All new code is `testacc`-tagged; `make test` (the CI `check` job) is unchanged.

## Scenarios

**`TestAccMockRecords`**
- `merge_on_empty` — MERGE onto an empty zone, then a MERGE update replacing the managed set (create + update + domain mutex).
- `merge_preserves_existing` — MERGE leaves a pre-existing, unmanaged record intact on both apply and destroy.
- `overwrite_replaces_all` — OVERWRITE replaces the whole zone with the configured records and sets `email_type`; seeded records are dropped.
- `duplicate_conflict` — two MERGE resources declaring the same record → `Error: Duplicate record`.
- `mx_email_type` — MX record with `email_type = "MX"`, exercising trailing-dot reconciliation (see below).

**`TestAccMockNameservers`**
- `merge` — custom-nameserver MERGE.
- `overwrite_update` — OVERWRITE then update to a different NS set.
- `duplicate_conflict` — two MERGE resources sharing a nameserver → `Error: Duplicate nameserver` (both declare two NS with one overlapping, so the duplicate — not the minimum-two — check fires).

## Fidelity: trailing-dot normalization

The provider sends MX/CNAME/ALIAS/NS addresses to `SetHosts` **without** a trailing dot; the real Namecheap server stores and returns them **with** one, and the provider's read reconciles the two. `mockNormalizeAddress` replicates the server here, so the mock actually exercises that reconciliation path rather than trivially echoing the input — closing a green-but-wrong gap. Confirmed: the MX case round-trips with an empty follow-up plan.

## Supporting changes

- **mock** — `seed()` to establish pre-existing backend state; `mockNormalizeAddress()` for server-side trailing-dot behavior.
- **harness** — `mockCheckHostContains` / `mockCheckEmailType` / `mockCheckNameservers` / `mockCheckNameserversDefault` check helpers.

## Testing

- [x] `make testacc-mock` (9 subtests) passes against **real Terraform v1.15.1** (~7s total); every apply yields an empty follow-up plan (no perpetual diff), and each scenario asserts **both** Terraform state and the mock backend.
- [x] `make test` (release build) unchanged; `go vet` + `golangci-lint` (v2.12.2) clean in both build variants.

## Notes

- Titled `test:` — no production code / schema / CI / `go.mod` change; no release-please bump, no TF plan/state impact.
- Named regression cases (#71/#68/#37/#73) follow in the next slice; the live sandbox suite remains authoritative for API-contract fidelity.

Refs #246