### PR TITLE
test: add mock-backed regression guards for #71/#68/#37/#73

### DIFF
--- a/namecheap/mock_regression_test.go
+++ b/namecheap/mock_regression_test.go
@@ -1,0 +1,156 @@
+//go:build testacc
+
+package namecheap_provider
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// TestAccMockRegression pins the fixes for four historical bugs so they cannot
+// silently regress. All four issues are closed/fixed; these are guardrails, run
+// fast and credential-free against the stateful mock.
+func TestAccMockRegression(t *testing.T) {
+	const domain = "mock-example.com"
+	const resourceName = "namecheap_domain_records.test"
+
+	// #71: a FreeDNS subdomain (a domain value that parses to a non-empty
+	// third-level part) was silently written to the root zone. It is now rejected
+	// at validation time by validateDomainIsNotSubdomain.
+	t.Run("regression_71_subdomain_rejected", func(t *testing.T) {
+		m := newNamecheapMock(t)
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { mockPreCheck(t, m) },
+			ProviderFactories: mockProviderFactories(),
+			Steps: []resource.TestStep{
+				{
+					Config: `
+resource "namecheap_domain_records" "test" {
+  domain = "sub.mock-example.com"
+  mode   = "MERGE"
+
+  record {
+    hostname = "@"
+    type     = "A"
+    address  = "1.2.3.4"
+  }
+}
+`,
+					ExpectError: regexp.MustCompile(`contains a subdomain`),
+				},
+			},
+		})
+	})
+
+	// #37: creating an MX record failed. It now succeeds; the provider appends a
+	// trailing dot to the MX address on the server side, and the record is
+	// idempotent on replan (this exercises the MERGE path, complementing the
+	// OVERWRITE MX case in the scenario matrix).
+	t.Run("regression_37_mx_create", func(t *testing.T) {
+		m := newNamecheapMock(t)
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { mockPreCheck(t, m) },
+			ProviderFactories: mockProviderFactories(),
+			CheckDestroy:      mockCheckHostsCleared(m, domain),
+			Steps: []resource.TestStep{
+				{
+					Config: fmt.Sprintf(`
+resource "namecheap_domain_records" "test" {
+  domain     = "%s"
+  mode       = "MERGE"
+  email_type = "MX"
+
+  record {
+    hostname = "@"
+    type     = "MX"
+    address  = "mail.example.com"
+    mx_pref  = 10
+  }
+}
+`, domain),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(resourceName, "record.#", "1"),
+						resource.TestCheckResourceAttr(resourceName, "email_type", "MX"),
+						mockCheckEmailType(m, domain, "MX"),
+						mockCheckHostContains(m, domain, "@", "MX", "mail.example.com."),
+					),
+				},
+			},
+		})
+	})
+
+	// #68: `terraform import` set an internal mode=IMPORT that the schema's mode
+	// validator rejected ("expected mode to be one of [MERGE OVERWRITE]"). Import
+	// now succeeds. mode is import-only and differs from the configured value, so
+	// it is excluded from ImportStateVerify.
+	t.Run("regression_68_import", func(t *testing.T) {
+		m := newNamecheapMock(t)
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { mockPreCheck(t, m) },
+			ProviderFactories: mockProviderFactories(),
+			CheckDestroy:      mockCheckNameserversDefault(m, domain),
+			Steps: []resource.TestStep{
+				{
+					Config: mockNameserversConfig("OVERWRITE",
+						"ns-1467.awsdns-55.org", "ns-1076.awsdns-06.org"),
+					Check: mockCheckNameservers(m, domain,
+						"ns-1467.awsdns-55.org", "ns-1076.awsdns-06.org"),
+				},
+				{
+					ResourceName:            resourceName,
+					ImportState:             true,
+					ImportStateId:           domain,
+					ImportStateVerify:       true,
+					ImportStateVerifyIgnore: []string{"mode"},
+				},
+			},
+		})
+	})
+
+	// #73: a pre-existing CAA iodef record (with a quoted value) broke all record
+	// creation in MERGE mode, because MERGE re-sent the existing record through
+	// the address fixer. The fixer now round-trips a quoted 3-part iodef value, so
+	// an unrelated MERGE add succeeds and the CAA record is preserved.
+	t.Run("regression_73_caa_iodef_preserved", func(t *testing.T) {
+		m := newNamecheapMock(t)
+		const caaAddress = `0 iodef "mailto:support@mock-example.com"`
+		m.seed(domain, []hostEntry{
+			{Name: "@", Type: "CAA", Address: caaAddress, MXPref: 10, TTL: 1800},
+		}, "NONE", nil)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { mockPreCheck(t, m) },
+			ProviderFactories: mockProviderFactories(),
+			CheckDestroy: resource.ComposeTestCheckFunc(
+				mockCheckHostCount(m, domain, 1),
+				mockCheckHostContains(m, domain, "@", "CAA", caaAddress),
+			),
+			Steps: []resource.TestStep{
+				{
+					Config: fmt.Sprintf(`
+resource "namecheap_domain_records" "test" {
+  domain = "%s"
+  mode   = "MERGE"
+
+  record {
+    hostname = "test"
+    type     = "A"
+    address  = "1.1.1.1"
+    ttl      = 1800
+  }
+}
+`, domain),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(resourceName, "record.#", "1"),
+						mockCheckHostCount(m, domain, 2),
+						mockCheckHostContains(m, domain, "test", "A", "1.1.1.1"),
+						mockCheckHostContains(m, domain, "@", "CAA", caaAddress),
+					),
+				},
+			},
+		})
+	})
+}

--- a/namecheap/mock_server_test.go
+++ b/namecheap/mock_server_test.go
@@ -180,12 +180,22 @@ func splitNameservers(raw string) []string {
 	return out
 }
 
+// mockXMLAttrEscaper escapes values placed in XML attributes. It is needed for
+// record addresses that legitimately contain quotes (e.g. a CAA iodef value like
+// `0 iodef "mailto:..."`); without it the rendered response would be malformed.
+var mockXMLAttrEscaper = strings.NewReplacer(
+	"&", "&amp;",
+	"<", "&lt;",
+	">", "&gt;",
+	`"`, "&quot;",
+)
+
 func renderGetHostsXML(domain string, st *mockDomainState) string {
 	var lines []string
 	for i, h := range st.hosts {
 		lines = append(lines, fmt.Sprintf(
 			`<host HostId="%d" Name="%s" Type="%s" Address="%s" MXPref="%d" TTL="%d" AssociatedAppTitle="" FriendlyName="" IsActive="true" IsDDNSEnabled="false" />`,
-			i+1, h.Name, h.Type, h.Address, h.MXPref, h.TTL))
+			i+1, mockXMLAttrEscaper.Replace(h.Name), h.Type, mockXMLAttrEscaper.Replace(h.Address), h.MXPref, h.TTL))
 	}
 	emailType := st.emailType
 	if emailType == "" {


### PR DESCRIPTION
## Summary

Fifth slice of #246. Pins the fixes for four historical bugs against the stateful mock so they cannot silently regress — fast and credential-free. `testacc`-tagged; `make test` unchanged.

## Regression guards (`TestAccMockRegression`)

| Issue | Bug | Guard |
|-------|-----|-------|
| **#71** | FreeDNS subdomain silently written to the root zone | `ExpectError` `contains a subdomain` — rejected at validation |
| **#37** | MX record creation failed | MX create succeeds + idempotent replan (MERGE path, complements the OVERWRITE MX scenario) |
| **#68** | `terraform import` set `mode=IMPORT` the schema validator rejected | `ImportState`/`ImportStateVerify` succeeds (`mode` excluded — it's import-only and differs from the configured value) |
| **#73** | Pre-existing CAA `iodef` record broke all MERGE creation | seed CAA `iodef`, MERGE-add an A record → succeeds, CAA preserved unchanged |

## Supporting change

The mock's `GetHosts` renderer now **XML-escapes** the record `Name`/`Address` attributes — required for the CAA `iodef` value's embedded quotes (`0 iodef "mailto:..."`), which would otherwise emit malformed XML. No-op for plain addresses.

## Testing

- [x] `make testacc-mock` (now 13 subtests total) passes against **real Terraform v1.15.1**; each apply yields an empty follow-up plan and asserts both Terraform state and the mock backend.
- [x] `make test` (release build) unchanged; `go vet` + `golangci-lint` (v2.12.2) clean in both build variants.

## Notes

- Titled `test:` — no production code / schema / CI / `go.mod` change; no release-please bump, no TF plan/state impact.
- The live sandbox suite retains these behaviors as the source of truth for API-contract fidelity. #68's `ImportStateVerify` note (server-normalized fields) does not bite here — the imported resource is nameserver-only, so there are no trailing-dot / `mx_pref` import diffs.

Refs #246