### PR TITLE
docs: document mock acceptance suite and fork-safe CI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,9 +10,15 @@ make format         # go fmt ./...
 make check          # go vet ./...
 make lint           # golangci-lint run
 make test           # Unit tests with coverage
+make testacc-mock   # Mock-backed acceptance tests (no credentials; needs a terraform/tofu binary)
 ```
 
 Run a single test: `go test -v ./namecheap/... -run TestFunctionName -count=1`
+
+`make testacc-mock` runs the `testacc`-tagged mock acceptance suite; the mock
+lives in `namecheap/mock_server_test.go` and is exercised on every PR (see
+`CONTRIBUTING.md`). `make testacc` remains the live-API sandbox suite (needs
+`NAMECHEAP_*` credentials + a whitelisted IP).
 
 ## DCO Sign-off
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,29 @@ Run acceptance tests:
 $ make testacc
 ```
 
+### Running mock acceptance tests
+
+The provider also ships a **mock-backed** acceptance suite that runs the same
+`resource.Test` lifecycles against an in-process, stateful mock of the Namecheap
+API — no credentials, no network, no whitelisted IP:
+
+```shell
+$ make testacc-mock
+```
+
+This suite is compiled only under the `testacc` build tag (which enables a
+test-only `NAMECHEAP_API_URL` endpoint override; see
+[`SECURITY_COMPLIANCE.md`](SECURITY_COMPLIANCE.md#fork-safe-pull-request-ci)),
+so it never affects `make test` or released binaries. It still drives a real
+`terraform` binary; `make testacc-mock` uses the one on your `PATH` (set
+`TF_ACC_TERRAFORM_PATH` to target a specific `terraform`/`tofu`). It is a fast,
+credential-free **complement** to — not a replacement for — the live sandbox
+suite, which remains the source of truth for API-contract behavior.
+
+If the Namecheap SDK ever ships a reusable mock package (SDK issue #121), the
+in-repo mock in `namecheap/mock_server_test.go` can be swapped out behind the
+same test helpers without touching individual test bodies.
+
 ## Git Email Privacy
 
 To keep your personal email out of the public git history, consider using a GitHub noreply address.
@@ -86,9 +109,28 @@ $ git push --force-with-lease
 - Keep PRs focused — one logical change per PR.
 - Familiarize yourself with [`SECURITY_COMPLIANCE.md`](SECURITY_COMPLIANCE.md) for the compliance gates your PR will be checked against (dependency drift, vulnerability and license scans, SBOM publication, etc.).
 
+### What runs on your PR
+
+Every pull request — **including PRs from forks** — runs, on GitHub-hosted
+runners with no secrets:
+
+- the `check` job (unit tests, lint, coverage), and
+- `acceptance_mock`: the credential-free mock acceptance suite (`make
+  testacc-mock`) across a Terraform + OpenTofu version matrix.
+
+The live-API sandbox suite (`acceptance_test`, on the self-hosted EC2 runner) is
+**push-only** — it runs on branch pushes within this repository, not on
+`pull_request` events, because it needs secrets that GitHub does not expose to
+fork PRs. So for a fork contribution, the mock suite is the acceptance signal;
+a maintainer validates against the live sandbox before merge.
+
+Definition of done for a change to provider behavior: unit tests **and** a
+mock-backed `TestAccMock*` case cover it, and both pass locally
+(`make test && make testacc-mock`).
+
 ### Dependabot PRs (maintainers)
 
-Dependabot-triggered workflow runs don't have access to repository secrets — GitHub redacts `secrets.*` for `dependabot[bot]` by design, so any job that reaches AWS, the self-hosted EC2 runner, or the Namecheap sandbox credentials cannot complete. For that reason the `start-runner`, `acceptance_test`, and `stop-runner` jobs are gated with `if: ${{ github.actor != 'dependabot[bot]' }}` and will show as **skipped** (not failed) on Dependabot PRs. The `check` job still runs and must pass.
+Dependabot-triggered workflow runs don't have access to repository secrets — GitHub redacts `secrets.*` for `dependabot[bot]` by design, so any job that reaches AWS, the self-hosted EC2 runner, or the Namecheap sandbox credentials cannot complete. For that reason the `start-runner`, `acceptance_test`, and `stop-runner` jobs are gated with `if: ${{ github.event_name == 'push' && github.actor != 'dependabot[bot]' }}` and will show as **skipped** (not failed) on Dependabot PRs. The `check` job and the credential-free `acceptance_mock` job still run and must pass.
 
 Before merging a Dependabot PR, a maintainer must trigger acceptance tests manually under their own identity. Secrets resolve for maintainer-initiated runs, so the full pipeline executes. Use the exact branch name shown on the PR — Dependabot prefixes branches with the ecosystem (`go_modules`, `github_actions`, etc.), and the package segment that follows varies per update:
 

--- a/SECURITY_COMPLIANCE.md
+++ b/SECURITY_COMPLIANCE.md
@@ -93,6 +93,9 @@ CI gates (in [`.github/workflows/ci.yml`](.github/workflows/ci.yml), `check` job
 - `namecheap/ec2-github-runner` is SHA-pinned for both the `start-runner`
   and `stop-runner` jobs at the same SHA (#149). Rotations are tracked
   as single-line PRs (#159, #164, #165).
+- `hashicorp/setup-terraform` and `opentofu/setup-opentofu` (used by the
+  fork-safe `acceptance_mock` job) are likewise SHA-pinned with a trailing
+  `# v<semver>` comment.
 - Dependabot covers `gomod` and `github-actions` with a weekly cadence
   and a 5-PR cap per ecosystem (#150).
 
@@ -138,6 +141,26 @@ self-hosted runner action:
   behind older in-progress ones (FIFO, no cancellation). This replaces the
   former shared `concurrency` group, which silently cancelled pending runs
   when PRs were pushed close together.
+
+## Fork-safe pull-request CI
+
+CI runs on both `push` and `pull_request`, which lets PRs from forks run the
+required checks and a credential-free acceptance suite without ever exposing
+secrets:
+
+- The trigger is `pull_request`, **never `pull_request_target`** — fork code runs
+  only on GitHub-hosted runners with a read-only token and `secrets.*` redacted.
+- The secret-bound EC2 sandbox jobs (`start-runner`, `acceptance_test`,
+  `stop-runner`) are gated `github.event_name == 'push'`, so untrusted fork code
+  never reaches the self-hosted runner, the whitelisted Elastic IP, or the AWS /
+  Namecheap credentials. They keep running on every in-repo push, unchanged.
+- The `acceptance_mock` job provides the fork-facing acceptance signal: it runs
+  on `pull_request` on GitHub-hosted `ubuntu-latest`, references no `secrets.*`,
+  and drives the in-process mock (see
+  [`CONTRIBUTING.md`](CONTRIBUTING.md#running-mock-acceptance-tests)). The
+  test-only `NAMECHEAP_API_URL` endpoint override it relies on is compiled only
+  under the `testacc` build tag and is absent from released binaries.
+- No `${{ github.event.* }}` value is interpolated into a `run:` shell block.
 
 ## What triggers a compliance failure
 


### PR DESCRIPTION
## Summary

Final slice of #246. Documents the mock acceptance suite and the fork-safe CI model introduced across #272–#277. **Documentation only** — no code, schema, CI, or `go.mod` change.

## Changes

- **`CONTRIBUTING.md`**
  - New "Running mock acceptance tests" section: `make testacc-mock`, the `testacc` build tag, no credentials/network, real `terraform`/`tofu` binary, and the SDK-`namecheaptest` (#121) swap-in point.
  - New "What runs on your PR": every PR (incl. forks) runs `check` + `acceptance_mock` on GitHub-hosted runners with no secrets; the live EC2 sandbox is push-only; definition of done = unit **and** mock coverage.
  - Corrected the Dependabot section's job guard to the current `github.event_name == 'push' && github.actor != 'dependabot[bot]'`, and noted `acceptance_mock` also gates.
- **`SECURITY_COMPLIANCE.md`**
  - Added `hashicorp/setup-terraform` and `opentofu/setup-opentofu` to the SHA-pinned third-party actions.
  - New "Fork-safe pull-request CI" section: `pull_request` (not `pull_request_target`), EC2 jobs push-only, credential-free `acceptance_mock`, `testacc`-gated `NAMECHEAP_API_URL` absent from released binaries, no `${{ github.event.* }}` in `run:` blocks.
- **`CLAUDE.md`**: added `make testacc-mock` to the verification steps and distinguished it from the live-API `make testacc`.

## Testing

- [x] Docs-only; verified no non-`.md` files touched.
- [x] Cross-reference anchors resolve (`#fork-safe-pull-request-ci`, `#running-mock-acceptance-tests`).

Refs #246