### PR TITLE
test: add drift-refresh and error-surface mock coverage; testacc-sandbox target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,13 @@ check:
 test:
 	go test -v ./namecheap/... -count=1 -covermode=atomic -coverprofile=coverage.out
 
+# Live-API acceptance tests against the real Namecheap sandbox.
 # Please set the following ENV variables for this test:
 # NAMECHEAP_USER_NAME, NAMECHEAP_API_USER, NAMECHEAP_API_KEY, NAMECHEAP_TEST_DOMAIN, NAMECHEAP_USE_SANDBOX (optional, default is false)
-testacc:
+# `testacc` is kept as a backwards-compatible alias for `testacc-sandbox`.
+testacc: testacc-sandbox
+
+testacc-sandbox:
 	TF_ACC=1 go test ./namecheap -v -run=TestAcc -count=1 -timeout=30m -failfast
 
 # Mock-backed acceptance tests: run the acceptance suite against an in-process
@@ -60,4 +64,4 @@ lint:
 docs:
 	tfplugindocs
 
-.PHONY: format check test testacc testacc-mock build release install_darwin_amd64 install_linux_amd64 lint docs
+.PHONY: format check test testacc testacc-sandbox testacc-mock build release install_darwin_amd64 install_linux_amd64 lint docs

--- a/README.md
+++ b/README.md
@@ -80,6 +80,21 @@ resource "namecheap_domain_records" "domain2-com" {
 }
 ```
 
+### Testing
+
+Every pull request runs a fast, credential-free mock-backed acceptance suite
+(`make testacc-mock`) on GitHub-hosted runners across a Terraform + OpenTofu
+version matrix:
+
+| Engine | Versions tested in CI |
+| --- | --- |
+| Terraform | 1.5.7 (minimum supported), 1.15.5 (latest series) |
+| OpenTofu | 1.12.3 |
+
+A live-API sandbox suite (`make testacc-sandbox`, aliased as `make testacc`)
+additionally runs on pushes to this repository. See
+[CONTRIBUTING.md](CONTRIBUTING.md#tests) for how to run each locally.
+
 ### Contributing
 
 To contribute, please read our [contributing](CONTRIBUTING.md) docs.

--- a/namecheap/mock_drift_error_test.go
+++ b/namecheap/mock_drift_error_test.go
@@ -1,0 +1,95 @@
+//go:build testacc
+
+package namecheap_provider
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// TestAccMockDriftRefresh covers the drift-detection dimension: when the backend
+// changes out-of-band, a refresh must surface a non-empty plan (rather than the
+// provider silently ignoring the divergence).
+func TestAccMockDriftRefresh(t *testing.T) {
+	m := newNamecheapMock(t)
+	const domain = "mock-example.com"
+	const resourceName = "namecheap_domain_records.test"
+
+	config := fmt.Sprintf(`
+resource "namecheap_domain_records" "test" {
+  domain = "%s"
+  mode   = "OVERWRITE"
+
+  record {
+    hostname = "www"
+    type     = "A"
+    address  = "10.0.0.1"
+    ttl      = 1800
+  }
+}
+`, domain)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { mockPreCheck(t, m) },
+		ProviderFactories: mockProviderFactories(),
+		CheckDestroy:      mockCheckHostsCleared(m, domain),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "record.#", "1"),
+					mockCheckHostContains(m, domain, "www", "A", "10.0.0.1"),
+				),
+			},
+			{
+				// Simulate an external change to the record's address, then plan
+				// the unchanged config: the refresh must observe the drift and
+				// produce a non-empty plan that would correct it back.
+				PreConfig: func() {
+					m.seed(domain, []hostEntry{
+						{Name: "www", Type: "A", Address: "10.9.9.9", MXPref: 10, TTL: 1800},
+					}, "NONE", nil)
+				},
+				Config:             config,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// TestAccMockErrorSurface covers the error-surface dimension: an API error must
+// propagate as a Terraform error with the actionable, code-mapped diagnostic
+// (diagnostics.go), not a silent success. Here the mock fails the GetHosts read
+// during create with code 2019166, which maps to the "Domain not found"
+// diagnostic.
+func TestAccMockErrorSurface(t *testing.T) {
+	m := newNamecheapMock(t)
+	const domain = "mock-example.com"
+	m.failOn("namecheap.domains.dns.getHosts", "2019166", "Domain not found")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { mockPreCheck(t, m) },
+		ProviderFactories: mockProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "namecheap_domain_records" "test" {
+  domain = "%s"
+  mode   = "MERGE"
+
+  record {
+    hostname = "sub1"
+    type     = "A"
+    address  = "1.2.3.4"
+  }
+}
+`, domain),
+				ExpectError: regexp.MustCompile(`Domain not found`),
+			},
+		},
+	})
+}

--- a/namecheap/mock_server_test.go
+++ b/namecheap/mock_server_test.go
@@ -41,6 +41,13 @@ type namecheapMock struct {
 	server  *httptest.Server
 	mu      sync.Mutex
 	domains map[string]*mockDomainState
+
+	// Optional fault injection: when failCommand is set, any request whose
+	// Command equals it returns an API error with failCode/failMessage instead
+	// of the normal response. Used to exercise the provider's error-surfacing.
+	failCommand string
+	failCode    string
+	failMessage string
 }
 
 // newNamecheapMock starts a stateful mock server and registers its shutdown
@@ -57,6 +64,17 @@ func newNamecheapMock(t *testing.T) *namecheapMock {
 
 // url returns the base URL of the running mock server.
 func (m *namecheapMock) url() string { return m.server.URL }
+
+// failOn makes the mock return an API error (code/message) for every request
+// whose Command equals the given command, until cleared. Safe to call while the
+// server is running.
+func (m *namecheapMock) failOn(command, code, message string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.failCommand = command
+	m.failCode = code
+	m.failMessage = message
+}
 
 // state returns the current mock state for a domain, or nil if the domain has
 // never been touched. Callers must not mutate the returned pointer.
@@ -101,9 +119,16 @@ func (m *namecheapMock) handler(w http.ResponseWriter, r *http.Request) {
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	st := m.stateFor(domain)
 
 	w.Header().Set("Content-Type", "text/xml")
+
+	// Fault injection: return an API error for the configured command.
+	if m.failCommand != "" && command == m.failCommand {
+		_, _ = io.WriteString(w, apiErrorXML(m.failCode, m.failMessage))
+		return
+	}
+
+	st := m.stateFor(domain)
 	var resp string
 	switch command {
 	case "namecheap.domains.dns.getHosts":


### PR DESCRIPTION
## Summary

Closes the remaining #246 acceptance-criteria gaps: the last two lifecycle-matrix dimensions (drift-refresh, error-surface) plus the `make testacc-sandbox` target and the README version matrix.

## Changes

- **Drift detection** (`TestAccMockDriftRefresh`) — after apply, an out-of-band change to the mock backend must produce a **non-empty refresh plan** (via `PreConfig` mutation + `PlanOnly` + `ExpectNonEmptyPlan`), proving the provider detects external drift rather than ignoring it.
- **Error surfacing** (`TestAccMockErrorSurface`) — the mock fails the `GetHosts` read with API code **2019166**, and the provider must surface the actionable, code-mapped **"Domain not found"** diagnostic (`diagnostics.go`, from #264) as a Terraform error. Adds `failOn(command, code, message)` fault injection to the mock.
- **`make testacc-sandbox`** — explicit target for the live-API suite; `make testacc` stays a backwards-compatible alias (the EC2 `acceptance_test` job still calls `make testacc`, unchanged).
- **README** — states the CI-tested Terraform (1.5.7 / 1.15.5) + OpenTofu (1.12.3) matrix and links local test instructions.

## Testing

- [x] `TestAccMockDriftRefresh` and `TestAccMockErrorSurface` pass under **Terraform 1.15.1** and **OpenTofu 1.12.3**.
- [x] Full mock suite green under both engines; `make test` unchanged; `go vet` + `golangci-lint` clean in both build variants; `make testacc` alias verified.

## Why now

The #246 matrix already covered create / update / import / MERGE+OVERWRITE / email-type / conflicts / the four historical regressions. This adds the two dimensions the AC lists that weren't yet explicit — drift-refresh and error-diagnostic — so `namecheap_domain_records` has the full standard matrix future resources are measured against.

Refs #246