### PR TITLE
ci: make Dependabot dependency bumps use releasing commit types

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,24 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    # Go module bumps change the SHIPPED provider binary, so they must land as
+    # a releasing Conventional Commit type. release-please maps `fix:` -> patch,
+    # which opens/refreshes the Release PR and actually ships the dependency.
+    # Dependabot's default `chore(deps):` is NON-releasing, so without this
+    # bumps would sit unreleased until an unrelated fix:/feat: swept them in.
+    # `include: scope` yields `fix(deps): ...`. See CLAUDE.md > Commit Messages.
+    commit-message:
+      prefix: "fix"
+      include: "scope"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    # Action bumps are CI-only and never touch the shipped binary, so they use
+    # a NON-releasing type (`ci`) and must not cut a release. Matches the
+    # maintainer's manual `ci:` convention for runner/scanner bumps.
+    commit-message:
+      prefix: "ci"
+      include: "scope"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,16 @@ Before creating git commits, check that `git config user.email` is set. If it is
 - Do **not** add `Co-Authored-By` trailers to commits. Keep authorship clean. (The DCO `Signed-off-by` line is still required — see DCO Sign-off above.)
 - Use [Conventional Commits](https://www.conventionalcommits.org/) for PR titles and commit subjects: `feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, `test:`, `ci:`, `perf:`, `build:`, `revert:`. The release automation ([release-please](https://github.com/googleapis/release-please)) parses these to compute version bumps and the changelog: `fix:` → patch, `feat:` → minor, `feat!:`/`BREAKING CHANGE:` → major. A non-conventional title leaves a change out of the release notes. `pr-title.yml` enforces this on PRs.
 
+### Releasing vs non-releasing changes
+
+release-please bumps the version only on `fix:` → patch, `feat:` → minor, `feat!:`/`BREAKING CHANGE:` → major. `chore:`/`ci:`/`refactor:`/`test:`/`docs:` are **non-releasing** — at most they appear in the changelog when some *other* commit cuts a release. Two **published artifacts** make this easy to get wrong:
+
+- **Runtime dependencies** (anything in `go.mod` — the `gomod` ecosystem) ship inside the provider binary, so they **must** land as `fix(deps):` (or `feat(deps):` if the bump exposes new provider behavior). `chore(deps):` here is a bug: the update ships to nobody until an unrelated `fix:`/`feat:` sweeps it into the next Release PR.
+- **Registry-published docs** — the `docs/` tree (tfplugindocs output) is ingested by the Terraform Registry *only at a release tag*, so a correction there must ride a release: commit it as `fix(docs):`. Repo-internal markdown (README, `RELEASE.md`, `CLAUDE.md`, code comments) publishes nowhere and stays `docs:` — non-releasing.
+- **CI/tooling only** (GitHub Actions, scanners, runners — the `github-actions` ecosystem) never touch either published artifact, so they use a non-releasing type: `ci(deps):` (Dependabot) or `ci:` (manual).
+
+Rule of thumb: **if a change lands in something published (the binary or the `docs/` tree), it needs a releasing type (`fix:`/`feat:`); if it's repo-internal, it doesn't.** For Dependabot this is enforced via `commit-message.prefix` in `.github/dependabot.yml` (gomod → `fix`, github-actions → `ci`).
+
 ## Releases
 
 Semi-automatic, maintainer-gated via release-please. Merging conventional-commit PRs to `master` updates a long-lived "Release PR"; merging that Release PR tags `vX.Y.Z` and triggers GoReleaser. Full flow and required secrets are documented in `RELEASE.md`. Don't hand-cut tags except for the emergency path described there.
@@ -47,6 +57,8 @@ The `docs/` directory (`index.md`, `guides/`, `resources/`) is reserved for Terr
 - `SECURITY_COMPLIANCE.md` is the authoritative reference for the compliance gates a PR is judged against (dependency drift, vulnerability/license scans, SBOM, supply-chain pinning). Check it before proposing anything that touches `go.mod`, CI workflows, or action pins.
 
 ### Dependabot PRs
+
+Dependabot commit/PR-title prefixes are pinned in `.github/dependabot.yml` so `go.mod` bumps land as releasing `fix(deps):` and action bumps as non-releasing `ci(deps):` — see *Commit Messages > Dependency bumps must use a releasing type* above for the rationale.
 
 Workflow runs triggered by `dependabot[bot]` do **not** have access to `secrets.*` (GitHub redacts them by design). The `start-runner`, `acceptance_test`, and `stop-runner` jobs are gated with `if: ${{ github.actor != 'dependabot[bot]' }}` and appear as **skipped**, not failed, on Dependabot PRs — treat that as the expected state, not a regression.
 


### PR DESCRIPTION
## Problem

No release has been cut since `v2.3.5` despite 13 merged PRs. Root cause: every commit since then is `ci:` or `chore(deps):`, and release-please only bumps on `fix:` / `feat:` / breaking. In particular the `go-namecheap-sdk` bump (#240) landed as `chore(deps):` — a **non-releasing** type — so a real runtime-dependency change shipped to nobody.

## Fix

Pin Dependabot's commit/PR-title prefixes in `.github/dependabot.yml` so the release behavior is correct at the source (Dependabot authors these commits, not humans):

| Ecosystem | Prefix | Result | Release effect |
|-----------|--------|--------|----------------|
| `gomod` (runtime deps) | `fix` + scope | `fix(deps): …` | **patch release** ✓ |
| `github-actions` (CI only) | `ci` + scope | `ci(deps): …` | non-releasing (correct) |

Also documents the convention in `CLAUDE.md` so hand-authored dependency PRs follow the same rule.

## Notes

- This `ci:` PR is itself non-releasing (correct — it doesn't change the shipped binary).
- The already-merged `go-namecheap-sdk` bump stays unreleased until the next `gomod` bump (now `fix(deps):`) sweeps it into a Release PR, or a maintainer forces a release.