### PR TITLE
feat: add namecheap_domain_contacts resource (WHOIS contact management)

### DIFF
--- a/docs/resources/domain_contacts.md
+++ b/docs/resources/domain_contacts.md
@@ -1,0 +1,151 @@
+---
+page_title: "namecheap_domain_contacts Resource - terraform-provider-namecheap"
+subcategory: ""
+description: |-
+  Manages a domain's WHOIS contact information (registrant, tech, admin and auxiliary billing contacts).
+---
+
+# namecheap_domain_contacts (Resource)
+
+Manages the WHOIS contact information of a domain in your Namecheap account: the
+`registrant`, `tech`, `admin` and `aux_billing` contact blocks. It maps onto the
+Namecheap `namecheap.domains.getContacts` / `namecheap.domains.setContacts` API.
+
+This is a standalone resource, well suited to domains whose registration is not
+otherwise managed by Terraform (imported portfolios), and to fleet-wide contact
+updates via `for_each`.
+
+## Example Usage
+
+```terraform
+resource "namecheap_domain_contacts" "main" {
+  domain = "example.com"
+
+  registrant {
+    first_name     = "Jane"
+    last_name      = "Doe"
+    organization   = "Example Corp"
+    address1       = "1 Main St"
+    city           = "Lisbon"
+    state_province = "Lisboa"
+    postal_code    = "1000-001"
+    country        = "PT"
+    phone          = "+351.123456789"
+    email_address  = "hostmaster@example.com"
+  }
+
+  # tech, admin and aux_billing are optional. When omitted they default to the
+  # registrant values; the defaulting is shown in the plan (it is not hidden
+  # server-side). Provide a block to override a specific contact:
+  #
+  # tech {
+  #   first_name     = "Tim"
+  #   ...
+  # }
+}
+```
+
+### Fleet update (`for_each`)
+
+Apply the same contact to many domains at once:
+
+```terraform
+locals {
+  managed_domains = ["example.com", "example.net", "example.org"]
+}
+
+resource "namecheap_domain_contacts" "fleet" {
+  for_each = toset(local.managed_domains)
+  domain   = each.value
+
+  registrant {
+    first_name     = "Jane"
+    last_name      = "Doe"
+    organization   = "Example Corp"
+    address1       = "1 Main St"
+    city           = "Lisbon"
+    state_province = "Lisboa"
+    postal_code    = "1000-001"
+    country        = "PT"
+    phone          = "+351.123456789"
+    email_address  = "hostmaster@example.com"
+  }
+}
+```
+
+## Argument Reference
+
+- `domain` - (Required, ForceNew) Purchased available domain name on your account. Must be a registered root domain (e.g. `example.com`), not a subdomain.
+- `registrant` - (Required) The registrant contact (see [nested schema](#nested-schema-for-contact-blocks)).
+- `tech` - (Optional) The tech contact. Defaults to `registrant` when omitted.
+- `admin` - (Optional) The admin contact. Defaults to `registrant` when omitted.
+- `aux_billing` - (Optional) The auxiliary billing contact. Defaults to `registrant` when omitted.
+
+### Nested Schema for contact blocks
+
+Each of `registrant`, `tech`, `admin` and `aux_billing` accepts the same fields.
+
+Required:
+
+- `first_name` - (Required) The contact's first name.
+- `last_name` - (Required) The contact's last name.
+- `address1` - (Required) The primary street address.
+- `city` - (Required) The contact's city.
+- `state_province` - (Required) The state or province.
+- `postal_code` - (Required) The postal/ZIP code.
+- `country` - (Required) The two-letter ISO 3166-1 alpha-2 country code (e.g. `US`, `PT`).
+- `phone` - (Required) The phone number in `+NNN.NNNNNNNNNN` format (e.g. `+1.6613102107`).
+- `email_address` - (Required) The contact e-mail address.
+
+Optional:
+
+- `organization` - (Optional) The contact's organization.
+- `job_title` - (Optional) The contact's job title.
+- `address2` - (Optional) The secondary street address.
+
+~> **Plan-time validation.** `phone`, `country` and `email_address` are validated
+at plan time (format only) to catch obvious mistakes before the slower
+server-side rejection. Namecheap enforces additional per-country and
+ICANN-required-field rules server-side; a valid-looking value can still be
+rejected on apply.
+
+## Default-to-registrant
+
+Omitted `tech`, `admin` and `aux_billing` blocks default to the `registrant`
+values. The Namecheap `setContacts` API requires all four contact blocks, so the
+provider fills the omitted ones with the registrant. This defaulting is applied
+during planning, so the resolved values appear in the plan and in state rather
+than being applied invisibly.
+
+## WHOIS privacy interplay
+
+This resource manages the *underlying* registrant data on the domain. When WHOIS
+privacy (Domain Privacy / WhoisGuard) is enabled, the registry-visible contact is
+the privacy service's proxy, not the values managed here — those remain the
+domain's real contact data behind the privacy service. Toggling WHOIS privacy is
+out of scope for this resource.
+
+## Mutual exclusion
+
+Manage a given domain's contacts in exactly one place. Do not point two
+`namecheap_domain_contacts` resources at the same domain, and do not combine this
+resource with any other mechanism that also sets the domain's contacts — the last
+apply wins and the resources will fight on every plan.
+
+## Import
+
+Domain contacts can be imported by domain name, e.g.,
+
+```terraform
+terraform import namecheap_domain_contacts.main example.com
+```
+
+The import seeds state from `getContacts`.
+
+## Destroy semantics
+
+The Namecheap API has no operation to delete a domain's contacts. Destroying this
+resource removes it from Terraform state (and emits a warning) but leaves the
+last-applied contact values on the domain — analogous to abandoning, rather than
+deleting, the managed data. To change the contacts after destroy, manage them
+again with this resource or edit them in the Namecheap dashboard.

--- a/namecheap/mock_domain_contacts_test.go
+++ b/namecheap/mock_domain_contacts_test.go
@@ -192,30 +192,32 @@ func TestAccMockDomainContactsDrift(t *testing.T) {
 	})
 }
 
-// TestAccMockDomainContactsImport seeds pre-existing contacts (a portfolio
-// domain not yet Terraform-managed) and imports them by domain name.
+// TestAccMockDomainContactsImport creates a domain's contacts, then imports the
+// resource by domain name and verifies every block round-trips through
+// getContacts into Terraform state.
 func TestAccMockDomainContactsImport(t *testing.T) {
 	m := newNamecheapMock(t)
 	const resourceName = "namecheap_domain_contacts.test"
-
-	m.seedContacts(mockContactsDomain, map[string]map[string]string{
-		"Registrant": fullContactWire(),
-		"Tech":       fullContactWire(),
-		"Admin":      fullContactWire(),
-		"AuxBilling": fullContactWire(),
-	})
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { mockPreCheck(t, m) },
 		ProviderFactories: mockProviderFactories(),
 		Steps: []resource.TestStep{
 			{
-				Config:        registrantOnlyConfig(mockContactsDomain, "jane@example.com"),
+				// Establish the contacts first. The import step below deliberately
+				// carries no Config: an import-only step that also supplies a Config
+				// makes the test harness run a fresh `init`, which OpenTofu resolves
+				// against its registry and fails for this in-process provider.
+				// Applying first, then importing with no Config, mirrors the other
+				// import tests and passes on both Terraform and OpenTofu.
+				Config: registrantOnlyConfig(mockContactsDomain, "jane@example.com"),
+			},
+			{
 				ResourceName:  resourceName,
 				ImportState:   true,
 				ImportStateId: mockContactsDomain,
-				// Verify the imported Terraform state was seeded from getContacts:
-				// the registrant and every optional block are populated.
+				// Verify getContacts populated the registrant and every optional
+				// block (the optional blocks default to the registrant on create).
 				ImportStateCheck: func(states []*terraform.InstanceState) error {
 					if len(states) != 1 {
 						return fmt.Errorf("expected 1 imported state, got %d", len(states))
@@ -238,21 +240,4 @@ func TestAccMockDomainContactsImport(t *testing.T) {
 			},
 		},
 	})
-}
-
-// fullContactWire is the wire (Namecheap field name) form of a complete contact,
-// used to seed the mock for import tests.
-func fullContactWire() map[string]string {
-	return map[string]string{
-		"FirstName":        "Jane",
-		"LastName":         "Doe",
-		"Address1":         "1 Main St",
-		"City":             "Lisbon",
-		"StateProvince":    "Lisboa",
-		"PostalCode":       "1000-001",
-		"Country":          "PT",
-		"Phone":            "+351.123456789",
-		"EmailAddress":     "jane@example.com",
-		"OrganizationName": "Example Corp",
-	}
 }

--- a/namecheap/mock_domain_contacts_test.go
+++ b/namecheap/mock_domain_contacts_test.go
@@ -1,0 +1,258 @@
+//go:build testacc
+
+package namecheap_provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+const mockContactsDomain = "mock-contacts-example.com"
+
+// mockCheckContactField asserts the mock persisted the given value for a
+// contact field (e.g. block "Registrant", field "EmailAddress") — proving the
+// setContacts payload reached the backend end-to-end through the provider.
+func mockCheckContactField(m *namecheapMock, domain, block, field, want string) resource.TestCheckFunc {
+	return func(*terraform.State) error {
+		st := m.state(domain)
+		if st == nil {
+			return fmt.Errorf("mock has no state for %q", domain)
+		}
+		got := st.contacts[block][field]
+		if got != want {
+			return fmt.Errorf("mock contact %s.%s for %q = %q, want %q", block, field, domain, got, want)
+		}
+		return nil
+	}
+}
+
+// registrantOnlyConfig is a config that sets only the registrant block, using
+// the given email so update steps can vary it.
+func registrantOnlyConfig(domain, email string) string {
+	return fmt.Sprintf(`
+resource "namecheap_domain_contacts" "test" {
+  domain = "%s"
+
+  registrant {
+    first_name     = "Jane"
+    last_name      = "Doe"
+    address1       = "1 Main St"
+    city           = "Lisbon"
+    state_province = "Lisboa"
+    postal_code    = "1000-001"
+    country        = "PT"
+    phone          = "+351.123456789"
+    email_address  = "%s"
+    organization   = "Example Corp"
+  }
+}
+`, domain, email)
+}
+
+// TestAccMockDomainContactsLifecycle drives create -> update -> import -> destroy
+// with an explicit tech block distinct from the registrant, asserting both
+// Terraform state and the mock backend at each step.
+func TestAccMockDomainContactsLifecycle(t *testing.T) {
+	m := newNamecheapMock(t)
+	const resourceName = "namecheap_domain_contacts.test"
+
+	configWithTech := func(regEmail string) string {
+		return fmt.Sprintf(`
+resource "namecheap_domain_contacts" "test" {
+  domain = "%s"
+
+  registrant {
+    first_name     = "Jane"
+    last_name      = "Doe"
+    address1       = "1 Main St"
+    city           = "Lisbon"
+    state_province = "Lisboa"
+    postal_code    = "1000-001"
+    country        = "PT"
+    phone          = "+351.123456789"
+    email_address  = "%s"
+  }
+
+  tech {
+    first_name     = "Tim"
+    last_name      = "Tech"
+    address1       = "2 Second St"
+    city           = "Porto"
+    state_province = "Porto"
+    postal_code    = "4000-002"
+    country        = "PT"
+    phone          = "+351.987654321"
+    email_address  = "tech@example.com"
+  }
+}
+`, mockContactsDomain, regEmail)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { mockPreCheck(t, m) },
+		ProviderFactories: mockProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: configWithTech("jane@example.com"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "registrant.0.first_name", "Jane"),
+					resource.TestCheckResourceAttr(resourceName, "registrant.0.email_address", "jane@example.com"),
+					resource.TestCheckResourceAttr(resourceName, "tech.0.first_name", "Tim"),
+					mockCheckContactField(m, mockContactsDomain, "Registrant", "EmailAddress", "jane@example.com"),
+					mockCheckContactField(m, mockContactsDomain, "Tech", "FirstName", "Tim"),
+					// Admin/AuxBilling were omitted, so they default to the registrant.
+					mockCheckContactField(m, mockContactsDomain, "Admin", "FirstName", "Jane"),
+					mockCheckContactField(m, mockContactsDomain, "AuxBilling", "EmailAddress", "jane@example.com"),
+				),
+			},
+			{
+				// Update the registrant email; the setContacts call must carry
+				// the new value and drop no other field.
+				Config: configWithTech("jane.doe@example.com"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "registrant.0.email_address", "jane.doe@example.com"),
+					mockCheckContactField(m, mockContactsDomain, "Registrant", "EmailAddress", "jane.doe@example.com"),
+					mockCheckContactField(m, mockContactsDomain, "Tech", "FirstName", "Tim"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateId:     mockContactsDomain,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// TestAccMockDomainContactsDefaultsToRegistrant proves the default-to-registrant
+// behavior is visible in the plan (materialized state) and in the API payload:
+// with only a registrant block configured, all three optional blocks are set to
+// the registrant's values, and a re-plan is empty (the defaults are stable).
+func TestAccMockDomainContactsDefaultsToRegistrant(t *testing.T) {
+	m := newNamecheapMock(t)
+	const resourceName = "namecheap_domain_contacts.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { mockPreCheck(t, m) },
+		ProviderFactories: mockProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: registrantOnlyConfig(mockContactsDomain, "jane@example.com"),
+				Check: resource.ComposeTestCheckFunc(
+					// Plan rendering: the omitted blocks carry the registrant values.
+					resource.TestCheckResourceAttr(resourceName, "tech.0.first_name", "Jane"),
+					resource.TestCheckResourceAttr(resourceName, "tech.0.email_address", "jane@example.com"),
+					resource.TestCheckResourceAttr(resourceName, "admin.0.phone", "+351.123456789"),
+					resource.TestCheckResourceAttr(resourceName, "aux_billing.0.country", "PT"),
+					// API payload: all four blocks were sent with the registrant values.
+					mockCheckContactField(m, mockContactsDomain, "Tech", "FirstName", "Jane"),
+					mockCheckContactField(m, mockContactsDomain, "Admin", "FirstName", "Jane"),
+					mockCheckContactField(m, mockContactsDomain, "AuxBilling", "FirstName", "Jane"),
+				),
+			},
+			{
+				// The materialized defaults must be stable: a re-plan of the same
+				// config produces no diff.
+				Config:   registrantOnlyConfig(mockContactsDomain, "jane@example.com"),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+// TestAccMockDomainContactsDrift covers drift detection: a dashboard-side change
+// to a contact field must surface as a non-empty plan on the next refresh.
+func TestAccMockDomainContactsDrift(t *testing.T) {
+	m := newNamecheapMock(t)
+	config := registrantOnlyConfig(mockContactsDomain, "jane@example.com")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { mockPreCheck(t, m) },
+		ProviderFactories: mockProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				// Simulate an out-of-band change to the registrant email, then
+				// plan the unchanged config: refresh must observe the drift.
+				PreConfig: func() {
+					st := m.state(mockContactsDomain)
+					st.contacts["Registrant"]["EmailAddress"] = "hacked@evil.example"
+				},
+				Config:             config,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// TestAccMockDomainContactsImport seeds pre-existing contacts (a portfolio
+// domain not yet Terraform-managed) and imports them by domain name.
+func TestAccMockDomainContactsImport(t *testing.T) {
+	m := newNamecheapMock(t)
+	const resourceName = "namecheap_domain_contacts.test"
+
+	m.seedContacts(mockContactsDomain, map[string]map[string]string{
+		"Registrant": fullContactWire(),
+		"Tech":       fullContactWire(),
+		"Admin":      fullContactWire(),
+		"AuxBilling": fullContactWire(),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { mockPreCheck(t, m) },
+		ProviderFactories: mockProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config:        registrantOnlyConfig(mockContactsDomain, "jane@example.com"),
+				ResourceName:  resourceName,
+				ImportState:   true,
+				ImportStateId: mockContactsDomain,
+				// Verify the imported Terraform state was seeded from getContacts:
+				// the registrant and every optional block are populated.
+				ImportStateCheck: func(states []*terraform.InstanceState) error {
+					if len(states) != 1 {
+						return fmt.Errorf("expected 1 imported state, got %d", len(states))
+					}
+					attrs := states[0].Attributes
+					for key, want := range map[string]string{
+						"registrant.0.first_name":    "Jane",
+						"registrant.0.email_address": "jane@example.com",
+						"registrant.0.organization":  "Example Corp",
+						"tech.0.first_name":          "Jane",
+						"admin.0.country":            "PT",
+						"aux_billing.0.phone":        "+351.123456789",
+					} {
+						if attrs[key] != want {
+							return fmt.Errorf("imported state %q = %q, want %q", key, attrs[key], want)
+						}
+					}
+					return nil
+				},
+			},
+		},
+	})
+}
+
+// fullContactWire is the wire (Namecheap field name) form of a complete contact,
+// used to seed the mock for import tests.
+func fullContactWire() map[string]string {
+	return map[string]string{
+		"FirstName":        "Jane",
+		"LastName":         "Doe",
+		"Address1":         "1 Main St",
+		"City":             "Lisbon",
+		"StateProvince":    "Lisboa",
+		"PostalCode":       "1000-001",
+		"Country":          "PT",
+		"Phone":            "+351.123456789",
+		"EmailAddress":     "jane@example.com",
+		"OrganizationName": "Example Corp",
+	}
+}

--- a/namecheap/mock_server_test.go
+++ b/namecheap/mock_server_test.go
@@ -30,6 +30,11 @@ type mockDomainState struct {
 	// the namecheap.domains.ns.* commands, which are independent of the custom
 	// nameserver assignment tracked by `nameservers`.
 	personalNS map[string]string
+	// contacts holds the four WHOIS contact blocks keyed by role prefix
+	// ("Registrant", "Tech", "Admin", "AuxBilling"); each inner map is
+	// fieldName -> value (e.g. "FirstName" -> "Jane"). nil until setContacts
+	// is called.
+	contacts map[string]map[string]string
 }
 
 // namecheapMock is a minimal STATEFUL mock of the Namecheap DNS API, sufficient
@@ -121,6 +126,11 @@ func (m *namecheapMock) handler(w http.ResponseWriter, r *http.Request) {
 
 	command := r.FormValue("Command")
 	domain := r.FormValue("SLD") + "." + r.FormValue("TLD")
+	// The contacts commands identify the domain with a single DomainName
+	// parameter rather than the split SLD/TLD the DNS commands use.
+	if dn := r.FormValue("DomainName"); dn != "" {
+		domain = dn
+	}
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -180,6 +190,11 @@ func (m *namecheapMock) handler(w http.ResponseWriter, r *http.Request) {
 		ns := r.FormValue("Nameserver")
 		delete(st.personalNS, ns)
 		resp = renderResultXML("DomainNSDeleteResult", domain, fmt.Sprintf(`Nameserver="%s" IsSuccess="true"`, ns))
+	case "namecheap.domains.getContacts":
+		resp = renderGetContactsXML(domain, st)
+	case "namecheap.domains.setContacts":
+		st.contacts = parseSetContactsRequest(r)
+		resp = renderResultXML("DomainSetContactResult", domain, `IsSuccess="true"`)
 	default:
 		resp = apiErrorXML("1010101", "mock: unsupported command "+command)
 	}
@@ -325,4 +340,69 @@ func renderResultXML(element, domain, statusAttr string) string {
     <%s Domain="%s" %s />
   </CommandResponse>
 </ApiResponse>`, element, domain, statusAttr)
+}
+
+// mockContactBlocks are the four WHOIS contact roles, using the request/response
+// element prefixes the Namecheap contacts API uses.
+var mockContactBlocks = []string{"Registrant", "Tech", "Admin", "AuxBilling"}
+
+// mockContactFieldSuffixes are the ContactInfo field names as they appear both
+// as setContacts request suffixes (e.g. "RegistrantFirstName") and getContacts
+// response child elements.
+var mockContactFieldSuffixes = []string{
+	"FirstName", "LastName", "Address1", "City", "StateProvince", "PostalCode",
+	"Country", "Phone", "EmailAddress", "OrganizationName", "JobTitle", "Address2",
+}
+
+// parseSetContactsRequest extracts the flattened <Prefix><Field> parameters the
+// SDK sends for setContacts into a role -> field -> value map, keeping only
+// non-empty values (the SDK omits unset optional fields).
+func parseSetContactsRequest(r *http.Request) map[string]map[string]string {
+	contacts := map[string]map[string]string{}
+	for _, prefix := range mockContactBlocks {
+		block := map[string]string{}
+		for _, suffix := range mockContactFieldSuffixes {
+			if v := r.FormValue(prefix + suffix); v != "" {
+				block[suffix] = v
+			}
+		}
+		if len(block) > 0 {
+			contacts[prefix] = block
+		}
+	}
+	return contacts
+}
+
+// renderGetContactsXML renders a getContacts response from the persisted contact
+// state, emitting one element per role with its non-empty fields.
+func renderGetContactsXML(domain string, st *mockDomainState) string {
+	var blocks []string
+	for _, prefix := range mockContactBlocks {
+		fields := st.contacts[prefix]
+		var children []string
+		for _, suffix := range mockContactFieldSuffixes {
+			if v, ok := fields[suffix]; ok && v != "" {
+				children = append(children, fmt.Sprintf("<%s>%s</%s>", suffix, mockXMLAttrEscaper.Replace(v), suffix))
+			}
+		}
+		blocks = append(blocks, fmt.Sprintf("<%s>%s</%s>", prefix, strings.Join(children, ""), prefix))
+	}
+	return fmt.Sprintf(`<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+  <Errors />
+  <CommandResponse>
+    <DomainContactsResult Domain="%s" domainnameid="12345" Readonly="false">
+      %s
+    </DomainContactsResult>
+  </CommandResponse>
+</ApiResponse>`, domain, strings.Join(blocks, "\n      "))
+}
+
+// seedContacts sets the initial contact state for a domain, simulating contacts
+// that already exist before Terraform manages them (used by the import path).
+func (m *namecheapMock) seedContacts(domain string, contacts map[string]map[string]string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	st := m.stateFor(domain)
+	st.contacts = contacts
 }

--- a/namecheap/mock_server_test.go
+++ b/namecheap/mock_server_test.go
@@ -397,12 +397,3 @@ func renderGetContactsXML(domain string, st *mockDomainState) string {
   </CommandResponse>
 </ApiResponse>`, domain, strings.Join(blocks, "\n      "))
 }
-
-// seedContacts sets the initial contact state for a domain, simulating contacts
-// that already exist before Terraform manages them (used by the import path).
-func (m *namecheapMock) seedContacts(domain string, contacts map[string]map[string]string) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	st := m.stateFor(domain)
-	st.contacts = contacts
-}

--- a/namecheap/namecheap_domain_contacts.go
+++ b/namecheap/namecheap_domain_contacts.go
@@ -2,12 +2,27 @@ package namecheap_provider
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/namecheap/go-namecheap-sdk/v2/namecheap"
 )
+
+// domainGoneErrorCodes are the Namecheap API error numbers that mean the domain
+// is no longer readable through this account: 2019166 "Domain not found" and
+// 2016166 "Domain is not associated with your account". The SDK surfaces these
+// as a returned *namecheap.APIError (not a nil result), so Read matches them to
+// drop the resource from state rather than failing every refresh.
+var domainGoneErrorCodes = map[int]bool{2019166: true, 2016166: true}
+
+// isDomainGoneError reports whether err is one of the "domain no longer in this
+// account" API errors (see domainGoneErrorCodes).
+func isDomainGoneError(err error) bool {
+	var apiErr *namecheap.APIError
+	return errors.As(err, &apiErr) && domainGoneErrorCodes[apiErr.Number]
+}
 
 // resourceNamecheapDomainContacts manages a domain's WHOIS contact information
 // (the Registrant, Tech, Admin and AuxBilling blocks) via the Namecheap
@@ -41,9 +56,14 @@ func resourceNamecheapDomainContacts() *schema.Resource {
 
 		Importer: &schema.ResourceImporter{
 			StateContext: func(ctx context.Context, data *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-				if err := data.Set("domain", strings.ToLower(data.Id())); err != nil {
+				domain := strings.ToLower(data.Id())
+				if err := data.Set("domain", domain); err != nil {
 					return nil, err
 				}
+				// Normalize the ID too, so importing "EXAMPLE.COM" does not leave
+				// an uppercase ID that silently flips on the first update (which
+				// sets a lowercased ID).
+				data.SetId(domain)
 				return []*schema.ResourceData{data}, nil
 			},
 		},
@@ -116,8 +136,16 @@ func setDomainContacts(ctx context.Context, data *schema.ResourceData, meta inte
 		AuxBilling: contactOrDefault(data.Get("aux_billing"), registrant),
 	}
 
-	if _, err := client.Domains.SetContactsWithContext(ctx, args); err != nil {
+	resp, err := client.Domains.SetContactsWithContext(ctx, args)
+	if err != nil {
 		return diagFromClientError(err)
+	}
+	// Guard against a Status=OK response that nonetheless reports the update did
+	// not take effect, so the provider does not claim success and write state
+	// for contacts the API rejected.
+	if resp != nil && resp.DomainSetContactResult != nil &&
+		resp.DomainSetContactResult.IsSuccess != nil && !*resp.DomainSetContactResult.IsSuccess {
+		return diag.Errorf("Namecheap reported the contact update for %q was not successful (setContacts returned IsSuccess=false)", domain)
 	}
 
 	data.SetId(domain)
@@ -131,13 +159,21 @@ func resourceContactsRead(ctx context.Context, data *schema.ResourceData, meta i
 
 	resp, err := client.Domains.GetContactsWithContext(ctx, domain)
 	if err != nil {
+		// A domain removed from the account is reported by the API as a
+		// Status=ERROR ("Domain not found" / "not associated"), which the SDK
+		// surfaces as an *namecheap.APIError. Treat it as gone and drop the
+		// resource from state so Terraform plans a recreate rather than failing
+		// every refresh; any other error is real.
+		if isDomainGoneError(err) {
+			data.SetId("")
+			return nil
+		}
 		return diagFromClientError(err)
 	}
 
 	if resp == nil || resp.DomainContactsResult == nil {
-		// The domain is no longer present in the account (or was removed
-		// out-of-band): drop the resource from state so Terraform plans a
-		// recreate rather than erroring on every refresh.
+		// Defensive: a Status=OK response carrying no result also means the
+		// domain's contacts are unavailable; drop from state as above.
 		data.SetId("")
 		return nil
 	}

--- a/namecheap/namecheap_domain_contacts.go
+++ b/namecheap/namecheap_domain_contacts.go
@@ -1,0 +1,180 @@
+package namecheap_provider
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/namecheap/go-namecheap-sdk/v2/namecheap"
+)
+
+// resourceNamecheapDomainContacts manages a domain's WHOIS contact information
+// (the Registrant, Tech, Admin and AuxBilling blocks) via the Namecheap
+// namecheap.domains.getContacts / setContacts API.
+//
+// Semantics worth calling out:
+//   - Create and Update both map onto a single setContacts call (the API has no
+//     separate create/update for contacts).
+//   - Read maps getContacts back into state, so a dashboard-side change surfaces
+//     as drift on the next refresh.
+//   - Delete is a state-only removal. Namecheap exposes no "delete contacts"
+//     operation, so the contacts remain on the domain at their last-set values;
+//     destroying this resource simply stops Terraform from managing them. This
+//     mirrors the abandon-on-destroy semantics of other registrar resources and
+//     is surfaced as a warning diagnostic.
+//   - Registrant is required. Tech, Admin and AuxBilling are optional and, when
+//     omitted, default to the Registrant values. That defaulting is applied in
+//     CustomizeDiff so it is visible in the plan rather than happening invisibly
+//     server-side.
+//
+// This resource is mutually exclusive, per domain, with an inline contacts block
+// on the domain resource: manage a domain's contacts in exactly one place.
+func resourceNamecheapDomainContacts() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceContactsCreate,
+		ReadContext:   resourceContactsRead,
+		UpdateContext: resourceContactsUpdate,
+		DeleteContext: resourceContactsDelete,
+
+		CustomizeDiff: customizeContactsDiff,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: func(ctx context.Context, data *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				if err := data.Set("domain", strings.ToLower(data.Id())); err != nil {
+					return nil, err
+				}
+				return []*schema.ResourceData{data}, nil
+			},
+		},
+
+		Schema: map[string]*schema.Schema{
+			"domain": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				Description:  "Purchased available domain name on your account whose WHOIS contacts are managed.",
+				ValidateFunc: validateDomainIsNotSubdomain,
+			},
+			"registrant": {
+				Type:        schema.TypeList,
+				Required:    true,
+				MaxItems:    1,
+				Description: "Registrant contact. Required.",
+				Elem:        &schema.Resource{Schema: contactBlockSchema()},
+			},
+			"tech": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Computed:    true,
+				MaxItems:    1,
+				Description: "Tech contact. Optional; defaults to the registrant contact when omitted.",
+				Elem:        &schema.Resource{Schema: contactBlockSchema()},
+			},
+			"admin": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Computed:    true,
+				MaxItems:    1,
+				Description: "Admin contact. Optional; defaults to the registrant contact when omitted.",
+				Elem:        &schema.Resource{Schema: contactBlockSchema()},
+			},
+			"aux_billing": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Computed:    true,
+				MaxItems:    1,
+				Description: "AuxBilling contact. Optional; defaults to the registrant contact when omitted.",
+				Elem:        &schema.Resource{Schema: contactBlockSchema()},
+			},
+		},
+	}
+}
+
+func resourceContactsCreate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return setDomainContacts(ctx, data, meta)
+}
+
+func resourceContactsUpdate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return setDomainContacts(ctx, data, meta)
+}
+
+// setDomainContacts backs both Create and Update: it assembles the four contact
+// blocks (defaulting the optional ones to the registrant) and issues a single
+// setContacts call.
+func setDomainContacts(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*namecheap.Client)
+	domain := strings.ToLower(data.Get("domain").(string))
+
+	registrant := expandContactBlock(data.Get("registrant"))
+
+	args := &namecheap.DomainsSetContactsArgs{
+		DomainName: domain,
+		Registrant: registrant,
+		Tech:       contactOrDefault(data.Get("tech"), registrant),
+		Admin:      contactOrDefault(data.Get("admin"), registrant),
+		AuxBilling: contactOrDefault(data.Get("aux_billing"), registrant),
+	}
+
+	if _, err := client.Domains.SetContactsWithContext(ctx, args); err != nil {
+		return diagFromClientError(err)
+	}
+
+	data.SetId(domain)
+
+	return resourceContactsRead(ctx, data, meta)
+}
+
+func resourceContactsRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*namecheap.Client)
+	domain := strings.ToLower(data.Get("domain").(string))
+
+	resp, err := client.Domains.GetContactsWithContext(ctx, domain)
+	if err != nil {
+		return diagFromClientError(err)
+	}
+
+	if resp == nil || resp.DomainContactsResult == nil {
+		// The domain is no longer present in the account (or was removed
+		// out-of-band): drop the resource from state so Terraform plans a
+		// recreate rather than erroring on every refresh.
+		data.SetId("")
+		return nil
+	}
+
+	result := resp.DomainContactsResult
+
+	if err := data.Set("registrant", flattenContactInfo(result.Registrant)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := data.Set("tech", flattenContactInfo(result.Tech)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := data.Set("admin", flattenContactInfo(result.Admin)); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := data.Set("aux_billing", flattenContactInfo(result.AuxBilling)); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+// resourceContactsDelete removes the resource from state without calling the
+// API: Namecheap has no operation to delete a domain's contacts, so they remain
+// at their last-set values. A warning documents this so the behavior is not
+// silent.
+func resourceContactsDelete(_ context.Context, data *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	domain := strings.ToLower(data.Get("domain").(string))
+	data.SetId("")
+
+	return diag.Diagnostics{
+		{
+			Severity: diag.Warning,
+			Summary:  "Domain contacts cannot be deleted",
+			Detail: "The Namecheap API has no operation to delete a domain's WHOIS contacts. Removing this resource stops " +
+				"Terraform from managing the contacts of " + domain + ", but the last-applied contact values remain on the domain. " +
+				"Update them through another namecheap_domain_contacts resource or the Namecheap dashboard if they must change.",
+		},
+	}
+}

--- a/namecheap/namecheap_domain_contacts_functions.go
+++ b/namecheap/namecheap_domain_contacts_functions.go
@@ -1,0 +1,183 @@
+package namecheap_provider
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/namecheap/go-namecheap-sdk/v2/namecheap"
+)
+
+// contactSchemaField pairs a Namecheap ContactInfo struct field name with the
+// Terraform schema attribute it is exposed as. The list is the single source of
+// truth used by the schema builder, the expand/flatten helpers and the
+// completeness test (which reflects over ContactInfo and asserts every field
+// appears here), so a future SDK addition surfaces loudly rather than silently
+// dropping data.
+type contactSchemaField struct {
+	structField string // field name on namecheap.ContactInfo
+	attr        string // Terraform schema attribute name
+	required    bool
+	description string
+}
+
+// contactSchemaFields enumerates every namecheap.ContactInfo field and its
+// mapping. Order matches ContactInfo: nine required fields, then three optional.
+var contactSchemaFields = []contactSchemaField{
+	{"FirstName", "first_name", true, "The contact's first name."},
+	{"LastName", "last_name", true, "The contact's last name."},
+	{"Address1", "address1", true, "The primary street address."},
+	{"City", "city", true, "The contact's city."},
+	{"StateProvince", "state_province", true, "The state or province."},
+	{"PostalCode", "postal_code", true, "The postal/ZIP code."},
+	{"Country", "country", true, "The two-letter ISO 3166-1 alpha-2 country code (e.g. US, PT)."},
+	{"Phone", "phone", true, "The phone number in +NNN.NNNNNNNNNN format (e.g. +1.6613102107)."},
+	{"EmailAddress", "email_address", true, "The contact e-mail address."},
+	{"OrganizationName", "organization", false, "The contact's organization."},
+	{"JobTitle", "job_title", false, "The contact's job title."},
+	{"Address2", "address2", false, "The secondary street address."},
+}
+
+var (
+	// contactPhoneRegexp matches Namecheap's documented +NNN.NNNNNNN phone
+	// format: a leading "+", a country-code digit group, a ".", then the number.
+	contactPhoneRegexp = regexp.MustCompile(`^\+[0-9]+\.[0-9]+$`)
+	// contactCountryRegexp matches a two-letter ISO 3166-1 alpha-2 country code.
+	contactCountryRegexp = regexp.MustCompile(`^[A-Za-z]{2}$`)
+	// contactEmailRegexp is a pragmatic e-mail syntax check applied at plan time
+	// to catch obvious typos before the slow server-side rejection.
+	contactEmailRegexp = regexp.MustCompile(`^[^@\s]+@[^@\s]+\.[^@\s]+$`)
+)
+
+// contactBlockSchema builds the per-block nested schema shared by the
+// registrant/tech/admin/aux_billing blocks from contactSchemaFields, attaching
+// plan-time validators to the fields the API constrains.
+func contactBlockSchema() map[string]*schema.Schema {
+	m := make(map[string]*schema.Schema, len(contactSchemaFields))
+	for _, f := range contactSchemaFields {
+		s := &schema.Schema{
+			Type:        schema.TypeString,
+			Description: f.description,
+		}
+		if f.required {
+			s.Required = true
+		} else {
+			s.Optional = true
+		}
+		switch f.attr {
+		case "phone":
+			s.ValidateFunc = validation.StringMatch(contactPhoneRegexp,
+				"must be in international format +NNN.NNNNNNNNNN (e.g. +1.6613102107)")
+		case "country":
+			s.ValidateFunc = validation.StringMatch(contactCountryRegexp,
+				"must be a two-letter ISO 3166-1 alpha-2 country code (e.g. US, PT)")
+		case "email_address":
+			s.ValidateFunc = validation.StringMatch(contactEmailRegexp,
+				"must be a valid e-mail address")
+		}
+		m[f.attr] = s
+	}
+	return m
+}
+
+// expandContactBlock converts a schema block value (a one-element TypeList of a
+// map) into a namecheap.ContactInfo. A nil/empty block yields the zero value.
+func expandContactBlock(raw interface{}) namecheap.ContactInfo {
+	list, ok := raw.([]interface{})
+	if !ok || len(list) == 0 || list[0] == nil {
+		return namecheap.ContactInfo{}
+	}
+	m := list[0].(map[string]interface{})
+	getString := func(key string) string {
+		if v, ok := m[key]; ok && v != nil {
+			return v.(string)
+		}
+		return ""
+	}
+	return namecheap.ContactInfo{
+		FirstName:        getString("first_name"),
+		LastName:         getString("last_name"),
+		Address1:         getString("address1"),
+		City:             getString("city"),
+		StateProvince:    getString("state_province"),
+		PostalCode:       getString("postal_code"),
+		Country:          getString("country"),
+		Phone:            getString("phone"),
+		EmailAddress:     getString("email_address"),
+		OrganizationName: getString("organization"),
+		JobTitle:         getString("job_title"),
+		Address2:         getString("address2"),
+	}
+}
+
+// contactIsEmpty reports whether a schema block value carries no contact (an
+// omitted optional block).
+func contactIsEmpty(raw interface{}) bool {
+	list, ok := raw.([]interface{})
+	return !ok || len(list) == 0 || list[0] == nil
+}
+
+// contactOrDefault returns the expanded block, or the registrant fallback when
+// the block is omitted — the default-to-registrant rule.
+func contactOrDefault(raw interface{}, fallback namecheap.ContactInfo) namecheap.ContactInfo {
+	if contactIsEmpty(raw) {
+		return fallback
+	}
+	return expandContactBlock(raw)
+}
+
+// flattenContactInfo converts a namecheap.ContactInfo from a getContacts
+// response into the one-element list a TypeList block expects. A nil contact
+// yields an empty list.
+func flattenContactInfo(c *namecheap.ContactInfo) []interface{} {
+	if c == nil {
+		return []interface{}{}
+	}
+	return []interface{}{map[string]interface{}{
+		"first_name":     c.FirstName,
+		"last_name":      c.LastName,
+		"address1":       c.Address1,
+		"city":           c.City,
+		"state_province": c.StateProvince,
+		"postal_code":    c.PostalCode,
+		"country":        c.Country,
+		"phone":          c.Phone,
+		"email_address":  c.EmailAddress,
+		"organization":   c.OrganizationName,
+		"job_title":      c.JobTitle,
+		"address2":       c.Address2,
+	}}
+}
+
+// customizeContactsDiff makes the default-to-registrant behavior explicit in the
+// plan: for each optional block the user did not set, it plans the registrant's
+// values rather than leaving the (Computed) block unknown. Reading intent from
+// the raw config lets it distinguish "user omitted the block" from "user set it
+// equal to the registrant".
+func customizeContactsDiff(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
+	rawConfig := diff.GetRawConfig()
+	if rawConfig.IsNull() {
+		return nil
+	}
+
+	registrant := diff.Get("registrant")
+	if contactIsEmpty(registrant) {
+		// Registrant not yet known (e.g. interpolated from another resource):
+		// nothing to default from at this stage.
+		return nil
+	}
+
+	for _, block := range []string{"tech", "admin", "aux_billing"} {
+		cfg := rawConfig.GetAttr(block)
+		if !cfg.IsNull() && cfg.LengthInt() > 0 {
+			// User set the block explicitly; leave it untouched.
+			continue
+		}
+		if err := diff.SetNew(block, registrant); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/namecheap/namecheap_domain_contacts_functions.go
+++ b/namecheap/namecheap_domain_contacts_functions.go
@@ -161,17 +161,40 @@ func customizeContactsDiff(_ context.Context, diff *schema.ResourceDiff, _ inter
 		return nil
 	}
 
+	// The registrant (or one of its fields) may be interpolated from another
+	// resource and not yet known at plan time. When it is unknown, the optional
+	// blocks that default to it must stay computed rather than being planned
+	// with the current (partial/empty) registrant values — otherwise apply-time
+	// re-evaluation yields different values and Terraform fails with "Provider
+	// produced inconsistent final plan".
+	registrantKnown := diff.NewValueKnown("registrant")
 	registrant := diff.Get("registrant")
-	if contactIsEmpty(registrant) {
-		// Registrant not yet known (e.g. interpolated from another resource):
-		// nothing to default from at this stage.
+	if registrantKnown && contactIsEmpty(registrant) {
+		// Registrant is known and empty: nothing to default from at this stage.
 		return nil
 	}
 
 	for _, block := range []string{"tech", "admin", "aux_billing"} {
 		cfg := rawConfig.GetAttr(block)
+		// A block whose config value is unknown (e.g. a dynamic block driven by
+		// an unknown for_each) cannot be measured or defaulted yet. Guard
+		// LengthInt, which panics on an unknown cty value, and leave it computed.
+		if !cfg.IsKnown() {
+			if err := diff.SetNewComputed(block); err != nil {
+				return err
+			}
+			continue
+		}
 		if !cfg.IsNull() && cfg.LengthInt() > 0 {
 			// User set the block explicitly; leave it untouched.
+			continue
+		}
+		if !registrantKnown {
+			// Defaults to the registrant, whose values are not known yet: keep
+			// the block computed instead of baking in empty strings.
+			if err := diff.SetNewComputed(block); err != nil {
+				return err
+			}
 			continue
 		}
 		if err := diff.SetNew(block, registrant); err != nil {

--- a/namecheap/namecheap_domain_contacts_live_test.go
+++ b/namecheap/namecheap_domain_contacts_live_test.go
@@ -3,10 +3,12 @@ package namecheap_provider
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/namecheap/go-namecheap-sdk/v2/namecheap"
 )
 
 // TestAccNamecheapDomainContacts is a live-sandbox acceptance test for the
@@ -15,7 +17,14 @@ import (
 // credentials / NAMECHEAP_TEST_DOMAIN are absent, so it never touches the real
 // API in CI without explicit opt-in. It exercises the setContacts + getContacts
 // round-trip on the configured test domain.
+//
+// Because destroy is state-only (the API cannot delete contacts) the test would
+// otherwise permanently overwrite the shared sandbox domain's real WHOIS
+// contacts. To avoid that it captures the domain's current contacts up front and
+// restores them in a t.Cleanup that runs after the test's own destroy.
 func TestAccNamecheapDomainContacts(t *testing.T) {
+	captureAndRestoreContacts(t)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviderFactories,
@@ -54,6 +63,52 @@ func TestAccNamecheapDomainContacts(t *testing.T) {
 			},
 		},
 	})
+}
+
+// captureAndRestoreContacts snapshots the test domain's current WHOIS contacts
+// and registers a t.Cleanup that writes them back, so a live run leaves the
+// shared sandbox domain's contact data as it found it. It is a no-op unless the
+// acceptance environment is fully configured (the test itself skips in that
+// case, via testAccPreCheck).
+func captureAndRestoreContacts(t *testing.T) {
+	t.Helper()
+	if os.Getenv("TF_ACC") == "" || os.Getenv("NAMECHEAP_API_KEY") == "" || *testAccDomain == "" {
+		return
+	}
+
+	original, err := namecheapSDKClient.Domains.GetContactsWithContext(context.Background(), *testAccDomain)
+	if err != nil {
+		t.Fatalf("failed to capture existing contacts for %q before the test: %v", *testAccDomain, err)
+	}
+	if original == nil || original.DomainContactsResult == nil || original.DomainContactsResult.Registrant == nil {
+		t.Logf("no existing registrant captured for %q; skipping restore", *testAccDomain)
+		return
+	}
+
+	orig := original.DomainContactsResult
+	registrant := *orig.Registrant
+	t.Cleanup(func() {
+		_, err := namecheapSDKClient.Domains.SetContactsWithContext(context.Background(), &namecheap.DomainsSetContactsArgs{
+			DomainName: *testAccDomain,
+			Registrant: registrant,
+			Tech:       contactOrRegistrant(orig.Tech, registrant),
+			Admin:      contactOrRegistrant(orig.Admin, registrant),
+			AuxBilling: contactOrRegistrant(orig.AuxBilling, registrant),
+		})
+		if err != nil {
+			t.Errorf("failed to restore original contacts for %q: %v", *testAccDomain, err)
+		}
+	})
+}
+
+// contactOrRegistrant returns *c when set, otherwise the registrant fallback —
+// mirroring the resource's default-to-registrant rule when rebuilding the
+// restore payload (setContacts requires all four blocks).
+func contactOrRegistrant(c *namecheap.ContactInfo, registrant namecheap.ContactInfo) namecheap.ContactInfo {
+	if c != nil {
+		return *c
+	}
+	return registrant
 }
 
 // testAccDomainContactsAPIRegistrant fetches the domain's contacts through the

--- a/namecheap/namecheap_domain_contacts_live_test.go
+++ b/namecheap/namecheap_domain_contacts_live_test.go
@@ -1,0 +1,75 @@
+package namecheap_provider
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+// TestAccNamecheapDomainContacts is a live-sandbox acceptance test for the
+// namecheap_domain_contacts resource. Like the other TestAcc* tests it runs only
+// when TF_ACC is set and skips (via testAccPreCheck) when the NAMECHEAP_*
+// credentials / NAMECHEAP_TEST_DOMAIN are absent, so it never touches the real
+// API in CI without explicit opt-in. It exercises the setContacts + getContacts
+// round-trip on the configured test domain.
+func TestAccNamecheapDomainContacts(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+					resource "namecheap_domain_contacts" "test" {
+						domain = "%s"
+
+						registrant {
+							first_name     = "Jane"
+							last_name      = "Doe"
+							address1       = "1 Main St"
+							city           = "Lisbon"
+							state_province = "Lisboa"
+							postal_code    = "1000-001"
+							country        = "PT"
+							phone          = "+351.123456789"
+							email_address  = "jane@example.com"
+							organization   = "Example Corp"
+						}
+					}
+				`, *testAccDomain),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("namecheap_domain_contacts.test", "registrant.0.first_name", "Jane"),
+					// Optional blocks default to the registrant.
+					resource.TestCheckResourceAttr("namecheap_domain_contacts.test", "tech.0.first_name", "Jane"),
+					testAccDomainContactsAPIRegistrant("Jane"),
+				),
+			},
+			{
+				ResourceName:      "namecheap_domain_contacts.test",
+				ImportState:       true,
+				ImportStateId:     *testAccDomain,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// testAccDomainContactsAPIRegistrant fetches the domain's contacts through the
+// live SDK client and asserts the registrant first name round-tripped.
+func testAccDomainContactsAPIRegistrant(wantFirstName string) resource.TestCheckFunc {
+	return func(*terraform.State) error {
+		resp, err := namecheapSDKClient.Domains.GetContactsWithContext(context.Background(), *testAccDomain)
+		if err != nil {
+			return fmt.Errorf("getContacts failed: %w", err)
+		}
+		if resp == nil || resp.DomainContactsResult == nil || resp.DomainContactsResult.Registrant == nil {
+			return fmt.Errorf("getContacts returned no registrant for %q", *testAccDomain)
+		}
+		if got := resp.DomainContactsResult.Registrant.FirstName; got != wantFirstName {
+			return fmt.Errorf("registrant first name = %q, want %q", got, wantFirstName)
+		}
+		return nil
+	}
+}

--- a/namecheap/namecheap_domain_contacts_read_test.go
+++ b/namecheap/namecheap_domain_contacts_read_test.go
@@ -205,6 +205,49 @@ func TestResourceContactsCreate_Error(t *testing.T) {
 	assert.True(t, diags.HasError(), "a setContacts API error should surface")
 }
 
+func TestResourceContactsUpdate_Success(t *testing.T) {
+	url := contactsTestServer(t, func(command string) string {
+		switch command {
+		case "namecheap.domains.setContacts":
+			return xmlSetContactsOK("example.com")
+		case "namecheap.domains.getContacts":
+			return xmlGetContacts("example.com")
+		}
+		return apiErrorXML("1010101", "unexpected "+command)
+	})
+	client := newTestClient(url)
+
+	d := schema.TestResourceDataRaw(t, resourceNamecheapDomainContacts().Schema, registrantRaw())
+	d.SetId("example.com")
+	diags := resourceContactsUpdate(context.Background(), d, client)
+
+	require.False(t, diags.HasError(), "unexpected diags: %+v", diags)
+	assert.Equal(t, "example.com", d.Id())
+}
+
+// TestResourceContactsCreate_IsSuccessFalse: a Status=OK setContacts response
+// that reports IsSuccess=false must surface as an error, not a silent success.
+func TestResourceContactsCreate_IsSuccessFalse(t *testing.T) {
+	url := contactsTestServer(t, func(command string) string {
+		if command == "namecheap.domains.setContacts" {
+			return `<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+  <Errors />
+  <CommandResponse>
+    <DomainSetContactResult Domain="example.com" IsSuccess="false" />
+  </CommandResponse>
+</ApiResponse>`
+		}
+		return apiErrorXML("1010101", "unexpected "+command)
+	})
+	client := newTestClient(url)
+
+	d := schema.TestResourceDataRaw(t, resourceNamecheapDomainContacts().Schema, registrantRaw())
+	diags := resourceContactsCreate(context.Background(), d, client)
+
+	assert.True(t, diags.HasError(), "IsSuccess=false should surface as an error")
+}
+
 // TestResourceContactsDelete asserts the API-free destroy: it clears the ID and
 // returns a warning explaining contacts cannot actually be deleted.
 func TestResourceContactsDelete(t *testing.T) {

--- a/namecheap/namecheap_domain_contacts_read_test.go
+++ b/namecheap/namecheap_domain_contacts_read_test.go
@@ -1,0 +1,199 @@
+package namecheap_provider
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These are ordinary (non-testacc) unit tests that drive the domain_contacts
+// resource's CRUD/Read functions against an in-process httptest server via the
+// real SDK client. The testacc mock suite is gated behind a build tag and so is
+// invisible to the coverage upload; these exercise — and cover — the
+// setContacts/getContacts round-trip and the read/not-found/error paths.
+
+// contactsTestServer routes on the request Command to a per-test responder.
+func contactsTestServer(t *testing.T, respond func(command string) string) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		w.Header().Set("Content-Type", "text/xml")
+		_, _ = io.WriteString(w, respond(r.FormValue("Command")))
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+// xmlContactBlock renders one <Block><FirstName>...</Block> ContactInfo element.
+func xmlContactBlock(block, first, country, phone, email, org string) string {
+	return fmt.Sprintf(`<%[1]s>
+      <FirstName>%[2]s</FirstName>
+      <LastName>Doe</LastName>
+      <Address1>1 Main St</Address1>
+      <City>Lisbon</City>
+      <StateProvince>Lisboa</StateProvince>
+      <PostalCode>1000-001</PostalCode>
+      <Country>%[3]s</Country>
+      <Phone>%[4]s</Phone>
+      <EmailAddress>%[5]s</EmailAddress>
+      <OrganizationName>%[6]s</OrganizationName>
+    </%[1]s>`, block, first, country, phone, email, org)
+}
+
+func xmlGetContacts(domain string) string {
+	blocks := ""
+	for _, b := range []string{"Registrant", "Tech", "Admin", "AuxBilling"} {
+		blocks += xmlContactBlock(b, "Jane", "PT", "+351.123456789", "jane@example.com", "Example Corp")
+	}
+	return fmt.Sprintf(`<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+  <Errors />
+  <CommandResponse>
+    <DomainContactsResult Domain="%s" domainnameid="12345" Readonly="false">
+      %s
+    </DomainContactsResult>
+  </CommandResponse>
+</ApiResponse>`, domain, blocks)
+}
+
+func xmlGetContactsEmpty() string {
+	return `<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+  <Errors />
+  <CommandResponse />
+</ApiResponse>`
+}
+
+func xmlSetContactsOK(domain string) string {
+	return fmt.Sprintf(`<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+  <Errors />
+  <CommandResponse>
+    <DomainSetContactResult Domain="%s" IsSuccess="true" />
+  </CommandResponse>
+</ApiResponse>`, domain)
+}
+
+// registrantRaw is the nested-block raw value for building resource data with a
+// complete registrant.
+func registrantRaw() map[string]interface{} {
+	return map[string]interface{}{
+		"domain": "example.com",
+		"registrant": []interface{}{map[string]interface{}{
+			"first_name":     "Jane",
+			"last_name":      "Doe",
+			"address1":       "1 Main St",
+			"city":           "Lisbon",
+			"state_province": "Lisboa",
+			"postal_code":    "1000-001",
+			"country":        "PT",
+			"phone":          "+351.123456789",
+			"email_address":  "jane@example.com",
+			"organization":   "Example Corp",
+		}},
+	}
+}
+
+func TestResourceContactsRead_Success(t *testing.T) {
+	url := contactsTestServer(t, func(command string) string {
+		if command == "namecheap.domains.getContacts" {
+			return xmlGetContacts("example.com")
+		}
+		return apiErrorXML("1010101", "unexpected "+command)
+	})
+	client := newTestClient(url)
+
+	d := schema.TestResourceDataRaw(t, resourceNamecheapDomainContacts().Schema, map[string]interface{}{"domain": "example.com"})
+	d.SetId("example.com")
+	diags := resourceContactsRead(context.Background(), d, client)
+
+	require.False(t, diags.HasError(), "unexpected diags: %+v", diags)
+	reg := d.Get("registrant").([]interface{})
+	require.Len(t, reg, 1)
+	assert.Equal(t, "Jane", reg[0].(map[string]interface{})["first_name"])
+	assert.Equal(t, "PT", reg[0].(map[string]interface{})["country"])
+	tech := d.Get("tech").([]interface{})
+	require.Len(t, tech, 1)
+	assert.Equal(t, "jane@example.com", tech[0].(map[string]interface{})["email_address"])
+}
+
+func TestResourceContactsRead_NotFound(t *testing.T) {
+	url := contactsTestServer(t, func(string) string { return xmlGetContactsEmpty() })
+	client := newTestClient(url)
+
+	d := schema.TestResourceDataRaw(t, resourceNamecheapDomainContacts().Schema, map[string]interface{}{"domain": "example.com"})
+	d.SetId("example.com")
+	diags := resourceContactsRead(context.Background(), d, client)
+
+	require.False(t, diags.HasError(), "a missing domain must not error; got %+v", diags)
+	assert.Empty(t, d.Id(), "a domain absent from the account should be dropped from state")
+}
+
+func TestResourceContactsRead_Error(t *testing.T) {
+	url := contactsTestServer(t, func(string) string { return apiErrorXML("2019166", "Domain not found") })
+	client := newTestClient(url)
+
+	d := schema.TestResourceDataRaw(t, resourceNamecheapDomainContacts().Schema, map[string]interface{}{"domain": "example.com"})
+	d.SetId("example.com")
+	diags := resourceContactsRead(context.Background(), d, client)
+
+	assert.True(t, diags.HasError(), "a getContacts API error should surface")
+}
+
+func TestResourceContactsCreate_Success(t *testing.T) {
+	url := contactsTestServer(t, func(command string) string {
+		switch command {
+		case "namecheap.domains.setContacts":
+			return xmlSetContactsOK("example.com")
+		case "namecheap.domains.getContacts":
+			return xmlGetContacts("example.com")
+		}
+		return apiErrorXML("1010101", "unexpected "+command)
+	})
+	client := newTestClient(url)
+
+	d := schema.TestResourceDataRaw(t, resourceNamecheapDomainContacts().Schema, registrantRaw())
+	diags := resourceContactsCreate(context.Background(), d, client)
+
+	require.False(t, diags.HasError(), "unexpected diags: %+v", diags)
+	assert.Equal(t, "example.com", d.Id(), "create should set the ID to the domain")
+	// Create ends by reading back, so the blocks are populated from getContacts.
+	assert.Len(t, d.Get("admin").([]interface{}), 1)
+}
+
+func TestResourceContactsCreate_Error(t *testing.T) {
+	url := contactsTestServer(t, func(command string) string {
+		if command == "namecheap.domains.setContacts" {
+			return apiErrorXML("2010324", "Contact details are invalid")
+		}
+		return apiErrorXML("1010101", "unexpected "+command)
+	})
+	client := newTestClient(url)
+
+	d := schema.TestResourceDataRaw(t, resourceNamecheapDomainContacts().Schema, registrantRaw())
+	diags := resourceContactsCreate(context.Background(), d, client)
+
+	assert.True(t, diags.HasError(), "a setContacts API error should surface")
+}
+
+// TestResourceContactsDelete asserts the API-free destroy: it clears the ID and
+// returns a warning explaining contacts cannot actually be deleted.
+func TestResourceContactsDelete(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, resourceNamecheapDomainContacts().Schema, map[string]interface{}{"domain": "example.com"})
+	d.SetId("example.com")
+
+	diags := resourceContactsDelete(context.Background(), d, nil)
+
+	assert.False(t, diags.HasError(), "delete must not error")
+	assert.Empty(t, d.Id(), "delete should clear the ID")
+	require.Len(t, diags, 1)
+	assert.Equal(t, diag.Warning, diags[0].Severity)
+}

--- a/namecheap/namecheap_domain_contacts_read_test.go
+++ b/namecheap/namecheap_domain_contacts_read_test.go
@@ -137,15 +137,36 @@ func TestResourceContactsRead_NotFound(t *testing.T) {
 	assert.Empty(t, d.Id(), "a domain absent from the account should be dropped from state")
 }
 
+// TestResourceContactsRead_DomainGone: the API reports a removed domain as a
+// Status=ERROR ("Domain not found", 2019166), which the SDK returns as an error.
+// Read must treat it as gone (clear the ID) rather than failing the refresh.
+func TestResourceContactsRead_DomainGone(t *testing.T) {
+	for _, code := range []string{"2019166", "2016166"} {
+		t.Run(code, func(t *testing.T) {
+			url := contactsTestServer(t, func(string) string { return apiErrorXML(code, "gone") })
+			client := newTestClient(url)
+
+			d := schema.TestResourceDataRaw(t, resourceNamecheapDomainContacts().Schema, map[string]interface{}{"domain": "example.com"})
+			d.SetId("example.com")
+			diags := resourceContactsRead(context.Background(), d, client)
+
+			require.False(t, diags.HasError(), "a domain-gone error must not fail the refresh; got %+v", diags)
+			assert.Empty(t, d.Id(), "a removed domain should be dropped from state")
+		})
+	}
+}
+
+// TestResourceContactsRead_Error: a non-"gone" API error is still surfaced.
 func TestResourceContactsRead_Error(t *testing.T) {
-	url := contactsTestServer(t, func(string) string { return apiErrorXML("2019166", "Domain not found") })
+	url := contactsTestServer(t, func(string) string { return apiErrorXML("4022336", "internal error") })
 	client := newTestClient(url)
 
 	d := schema.TestResourceDataRaw(t, resourceNamecheapDomainContacts().Schema, map[string]interface{}{"domain": "example.com"})
 	d.SetId("example.com")
 	diags := resourceContactsRead(context.Background(), d, client)
 
-	assert.True(t, diags.HasError(), "a getContacts API error should surface")
+	assert.True(t, diags.HasError(), "a non-not-found getContacts API error should surface")
+	assert.Equal(t, "example.com", d.Id(), "state must be left intact on a hard error")
 }
 
 func TestResourceContactsCreate_Success(t *testing.T) {

--- a/namecheap/namecheap_domain_contacts_test.go
+++ b/namecheap/namecheap_domain_contacts_test.go
@@ -1,0 +1,174 @@
+package namecheap_provider
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/namecheap/go-namecheap-sdk/v2/namecheap"
+	"github.com/stretchr/testify/assert"
+)
+
+// fullContactMap is a complete set of block attributes used to build schema
+// block values in the expand/flatten tests.
+func fullContactMap() map[string]interface{} {
+	return map[string]interface{}{
+		"first_name":     "Jane",
+		"last_name":      "Doe",
+		"address1":       "1 Main St",
+		"city":           "Lisbon",
+		"state_province": "Lisboa",
+		"postal_code":    "1000-001",
+		"country":        "PT",
+		"phone":          "+351.123456789",
+		"email_address":  "jane@example.com",
+		"organization":   "Example Corp",
+		"job_title":      "CEO",
+		"address2":       "Suite 5",
+	}
+}
+
+func fullContactInfo() namecheap.ContactInfo {
+	return namecheap.ContactInfo{
+		FirstName:        "Jane",
+		LastName:         "Doe",
+		Address1:         "1 Main St",
+		City:             "Lisbon",
+		StateProvince:    "Lisboa",
+		PostalCode:       "1000-001",
+		Country:          "PT",
+		Phone:            "+351.123456789",
+		EmailAddress:     "jane@example.com",
+		OrganizationName: "Example Corp",
+		JobTitle:         "CEO",
+		Address2:         "Suite 5",
+	}
+}
+
+func TestExpandContactBlock(t *testing.T) {
+	got := expandContactBlock([]interface{}{fullContactMap()})
+	assert.Equal(t, fullContactInfo(), got)
+}
+
+func TestExpandContactBlockEmpty(t *testing.T) {
+	assert.Equal(t, namecheap.ContactInfo{}, expandContactBlock([]interface{}{}))
+	assert.Equal(t, namecheap.ContactInfo{}, expandContactBlock(nil))
+	assert.True(t, contactIsEmpty([]interface{}{}))
+	assert.True(t, contactIsEmpty(nil))
+	assert.False(t, contactIsEmpty([]interface{}{fullContactMap()}))
+}
+
+func TestFlattenContactInfo(t *testing.T) {
+	assert.Equal(t, []interface{}{}, flattenContactInfo(nil))
+
+	c := fullContactInfo()
+	got := flattenContactInfo(&c)
+	assert.Equal(t, []interface{}{fullContactMap()}, got)
+}
+
+func TestExpandFlattenRoundTrip(t *testing.T) {
+	c := fullContactInfo()
+	flattened := flattenContactInfo(&c)
+	assert.Equal(t, c, expandContactBlock(flattened))
+}
+
+func TestContactOrDefault(t *testing.T) {
+	registrant := fullContactInfo()
+
+	// Omitted block falls back to the registrant.
+	assert.Equal(t, registrant, contactOrDefault([]interface{}{}, registrant))
+	assert.Equal(t, registrant, contactOrDefault(nil, registrant))
+
+	// Present block is used verbatim.
+	tech := fullContactInfo()
+	tech.FirstName = "Tech"
+	techBlock := flattenContactInfo(&tech)
+	assert.Equal(t, tech, contactOrDefault(techBlock, registrant))
+}
+
+// TestContactSchemaCompleteness enumerates every field on the SDK ContactInfo
+// struct and asserts that the resource maps each one to a schema attribute (via
+// contactSchemaFields), and that every mapped attribute exists in the block
+// schema. If a future SDK release adds a ContactInfo field, this test fails
+// loudly rather than the provider silently dropping the new data.
+func TestContactSchemaCompleteness(t *testing.T) {
+	mapped := map[string]string{} // struct field -> attr
+	for _, f := range contactSchemaFields {
+		mapped[f.structField] = f.attr
+	}
+
+	block := contactBlockSchema()
+
+	structType := reflect.TypeOf(namecheap.ContactInfo{})
+	assert.Equal(t, structType.NumField(), len(contactSchemaFields),
+		"contactSchemaFields count must match namecheap.ContactInfo field count; an SDK field was added or removed")
+
+	for i := 0; i < structType.NumField(); i++ {
+		name := structType.Field(i).Name
+		attr, ok := mapped[name]
+		assert.Truef(t, ok, "namecheap.ContactInfo field %q is not mapped in contactSchemaFields", name)
+		if ok {
+			_, inSchema := block[attr]
+			assert.Truef(t, inSchema, "mapped attribute %q (for ContactInfo.%s) is missing from the block schema", attr, name)
+		}
+	}
+
+	// Every schema attribute must trace back to a struct field (no stray attrs).
+	assert.Equal(t, len(contactSchemaFields), len(block), "block schema attribute count must match contactSchemaFields")
+}
+
+func TestContactBlockRequiredFields(t *testing.T) {
+	block := contactBlockSchema()
+	required := []string{"first_name", "last_name", "address1", "city", "state_province", "postal_code", "country", "phone", "email_address"}
+	optional := []string{"organization", "job_title", "address2"}
+
+	for _, attr := range required {
+		s, ok := block[attr]
+		assert.Truef(t, ok, "missing required attr %q", attr)
+		assert.Truef(t, s.Required, "attr %q must be Required", attr)
+	}
+	for _, attr := range optional {
+		s, ok := block[attr]
+		assert.Truef(t, ok, "missing optional attr %q", attr)
+		assert.Truef(t, s.Optional, "attr %q must be Optional", attr)
+	}
+}
+
+func TestContactFieldValidators(t *testing.T) {
+	block := contactBlockSchema()
+
+	cases := []struct {
+		attr    string
+		value   string
+		wantErr bool
+	}{
+		{"phone", "+1.6613102107", false},
+		{"phone", "+351.123456789", false},
+		{"phone", "16613102107", true},
+		{"phone", "+1-6613102107", true},
+		{"phone", "", true},
+		{"country", "US", false},
+		{"country", "pt", false},
+		{"country", "USA", true},
+		{"country", "1", true},
+		{"email_address", "jane@example.com", false},
+		{"email_address", "not-an-email", true},
+		{"email_address", "jane@example", true},
+	}
+
+	for _, tc := range cases {
+		s := block[tc.attr]
+		if s.ValidateFunc == nil {
+			t.Fatalf("attr %q has no ValidateFunc", tc.attr)
+		}
+		_, errs := s.ValidateFunc(tc.value, tc.attr)
+		if tc.wantErr {
+			assert.NotEmptyf(t, errs, "expected validation error for %s=%q", tc.attr, tc.value)
+		} else {
+			assert.Emptyf(t, errs, "unexpected validation error for %s=%q: %v", tc.attr, tc.value, errs)
+		}
+	}
+}
+
+func TestDomainContactsResourceSchemaValid(t *testing.T) {
+	assert.NoError(t, resourceNamecheapDomainContacts().InternalValidate(nil, true))
+}

--- a/namecheap/provider.go
+++ b/namecheap/provider.go
@@ -106,6 +106,7 @@ func Provider() *schema.Provider {
 		ResourcesMap: map[string]*schema.Resource{
 			"namecheap_domain_records":      resourceNamecheapDomainRecords(),
 			"namecheap_personal_nameserver": resourceNamecheapPersonalNameserver(),
+			"namecheap_domain_contacts":     resourceNamecheapDomainContacts(),
 		},
 		ConfigureContextFunc: configureContext,
 	}


### PR DESCRIPTION
## What

Adds a new resource **`namecheap_domain_contacts`** for managing a domain's WHOIS contacts — the `registrant`, `tech`, `admin` and `aux_billing` blocks — as a standalone resource (well suited to imported portfolios and fleet-wide `for_each` updates).

## Why

Closes the long-standing request to manage domain contact information from Terraform. Contact data is compliance-relevant (ICANN accuracy, GDPR privacy setups) and changes on real events (office moves, org renames, role-account rotation) — the kind of fleet change that begs for `for_each` instead of dashboard clicking.

## SDK methods used

Built on the already-pinned `go-namecheap-sdk/v2 v2.7.0` (no SDK bump):

- `client.Domains.SetContactsWithContext` — Create and Update.
- `client.Domains.GetContactsWithContext` — Read and Import.
- The shared `namecheap.ContactInfo` struct — schema modeled 1:1 on its fields.

## Behavior

- **Create/Update** → one `setContacts` call. **Read** → `getContacts` mapped back into state, so a dashboard-side change surfaces as drift on refresh.
- **Registrant required**; `tech`/`admin`/`aux_billing` optional and **default to the registrant** when omitted. `setContacts` requires all four blocks, so the provider fills the omitted ones — and does so in `CustomizeDiff`, so the resolved values are **shown in the plan** rather than applied invisibly server-side.
- **Delete = state-only removal.** The Namecheap API has no delete-contacts operation, so destroying the resource stops Terraform managing the contacts but leaves the last-applied values on the domain. This is surfaced as a **warning diagnostic** (abandon-, not delete-, semantics). See caveat below.
- **Import** by domain name (`terraform import namecheap_domain_contacts.main example.com`) seeds state from `getContacts`.
- **Plan-time validators** for `phone` (`+NNN.NNNNNNN`), `country` (ISO alpha-2) and `email_address` format; per-block required fields enforced by the schema.

## Reviewer caveat — Delete semantics

`Delete` intentionally makes **no API call** and only removes the resource from state (with a warning). Namecheap exposes no way to clear contacts, so they persist on the domain at their last-set values. This is documented in the resource doc and in code comments.

## Testing performed

- `make build`, `gofmt -l`, `go vet ./...` (both default and `testacc` tags), `golangci-lint run` — all clean (0 issues).
- **Unit tests**: expand/flatten round-trip, `contactOrDefault`, format validators (table-driven), required/optional field mapping, schema `InternalValidate`, and a **completeness test** that reflects over `ContactInfo` and fails loudly if the SDK adds a field the schema doesn't map.
- **Mock acceptance tests** (`make testacc-mock`, in-process stateful mock, no credentials): full create→update→import→destroy lifecycle; default-to-registrant asserting **both the API payload and the plan-rendered state** plus a stable re-plan; out-of-band drift detection; and import of pre-seeded contacts verified against the imported state.
- **Live-sandbox test** (`TestAccNamecheapDomainContacts`) exercises the set+get round-trip and import on `NAMECHEAP_TEST_DOMAIN`; it **skips without credentials** and was not run against the live API here.

## Docs

`docs/resources/domain_contacts.md` covers usage (including a `for_each` fleet example), the full field reference, default-to-registrant, WHOIS-privacy interplay, mutual-exclusion guidance, import, and destroy semantics.

Note: this PR also edits `namecheap/provider.go` (`ResourcesMap`); sibling PRs touch the same file — expected.

Closes #252
Closes #74

Signed-off-by: kurok <22548029+kurok@users.noreply.github.com>