### PR TITLE
feat: add namecheap_domain, namecheap_domains, namecheap_domain_records data sources

### DIFF
--- a/docs/data-sources/domain.md
+++ b/docs/data-sources/domain.md
@@ -7,15 +7,19 @@ description: |-
 
 # namecheap_domain (Data Source)
 
-Looks up read-only information about a single domain via the Namecheap
-`namecheap.domains.getInfo` API command. Use it to reference an existing
-(non-Terraform-managed) domain's DNS provider or nameservers in other resources,
-or to gate logic on whether a domain uses Namecheap DNS.
+Looks up read-only information about a single domain. Use it to reference an
+existing (non-Terraform-managed) domain's DNS provider, nameservers or expiry in
+other resources, or to gate logic on domain properties (is it expiring? locked?
+which DNS type is active?).
 
-~> `getInfo` returns DNS-oriented information only. Domain lifecycle fields
-(`created`, `expires`, `is_expired`, `is_locked`, `auto_renew`, `whois_guard`)
-are **not** returned by `getInfo` — they are available per-domain from the
-[`namecheap_domains`](domains.md) portfolio data source instead.
+~> This data source performs **two** Namecheap API calls per read:
+`namecheap.domains.getInfo` supplies the DNS-oriented fields (`dns_provider_type`,
+`is_our_dns`, `is_premium`, `is_premium_dns`, `nameservers`), and
+`namecheap.domains.getList` supplies the lifecycle fields (`created`, `expires`,
+`is_expired`, `is_locked`, `auto_renew`, `whois_guard`) that `getInfo` does not
+return. If you only need lifecycle data for many domains at once, prefer the
+[`namecheap_domains`](domains.md) portfolio data source, which returns all of it
+in one paginated listing.
 
 ## Example Usage
 
@@ -31,6 +35,10 @@ output "uses_namecheap_dns" {
 output "nameservers" {
   value = data.namecheap_domain.main.nameservers
 }
+
+output "expires" {
+  value = data.namecheap_domain.main.expires
+}
 ```
 
 ## Argument Reference
@@ -44,3 +52,10 @@ output "nameservers" {
 - `is_premium` - Whether the domain is a premium domain.
 - `is_premium_dns` - Whether the domain has an active PremiumDNS subscription.
 - `nameservers` - The nameservers currently configured for the domain.
+- `created` - Registration date as an RFC3339 timestamp (UTC).
+- `expires` - Expiration date as an RFC3339 timestamp (UTC).
+- `expires_in_days` - Whole calendar days until the domain expires (negative if already expired). Derived from the wall clock at read time; prefer `expires` where a stable value is needed.
+- `is_expired` - Whether the domain has expired.
+- `is_locked` - Whether the registrar lock is enabled.
+- `auto_renew` - Whether auto-renew is enabled.
+- `whois_guard` - WhoisGuard status (e.g. `ENABLED`, `DISABLED`, `NOTPRESENT`).

--- a/docs/data-sources/domain.md
+++ b/docs/data-sources/domain.md
@@ -1,0 +1,46 @@
+---
+page_title: "namecheap_domain Data Source - terraform-provider-namecheap"
+subcategory: ""
+description: |-
+  Read-only information about a single domain in the account.
+---
+
+# namecheap_domain (Data Source)
+
+Looks up read-only information about a single domain via the Namecheap
+`namecheap.domains.getInfo` API command. Use it to reference an existing
+(non-Terraform-managed) domain's DNS provider or nameservers in other resources,
+or to gate logic on whether a domain uses Namecheap DNS.
+
+~> `getInfo` returns DNS-oriented information only. Domain lifecycle fields
+(`created`, `expires`, `is_expired`, `is_locked`, `auto_renew`, `whois_guard`)
+are **not** returned by `getInfo` — they are available per-domain from the
+[`namecheap_domains`](domains.md) portfolio data source instead.
+
+## Example Usage
+
+```terraform
+data "namecheap_domain" "main" {
+  domain = "example.com"
+}
+
+output "uses_namecheap_dns" {
+  value = data.namecheap_domain.main.is_our_dns
+}
+
+output "nameservers" {
+  value = data.namecheap_domain.main.nameservers
+}
+```
+
+## Argument Reference
+
+- `domain` - (Required) The domain name to look up (e.g. `example.com`). Must be a registered root domain, not a subdomain.
+
+## Attribute Reference
+
+- `dns_provider_type` - The DNS provider currently serving the domain (e.g. `NAMECHEAP`, `FreeDNS`, `Custom`).
+- `is_our_dns` - Whether the domain is using Namecheap's DNS.
+- `is_premium` - Whether the domain is a premium domain.
+- `is_premium_dns` - Whether the domain has an active PremiumDNS subscription.
+- `nameservers` - The nameservers currently configured for the domain.

--- a/docs/data-sources/domain_records.md
+++ b/docs/data-sources/domain_records.md
@@ -1,0 +1,74 @@
+---
+page_title: "namecheap_domain_records Data Source - terraform-provider-namecheap"
+subcategory: ""
+description: |-
+  A read-only view of a domain's live DNS records.
+---
+
+# namecheap_domain_records (Data Source)
+
+Reads a domain's live DNS record set via `namecheap.domains.dns.getHosts`, along
+with its nameservers (`namecheap.domains.dns.getList`) and email routing type.
+
+The `records` object shape mirrors the
+[`namecheap_domain_records`](../resources/domain_records.md) resource `record`
+block attribute-for-attribute, so the output composes into resource inputs
+without any field remapping.
+
+## Example Usage
+
+```terraform
+data "namecheap_domain_records" "current" {
+  domain = "example.com"
+}
+
+output "record_hostnames" {
+  value = [for r in data.namecheap_domain_records.current.records : r.hostname]
+}
+```
+
+Merge/augment an existing zone by feeding the live records into a resource
+`dynamic` block:
+
+```terraform
+data "namecheap_domain_records" "current" {
+  domain = "example.com"
+}
+
+resource "namecheap_domain_records" "managed" {
+  domain = "example.com"
+  mode   = "OVERWRITE"
+
+  dynamic "record" {
+    for_each = data.namecheap_domain_records.current.records
+    content {
+      hostname = record.value.hostname
+      type     = record.value.type
+      address  = record.value.address
+      mx_pref  = record.value.mx_pref
+      ttl      = record.value.ttl
+    }
+  }
+
+  record {
+    hostname = "new"
+    type     = "A"
+    address  = "10.0.0.9"
+  }
+}
+```
+
+## Argument Reference
+
+- `domain` - (Required) The domain whose DNS records to read (e.g. `example.com`). Must be a registered root domain, not a subdomain.
+
+## Attribute Reference
+
+- `email_type` - The email routing type configured for the domain (e.g. `NONE`, `FWD`, `MXE`, `MX`, `OX`, `GMAIL`).
+- `nameservers` - The custom nameservers configured for the domain; empty when the domain is using Namecheap's DNS.
+- `records` - The live DNS host records for the domain. Each element has the following attributes:
+  - `hostname` - Sub-domain/hostname of the record.
+  - `type` - Record type (e.g. `A`, `AAAA`, `CNAME`, `MX`, `TXT`).
+  - `address` - Record value (URL or IP address, depending on the record type).
+  - `mx_pref` - MX preference for the host. Applicable to MX records only.
+  - `ttl` - Time to live for the record, in seconds.

--- a/docs/data-sources/domains.md
+++ b/docs/data-sources/domains.md
@@ -1,0 +1,72 @@
+---
+page_title: "namecheap_domains Data Source - terraform-provider-namecheap"
+subcategory: ""
+description: |-
+  The account's domain portfolio, with optional filtering.
+---
+
+# namecheap_domains (Data Source)
+
+Lists the account's domain portfolio via the Namecheap `namecheap.domains.getList`
+API command. The data source **auto-paginates** across all result pages, so the
+`domains` attribute always reflects the complete result set for the given
+filters.
+
+## Example Usage
+
+```terraform
+data "namecheap_domains" "all" {
+  search_term = ""    # optional keyword filter
+  list_type   = "ALL" # ALL | EXPIRING | EXPIRED
+}
+
+output "domain_names" {
+  value = [for d in data.namecheap_domains.all.domains : d.name]
+}
+```
+
+## Portfolio-wide composition pattern
+
+The portfolio pairs naturally with `for_each` to apply uniform policy (SPF,
+DMARC, verification records, ...) across every domain in the account in a few
+lines:
+
+```terraform
+data "namecheap_domains" "all" {
+  list_type = "ALL"
+}
+
+resource "namecheap_domain_records" "spf" {
+  for_each = { for d in data.namecheap_domains.all.domains : d.name => d }
+
+  domain = each.value.name
+  mode   = "MERGE"
+
+  record {
+    hostname = "@"
+    type     = "TXT"
+    address  = "v=spf1 include:spf.example.com -all"
+  }
+}
+```
+
+## Argument Reference
+
+- `search_term` - (Optional) Keyword to filter the returned domains. Maps to the getList `SearchTerm` parameter.
+- `list_type` - (Optional) Which subset of the account's domains to return. Possible values: `ALL` (default), `EXPIRING`, `EXPIRED`. Maps to the getList `ListType` parameter.
+
+## Attribute Reference
+
+- `domains` - The list of domains matching the filters. Each element has the following attributes:
+  - `id` - Namecheap internal domain identifier.
+  - `name` - The domain name (e.g. `example.com`).
+  - `user` - The account user the domain belongs to.
+  - `created` - Registration date as an RFC3339 timestamp (UTC).
+  - `expires` - Expiration date as an RFC3339 timestamp (UTC).
+  - `expires_in_days` - Whole calendar days until the domain expires (negative if already expired).
+  - `is_expired` - Whether the domain has expired.
+  - `is_locked` - Whether the registrar lock is enabled.
+  - `auto_renew` - Whether auto-renew is enabled.
+  - `whois_guard` - WhoisGuard status (e.g. `ENABLED`, `DISABLED`, `NOTPRESENT`).
+  - `is_premium` - Whether the domain is a premium domain.
+  - `is_our_dns` - Whether the domain is using Namecheap's DNS.

--- a/namecheap/data_source_helpers.go
+++ b/namecheap/data_source_helpers.go
@@ -1,0 +1,208 @@
+package namecheap_provider
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/namecheap/go-namecheap-sdk/v2/namecheap"
+)
+
+// dataSourceDomainReadError converts an SDK error from a domain-scoped read into
+// diagnostics that name the domain. It reuses diagFromClientError so that known
+// Namecheap error codes (e.g. 2019166 "Domain not found") keep their remediation
+// text, while the summary is prefixed with the domain so a failed lookup clearly
+// identifies which domain could not be read.
+func dataSourceDomainReadError(domain string, err error) diag.Diagnostics {
+	diags := diagFromClientError(err)
+	for i := range diags {
+		diags[i].Summary = fmt.Sprintf("%s (domain %q)", diags[i].Summary, domain)
+	}
+	return diags
+}
+
+// formatDateTime renders a Namecheap DateTime as an RFC3339 string. Namecheap
+// returns lifecycle dates as calendar dates (the SDK parses "MM/DD/YYYY" with
+// time.Parse, yielding midnight UTC), so the RFC3339 output is timezone-stable.
+// A nil pointer renders as an empty string.
+func formatDateTime(dt *namecheap.DateTime) string {
+	if dt == nil {
+		return ""
+	}
+	return dt.Time.UTC().Format(time.RFC3339)
+}
+
+// daysUntil returns the whole number of calendar days from now until target,
+// negative when target is in the past. Both instants are reduced to their UTC
+// calendar date before subtracting, so the result is independent of the wall
+// clock time of day and of the local timezone. now is passed explicitly so the
+// boundary behaviour is deterministically testable.
+func daysUntil(target, now time.Time) int {
+	targetDay := time.Date(target.UTC().Year(), target.UTC().Month(), target.UTC().Day(), 0, 0, 0, 0, time.UTC)
+	nowDay := time.Date(now.UTC().Year(), now.UTC().Month(), now.UTC().Day(), 0, 0, 0, 0, time.UTC)
+	return int(targetDay.Sub(nowDay).Hours() / 24)
+}
+
+// derefString returns the dereferenced value of a *string, or "" when nil.
+func derefString(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
+}
+
+// derefBool returns the dereferenced value of a *bool, or false when nil.
+func derefBool(p *bool) bool {
+	if p == nil {
+		return false
+	}
+	return *p
+}
+
+// derefInt returns the dereferenced value of a *int, or 0 when nil.
+func derefInt(p *int) int {
+	if p == nil {
+		return 0
+	}
+	return *p
+}
+
+// domainRecordElemSchema returns the schema for a single DNS host record as
+// exported by the namecheap_domain_records data source. The attribute names and
+// types intentionally mirror the record block of the namecheap_domain_records
+// resource (see resourceNamecheapDomainRecords), so a data-source record object
+// feeds straight into a resource record block without field remapping. This
+// parity is asserted by TestDomainRecordFieldParity.
+func domainRecordElemSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"hostname": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Sub-domain/hostname of the record.",
+		},
+		"type": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Record type (e.g. A, AAAA, CNAME, MX, TXT).",
+		},
+		"address": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Record value (URL or IP address, depending on the record type).",
+		},
+		"mx_pref": {
+			Type:        schema.TypeInt,
+			Computed:    true,
+			Description: "MX preference for the host. Applicable to MX records only.",
+		},
+		"ttl": {
+			Type:        schema.TypeInt,
+			Computed:    true,
+			Description: "Time to live for the record, in seconds.",
+		},
+	}
+}
+
+// flattenHostRecord converts an SDK detailed host record into the map shape
+// described by domainRecordElemSchema.
+func flattenHostRecord(h *namecheap.DomainsDNSHostRecordDetailed) map[string]interface{} {
+	return map[string]interface{}{
+		"hostname": derefString(h.Name),
+		"type":     derefString(h.Type),
+		"address":  derefString(h.Address),
+		"mx_pref":  derefInt(h.MXPref),
+		"ttl":      derefInt(h.TTL),
+	}
+}
+
+// domainPortfolioElemSchema returns the schema for a single domain as exported
+// by the namecheap_domains portfolio data source.
+func domainPortfolioElemSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Namecheap internal domain identifier.",
+		},
+		"name": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The domain name (e.g. example.com).",
+		},
+		"user": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The account user the domain belongs to.",
+		},
+		"created": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Registration date as an RFC3339 timestamp (UTC).",
+		},
+		"expires": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Expiration date as an RFC3339 timestamp (UTC).",
+		},
+		"expires_in_days": {
+			Type:        schema.TypeInt,
+			Computed:    true,
+			Description: "Whole calendar days until the domain expires (negative if already expired).",
+		},
+		"is_expired": {
+			Type:        schema.TypeBool,
+			Computed:    true,
+			Description: "Whether the domain has expired.",
+		},
+		"is_locked": {
+			Type:        schema.TypeBool,
+			Computed:    true,
+			Description: "Whether the registrar lock is enabled.",
+		},
+		"auto_renew": {
+			Type:        schema.TypeBool,
+			Computed:    true,
+			Description: "Whether auto-renew is enabled.",
+		},
+		"whois_guard": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "WhoisGuard status (e.g. ENABLED, DISABLED, NOTPRESENT).",
+		},
+		"is_premium": {
+			Type:        schema.TypeBool,
+			Computed:    true,
+			Description: "Whether the domain is a premium domain.",
+		},
+		"is_our_dns": {
+			Type:        schema.TypeBool,
+			Computed:    true,
+			Description: "Whether the domain is using Namecheap's DNS.",
+		},
+	}
+}
+
+// flattenPortfolioDomain converts an SDK Domain (from getList) into the map
+// shape described by domainPortfolioElemSchema. now is used to compute
+// expires_in_days.
+func flattenPortfolioDomain(d *namecheap.Domain, now time.Time) map[string]interface{} {
+	m := map[string]interface{}{
+		"id":              derefString(d.ID),
+		"name":            derefString(d.Name),
+		"user":            derefString(d.User),
+		"created":         formatDateTime(d.Created),
+		"expires":         formatDateTime(d.Expires),
+		"expires_in_days": 0,
+		"is_expired":      derefBool(d.IsExpired),
+		"is_locked":       derefBool(d.IsLocked),
+		"auto_renew":      derefBool(d.AutoRenew),
+		"whois_guard":     derefString(d.WhoisGuard),
+		"is_premium":      derefBool(d.IsPremium),
+		"is_our_dns":      derefBool(d.IsOurDNS),
+	}
+	if d.Expires != nil {
+		m["expires_in_days"] = daysUntil(d.Expires.Time, now)
+	}
+	return m
+}

--- a/namecheap/data_source_helpers.go
+++ b/namecheap/data_source_helpers.go
@@ -1,13 +1,61 @@
 package namecheap_provider
 
 import (
+	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/namecheap/go-namecheap-sdk/v2/namecheap"
 )
+
+// domainLifecycleAttrs are the attributes exported by the namecheap_domain data
+// source that originate from the portfolio listing (namecheap.domains.getList)
+// rather than from getInfo. They are a subset of domainPortfolioElemSchema so
+// the single-domain and portfolio shapes stay consistent.
+var domainLifecycleAttrs = []string{
+	"created", "expires", "expires_in_days",
+	"is_expired", "is_locked", "auto_renew", "whois_guard",
+}
+
+// setDomainLifecycleFromList fetches domain from the account portfolio listing
+// and copies the lifecycle attributes (see domainLifecycleAttrs) onto data.
+//
+// getList's SearchTerm is a substring keyword filter, not an exact lookup, so
+// the exact domain is matched client-side (case-insensitively) among the
+// returned rows. A transport/API error is surfaced (named with the domain); a
+// clean response that simply does not contain the domain is treated as "no
+// lifecycle data available" and leaves the fields at their zero values, because
+// the caller has already confirmed the domain exists via getInfo.
+func setDomainLifecycleFromList(ctx context.Context, client *namecheap.Client, data *schema.ResourceData, domain string) diag.Diagnostics {
+	resp, err := client.Domains.GetListWithContext(ctx, &namecheap.DomainsGetListArgs{
+		SearchTerm: namecheap.String(domain),
+		Page:       namecheap.Int(1),
+		PageSize:   namecheap.Int(domainsPageSize),
+	})
+	if err != nil {
+		return dataSourceDomainReadError(domain, err)
+	}
+	if resp == nil || resp.Domains == nil {
+		return nil
+	}
+
+	now := time.Now().UTC()
+	for i := range *resp.Domains {
+		d := &(*resp.Domains)[i]
+		if d.Name == nil || !strings.EqualFold(*d.Name, domain) {
+			continue
+		}
+		flat := flattenPortfolioDomain(d, now)
+		for _, attr := range domainLifecycleAttrs {
+			_ = data.Set(attr, flat[attr])
+		}
+		break
+	}
+	return nil
+}
 
 // dataSourceDomainReadError converts an SDK error from a domain-scoped read into
 // diagnostics that name the domain. It reuses diagFromClientError so that known

--- a/namecheap/data_source_helpers.go
+++ b/namecheap/data_source_helpers.go
@@ -20,31 +20,67 @@ var domainLifecycleAttrs = []string{
 	"is_expired", "is_locked", "auto_renew", "whois_guard",
 }
 
+// fetchAllDomains pages through namecheap.domains.getList for the given filters,
+// returning every matching domain across all pages. It is shared by the
+// namecheap_domains portfolio read and by setDomainLifecycleFromList so both walk
+// the whole result set rather than a single page. Page/PageSize are managed here
+// (PageSize is the documented maximum); listType/searchTerm map to the getList
+// ListType/SearchTerm params (searchTerm is omitted when empty).
+func fetchAllDomains(ctx context.Context, client *namecheap.Client, listType, searchTerm string) ([]namecheap.Domain, error) {
+	var all []namecheap.Domain
+	for page := 1; ; page++ {
+		args := &namecheap.DomainsGetListArgs{
+			ListType: namecheap.String(listType),
+			Page:     namecheap.Int(page),
+			PageSize: namecheap.Int(domainsPageSize),
+		}
+		if searchTerm != "" {
+			args.SearchTerm = namecheap.String(searchTerm)
+		}
+
+		resp, err := client.Domains.GetListWithContext(ctx, args)
+		if err != nil {
+			return nil, err
+		}
+		if resp == nil {
+			return nil, fmt.Errorf("empty response from Namecheap while listing domains (page %d)", page)
+		}
+		if resp.Domains != nil {
+			all = append(all, *resp.Domains...)
+		}
+
+		// Stop when the paging block indicates every item has been fetched. When
+		// paging is absent or degenerate, stop after the current page so a
+		// malformed response cannot spin an unbounded loop.
+		if resp.Paging == nil || resp.Paging.TotalItems == nil || resp.Paging.PageSize == nil || *resp.Paging.PageSize <= 0 {
+			break
+		}
+		if page*(*resp.Paging.PageSize) >= *resp.Paging.TotalItems {
+			break
+		}
+	}
+	return all, nil
+}
+
 // setDomainLifecycleFromList fetches domain from the account portfolio listing
 // and copies the lifecycle attributes (see domainLifecycleAttrs) onto data.
 //
-// getList's SearchTerm is a substring keyword filter, not an exact lookup, so
-// the exact domain is matched client-side (case-insensitively) among the
-// returned rows. A transport/API error is surfaced (named with the domain); a
-// clean response that simply does not contain the domain is treated as "no
-// lifecycle data available" and leaves the fields at their zero values, because
-// the caller has already confirmed the domain exists via getInfo.
+// getList's SearchTerm is a substring keyword filter, not an exact lookup, so it
+// pages through the entire filtered result set and matches the exact domain
+// client-side (case-insensitively) — a match must never be missed just because
+// it landed on a later page. A transport/API error is surfaced (named with the
+// domain). When the domain is genuinely absent from the listing (despite getInfo
+// having confirmed it exists), the lifecycle fields are left at their zero values
+// and a warning is emitted so the gap is visible rather than silent.
 func setDomainLifecycleFromList(ctx context.Context, client *namecheap.Client, data *schema.ResourceData, domain string) diag.Diagnostics {
-	resp, err := client.Domains.GetListWithContext(ctx, &namecheap.DomainsGetListArgs{
-		SearchTerm: namecheap.String(domain),
-		Page:       namecheap.Int(1),
-		PageSize:   namecheap.Int(domainsPageSize),
-	})
+	domains, err := fetchAllDomains(ctx, client, domainsListTypeAll, domain)
 	if err != nil {
 		return dataSourceDomainReadError(domain, err)
 	}
-	if resp == nil || resp.Domains == nil {
-		return nil
-	}
 
 	now := time.Now().UTC()
-	for i := range *resp.Domains {
-		d := &(*resp.Domains)[i]
+	for i := range domains {
+		d := &domains[i]
 		if d.Name == nil || !strings.EqualFold(*d.Name, domain) {
 			continue
 		}
@@ -52,9 +88,17 @@ func setDomainLifecycleFromList(ctx context.Context, client *namecheap.Client, d
 		for _, attr := range domainLifecycleAttrs {
 			_ = data.Set(attr, flat[attr])
 		}
-		break
+		return nil
 	}
-	return nil
+
+	return diag.Diagnostics{{
+		Severity: diag.Warning,
+		Summary:  fmt.Sprintf("Lifecycle fields unavailable for domain %q", domain),
+		Detail: "getInfo confirmed the domain exists, but it did not appear in the " +
+			"namecheap.domains.getList portfolio listing, so the lifecycle fields " +
+			"(created, expires, expires_in_days, is_expired, is_locked, auto_renew, whois_guard) " +
+			"were left empty. This is unexpected; please report it if it persists.",
+	}}
 }
 
 // dataSourceDomainReadError converts an SDK error from a domain-scoped read into
@@ -153,12 +197,27 @@ func domainRecordElemSchema() map[string]*schema.Schema {
 }
 
 // flattenHostRecord converts an SDK detailed host record into the map shape
-// described by domainRecordElemSchema.
+// described by domainRecordElemSchema. The address is normalized the same way
+// the namecheap_domain_records resource normalizes on read (via
+// getFixedAddressOfRecord: a trailing dot for CNAME/ALIAS/NS/MX, quotes for CAA),
+// so a record exported here composes into that resource without plan drift on
+// those types. On a malformed value (e.g. a bad CAA) or a nil field it falls
+// back to the raw address rather than failing the read.
 func flattenHostRecord(h *namecheap.DomainsDNSHostRecordDetailed) map[string]interface{} {
+	address := derefString(h.Address)
+	if h.Type != nil && h.Address != nil {
+		if fixed, err := getFixedAddressOfRecord(&namecheap.DomainsDNSHostRecord{
+			HostName:   h.Name,
+			RecordType: h.Type,
+			Address:    h.Address,
+		}); err == nil && fixed != nil {
+			address = *fixed
+		}
+	}
 	return map[string]interface{}{
 		"hostname": derefString(h.Name),
 		"type":     derefString(h.Type),
-		"address":  derefString(h.Address),
+		"address":  address,
 		"mx_pref":  derefInt(h.MXPref),
 		"ttl":      derefInt(h.TTL),
 	}

--- a/namecheap/data_source_namecheap_domain.go
+++ b/namecheap/data_source_namecheap_domain.go
@@ -132,11 +132,14 @@ func dataSourceNamecheapDomainRead(ctx context.Context, data *schema.ResourceDat
 	// is_expired/is_locked/auto_renew/whois_guard). Fetch them from the account
 	// portfolio listing, which does. getInfo above has already confirmed the
 	// domain exists, so a portfolio miss leaves the lifecycle fields at their
-	// zero values rather than failing the whole lookup.
-	if diags := setDomainLifecycleFromList(ctx, client, data, domain); diags != nil {
-		return diags
+	// zero values (with a warning) rather than failing the whole lookup.
+	lifecycleDiags := setDomainLifecycleFromList(ctx, client, data, domain)
+	if lifecycleDiags.HasError() {
+		return lifecycleDiags
 	}
 
 	data.SetId(domain)
-	return nil
+	// Propagate any non-error diagnostics (e.g. the portfolio-miss warning)
+	// without discarding the successful read.
+	return lifecycleDiags
 }

--- a/namecheap/data_source_namecheap_domain.go
+++ b/namecheap/data_source_namecheap_domain.go
@@ -1,0 +1,95 @@
+package namecheap_provider
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/namecheap/go-namecheap-sdk/v2/namecheap"
+)
+
+// dataSourceNamecheapDomain exposes read-only information about a single domain
+// via the namecheap.domains.getInfo API command.
+//
+// getInfo returns DNS-oriented information (provider type, nameservers, premium
+// flags). It does NOT return the domain lifecycle fields (created/expires/
+// is_expired/is_locked/auto_renew/whois_guard); those are only available through
+// the account portfolio listing, so they are exposed by the namecheap_domains
+// data source rather than fabricated here.
+func dataSourceNamecheapDomain() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceNamecheapDomainRead,
+		Schema: map[string]*schema.Schema{
+			"domain": {
+				Type:         schema.TypeString,
+				Required:     true,
+				Description:  "The domain name to look up (e.g. example.com). Must be a registered root domain, not a subdomain.",
+				ValidateFunc: validateDomainIsNotSubdomain,
+			},
+			"dns_provider_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The DNS provider currently serving the domain (e.g. NAMECHEAP, FreeDNS, Custom).",
+			},
+			"is_our_dns": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Whether the domain is using Namecheap's DNS.",
+			},
+			"is_premium": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Whether the domain is a premium domain.",
+			},
+			"is_premium_dns": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Whether the domain has an active PremiumDNS subscription.",
+			},
+			"nameservers": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "The nameservers currently configured for the domain.",
+			},
+		},
+	}
+}
+
+func dataSourceNamecheapDomainRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*namecheap.Client)
+	domain := strings.ToLower(data.Get("domain").(string))
+
+	resp, err := client.Domains.GetInfoWithContext(ctx, domain)
+	if err != nil {
+		return dataSourceDomainReadError(domain, err)
+	}
+
+	if resp == nil || resp.DomainDNSGetListResult == nil {
+		return diag.Errorf("Namecheap returned no information for domain %q; it may not exist or may not be associated with this account", domain)
+	}
+
+	info := resp.DomainDNSGetListResult
+
+	if info.IsPremium != nil {
+		_ = data.Set("is_premium", *info.IsPremium)
+	}
+	if info.PremiumDnsSubscription != nil && info.PremiumDnsSubscription.IsActive != nil {
+		_ = data.Set("is_premium_dns", *info.PremiumDnsSubscription.IsActive)
+	}
+	if info.DnsDetails != nil {
+		if info.DnsDetails.ProviderType != nil {
+			_ = data.Set("dns_provider_type", *info.DnsDetails.ProviderType)
+		}
+		if info.DnsDetails.IsUsingOurDNS != nil {
+			_ = data.Set("is_our_dns", *info.DnsDetails.IsUsingOurDNS)
+		}
+		if info.DnsDetails.Nameservers != nil {
+			_ = data.Set("nameservers", *info.DnsDetails.Nameservers)
+		}
+	}
+
+	data.SetId(domain)
+	return nil
+}

--- a/namecheap/data_source_namecheap_domain.go
+++ b/namecheap/data_source_namecheap_domain.go
@@ -9,14 +9,17 @@ import (
 	"github.com/namecheap/go-namecheap-sdk/v2/namecheap"
 )
 
-// dataSourceNamecheapDomain exposes read-only information about a single domain
-// via the namecheap.domains.getInfo API command.
+// dataSourceNamecheapDomain exposes read-only information about a single domain.
 //
-// getInfo returns DNS-oriented information (provider type, nameservers, premium
-// flags). It does NOT return the domain lifecycle fields (created/expires/
-// is_expired/is_locked/auto_renew/whois_guard); those are only available through
-// the account portfolio listing, so they are exposed by the namecheap_domains
-// data source rather than fabricated here.
+// It combines two API commands so the exported attributes match the issue's
+// contract in full:
+//   - namecheap.domains.getInfo supplies the DNS-oriented fields (provider type,
+//     nameservers, premium flags);
+//   - namecheap.domains.getList supplies the domain lifecycle fields
+//     (created/expires/is_expired/is_locked/auto_renew/whois_guard), which
+//     getInfo does not return.
+//
+// The two-call cost is documented on the registry page.
 func dataSourceNamecheapDomain() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: dataSourceNamecheapDomainRead,
@@ -53,6 +56,41 @@ func dataSourceNamecheapDomain() *schema.Resource {
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Description: "The nameservers currently configured for the domain.",
 			},
+			"created": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Registration date as an RFC3339 timestamp (UTC).",
+			},
+			"expires": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Expiration date as an RFC3339 timestamp (UTC).",
+			},
+			"expires_in_days": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Whole calendar days until the domain expires (negative if already expired).",
+			},
+			"is_expired": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Whether the domain has expired.",
+			},
+			"is_locked": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Whether the registrar lock is enabled.",
+			},
+			"auto_renew": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Whether auto-renew is enabled.",
+			},
+			"whois_guard": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "WhoisGuard status (e.g. ENABLED, DISABLED, NOTPRESENT).",
+			},
 		},
 	}
 }
@@ -88,6 +126,15 @@ func dataSourceNamecheapDomainRead(ctx context.Context, data *schema.ResourceDat
 		if info.DnsDetails.Nameservers != nil {
 			_ = data.Set("nameservers", *info.DnsDetails.Nameservers)
 		}
+	}
+
+	// getInfo does not carry the domain lifecycle fields (created/expires/
+	// is_expired/is_locked/auto_renew/whois_guard). Fetch them from the account
+	// portfolio listing, which does. getInfo above has already confirmed the
+	// domain exists, so a portfolio miss leaves the lifecycle fields at their
+	// zero values rather than failing the whole lookup.
+	if diags := setDomainLifecycleFromList(ctx, client, data, domain); diags != nil {
+		return diags
 	}
 
 	data.SetId(domain)

--- a/namecheap/data_source_namecheap_domain_records.go
+++ b/namecheap/data_source_namecheap_domain_records.go
@@ -61,11 +61,30 @@ func dataSourceNamecheapDomainRecordsRead(ctx context.Context, data *schema.Reso
 		return dataSourceDomainReadError(domain, err)
 	}
 
-	nameservers := []string{}
-	if !*nsResp.DomainDNSGetListResult.IsUsingOurDNS && nsResp.DomainDNSGetListResult.Nameservers != nil {
-		nameservers = *nsResp.DomainDNSGetListResult.Nameservers
+	// A domain on custom nameservers is not served by Namecheap's DNS, so
+	// getHosts would fail (the resource read guards the same way, see
+	// resourceRecordRead in namecheap_domain_record.go). Expose the nameservers
+	// and an empty record set instead of calling getHosts.
+	if !*nsResp.DomainDNSGetListResult.IsUsingOurDNS {
+		nameservers := []string{}
+		if nsResp.DomainDNSGetListResult.Nameservers != nil {
+			nameservers = *nsResp.DomainDNSGetListResult.Nameservers
+		}
+		if err := data.Set("nameservers", nameservers); err != nil {
+			return diag.FromErr(err)
+		}
+		if err := data.Set("records", []map[string]interface{}{}); err != nil {
+			return diag.FromErr(err)
+		}
+		if err := data.Set("email_type", ""); err != nil {
+			return diag.FromErr(err)
+		}
+		data.SetId(domain)
+		return nil
 	}
-	if err := data.Set("nameservers", nameservers); err != nil {
+
+	// Namecheap DNS: no custom nameservers to expose; read the live record set.
+	if err := data.Set("nameservers", []string{}); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -83,8 +102,13 @@ func dataSourceNamecheapDomainRecordsRead(ctx context.Context, data *schema.Reso
 
 	records := []map[string]interface{}{}
 	if hostsResp.DomainDNSGetHostsResult.Hosts != nil {
-		for i := range *hostsResp.DomainDNSGetHostsResult.Hosts {
-			records = append(records, flattenHostRecord(&(*hostsResp.DomainDNSGetHostsResult.Hosts)[i]))
+		// Filter Namecheap's default parking records (CNAME www->parkingpage,
+		// URL @->http://www.<domain>) exactly as the namecheap_domain_records
+		// resource does on read (issue #260); otherwise composing this data
+		// source into that resource writes the parking records back and drifts.
+		filtered := filterDefaultParkingRecords(hostsResp.DomainDNSGetHostsResult.Hosts, &domain)
+		for i := range *filtered {
+			records = append(records, flattenHostRecord(&(*filtered)[i]))
 		}
 	}
 	if err := data.Set("records", records); err != nil {

--- a/namecheap/data_source_namecheap_domain_records.go
+++ b/namecheap/data_source_namecheap_domain_records.go
@@ -1,0 +1,96 @@
+package namecheap_provider
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/namecheap/go-namecheap-sdk/v2/namecheap"
+)
+
+// dataSourceNamecheapDomainRecords exposes a read-only view of a domain's live
+// DNS record set via namecheap.domains.dns.getHosts, together with the domain's
+// nameservers (namecheap.domains.dns.getList) and email routing type. The record
+// object shape mirrors the namecheap_domain_records resource so the output
+// composes into resource inputs without transformation.
+func dataSourceNamecheapDomainRecords() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceNamecheapDomainRecordsRead,
+		Schema: map[string]*schema.Schema{
+			"domain": {
+				Type:         schema.TypeString,
+				Required:     true,
+				Description:  "The domain whose DNS records to read (e.g. example.com). Must be a registered root domain, not a subdomain.",
+				ValidateFunc: validateDomainIsNotSubdomain,
+			},
+			"email_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The email routing type configured for the domain (e.g. NONE, FWD, MXE, MX, OX, GMAIL).",
+			},
+			"nameservers": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "The custom nameservers configured for the domain; empty when the domain is using Namecheap's DNS.",
+			},
+			"records": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The live DNS host records for the domain. Field shapes mirror the namecheap_domain_records resource record block.",
+				Elem: &schema.Resource{
+					Schema: domainRecordElemSchema(),
+				},
+			},
+		},
+	}
+}
+
+func dataSourceNamecheapDomainRecordsRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*namecheap.Client)
+	domain := strings.ToLower(data.Get("domain").(string))
+
+	// Read the DNS/nameserver state first (mirrors the resource read ordering):
+	// a domain on custom nameservers exposes those, otherwise the record set.
+	nsResp, err := client.DomainsDNS.GetListWithContext(ctx, domain)
+	if err != nil {
+		return dataSourceDomainReadError(domain, err)
+	}
+	if err := validateGetListResponse(nsResp); err != nil {
+		return dataSourceDomainReadError(domain, err)
+	}
+
+	nameservers := []string{}
+	if !*nsResp.DomainDNSGetListResult.IsUsingOurDNS && nsResp.DomainDNSGetListResult.Nameservers != nil {
+		nameservers = *nsResp.DomainDNSGetListResult.Nameservers
+	}
+	if err := data.Set("nameservers", nameservers); err != nil {
+		return diag.FromErr(err)
+	}
+
+	hostsResp, err := client.DomainsDNS.GetHostsWithContext(ctx, domain)
+	if err != nil {
+		return dataSourceDomainReadError(domain, err)
+	}
+	if err := validateGetHostsResponse(hostsResp); err != nil {
+		return dataSourceDomainReadError(domain, err)
+	}
+
+	if err := data.Set("email_type", derefString(hostsResp.DomainDNSGetHostsResult.EmailType)); err != nil {
+		return diag.FromErr(err)
+	}
+
+	records := []map[string]interface{}{}
+	if hostsResp.DomainDNSGetHostsResult.Hosts != nil {
+		for i := range *hostsResp.DomainDNSGetHostsResult.Hosts {
+			records = append(records, flattenHostRecord(&(*hostsResp.DomainDNSGetHostsResult.Hosts)[i]))
+		}
+	}
+	if err := data.Set("records", records); err != nil {
+		return diag.FromErr(err)
+	}
+
+	data.SetId(domain)
+	return nil
+}

--- a/namecheap/data_source_namecheap_domains.go
+++ b/namecheap/data_source_namecheap_domains.go
@@ -59,38 +59,11 @@ func dataSourceNamecheapDomainsRead(ctx context.Context, data *schema.ResourceDa
 	listType := data.Get("list_type").(string)
 	searchTerm := data.Get("search_term").(string)
 
-	var allDomains []namecheap.Domain
-	for page := 1; ; page++ {
-		args := &namecheap.DomainsGetListArgs{
-			ListType: namecheap.String(listType),
-			Page:     namecheap.Int(page),
-			PageSize: namecheap.Int(domainsPageSize),
-		}
-		if searchTerm != "" {
-			args.SearchTerm = namecheap.String(searchTerm)
-		}
-
-		resp, err := client.Domains.GetListWithContext(ctx, args)
-		if err != nil {
-			return diagFromClientError(err)
-		}
-		if resp == nil {
-			return diag.Errorf("Namecheap returned an empty response while listing domains (page %d)", page)
-		}
-
-		if resp.Domains != nil {
-			allDomains = append(allDomains, *resp.Domains...)
-		}
-
-		// Stop when the paging block indicates every item has been fetched.
-		// When paging is absent or degenerate, stop after the current page so a
-		// malformed response cannot spin an unbounded loop.
-		if resp.Paging == nil || resp.Paging.TotalItems == nil || resp.Paging.PageSize == nil || *resp.Paging.PageSize <= 0 {
-			break
-		}
-		if page*(*resp.Paging.PageSize) >= *resp.Paging.TotalItems {
-			break
-		}
+	// fetchAllDomains walks every page of the filtered listing (shared with the
+	// single-domain lifecycle lookup) so the returned set is always complete.
+	allDomains, err := fetchAllDomains(ctx, client, listType, searchTerm)
+	if err != nil {
+		return diagFromClientError(err)
 	}
 
 	now := time.Now().UTC()

--- a/namecheap/data_source_namecheap_domains.go
+++ b/namecheap/data_source_namecheap_domains.go
@@ -1,0 +1,108 @@
+package namecheap_provider
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/namecheap/go-namecheap-sdk/v2/namecheap"
+)
+
+const (
+	domainsListTypeAll      = "ALL"
+	domainsListTypeExpiring = "EXPIRING"
+	domainsListTypeExpired  = "EXPIRED"
+
+	// domainsPageSize is the per-request page size used while paginating
+	// getList. The Namecheap API caps PageSize at 100.
+	domainsPageSize = 100
+)
+
+// dataSourceNamecheapDomains lists the account's domain portfolio via the
+// namecheap.domains.getList API command, auto-paginating across all pages so
+// the returned domains attribute always reflects the complete result set for
+// the given filters.
+func dataSourceNamecheapDomains() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceNamecheapDomainsRead,
+		Schema: map[string]*schema.Schema{
+			"search_term": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Optional keyword to filter the returned domains (maps to the getList SearchTerm parameter).",
+			},
+			"list_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      domainsListTypeAll,
+				ValidateFunc: validation.StringInSlice([]string{domainsListTypeAll, domainsListTypeExpiring, domainsListTypeExpired}, false),
+				Description:  "Which subset of the account's domains to return. Possible values: ALL (default), EXPIRING, EXPIRED (maps to the getList ListType parameter).",
+			},
+			"domains": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The domains in the account matching the filters.",
+				Elem: &schema.Resource{
+					Schema: domainPortfolioElemSchema(),
+				},
+			},
+		},
+	}
+}
+
+func dataSourceNamecheapDomainsRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*namecheap.Client)
+
+	listType := data.Get("list_type").(string)
+	searchTerm := data.Get("search_term").(string)
+
+	var allDomains []namecheap.Domain
+	for page := 1; ; page++ {
+		args := &namecheap.DomainsGetListArgs{
+			ListType: namecheap.String(listType),
+			Page:     namecheap.Int(page),
+			PageSize: namecheap.Int(domainsPageSize),
+		}
+		if searchTerm != "" {
+			args.SearchTerm = namecheap.String(searchTerm)
+		}
+
+		resp, err := client.Domains.GetListWithContext(ctx, args)
+		if err != nil {
+			return diagFromClientError(err)
+		}
+		if resp == nil {
+			return diag.Errorf("Namecheap returned an empty response while listing domains (page %d)", page)
+		}
+
+		if resp.Domains != nil {
+			allDomains = append(allDomains, *resp.Domains...)
+		}
+
+		// Stop when the paging block indicates every item has been fetched.
+		// When paging is absent or degenerate, stop after the current page so a
+		// malformed response cannot spin an unbounded loop.
+		if resp.Paging == nil || resp.Paging.TotalItems == nil || resp.Paging.PageSize == nil || *resp.Paging.PageSize <= 0 {
+			break
+		}
+		if page*(*resp.Paging.PageSize) >= *resp.Paging.TotalItems {
+			break
+		}
+	}
+
+	now := time.Now().UTC()
+	result := make([]map[string]interface{}, 0, len(allDomains))
+	for i := range allDomains {
+		result = append(result, flattenPortfolioDomain(&allDomains[i], now))
+	}
+
+	if err := data.Set("domains", result); err != nil {
+		return diag.FromErr(err)
+	}
+
+	data.SetId(fmt.Sprintf("domains:%s:%s", listType, searchTerm))
+	return nil
+}

--- a/namecheap/data_source_read_test.go
+++ b/namecheap/data_source_read_test.go
@@ -1,0 +1,394 @@
+package namecheap_provider
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/namecheap/go-namecheap-sdk/v2/namecheap"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests exercise the data-source ReadContext functions directly against an
+// in-process httptest server, driving the real go-namecheap-sdk client. Unlike
+// the testacc mock suite (which the coverage upload does not observe because it
+// is gated behind the `testacc` build tag), these are ordinary unit tests, so
+// they exercise — and count coverage for — the read/pagination/error paths.
+
+// newDataSourceTestClient builds an SDK client whose requests are directed at
+// baseURL, with client-side rate limiting disabled so a test issuing several
+// calls does not stall on the limiter.
+func newDataSourceTestClient(baseURL string) *namecheap.Client {
+	client := namecheap.NewClient(&namecheap.ClientOptions{
+		UserName:  "unit-user",
+		ApiUser:   "unit-user",
+		ApiKey:    "unit-key",
+		ClientIp:  "127.0.0.1",
+		RateLimit: &namecheap.RateLimitOptions{Disabled: true},
+	})
+	client.BaseURL = baseURL
+	return client
+}
+
+// startDataSourceServer starts an httptest server routing on the request's
+// Command form value to handler, returns an SDK client bound to it, and
+// registers server shutdown with t.Cleanup.
+func startDataSourceServer(t *testing.T, handler func(command string, r *http.Request) string) *namecheap.Client {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		w.Header().Set("Content-Type", "text/xml")
+		_, _ = io.WriteString(w, handler(r.FormValue("Command"), r))
+	}))
+	t.Cleanup(srv.Close)
+	return newDataSourceTestClient(srv.URL)
+}
+
+// --- XML builders (mirror the real API envelopes the SDK parses) ------------
+
+func xmlGetInfo(domain string, isPremium, isPremiumDNS bool, providerType string, isOurDNS bool, nameservers []string) string {
+	var ns []string
+	for _, n := range nameservers {
+		ns = append(ns, fmt.Sprintf(`<Nameserver>%s</Nameserver>`, n))
+	}
+	return fmt.Sprintf(`<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+  <Errors />
+  <CommandResponse Type="namecheap.domains.getInfo">
+    <DomainGetInfoResult DomainName="%s" IsPremium="%t">
+      <PremiumDnsSubscription><IsActive>%t</IsActive></PremiumDnsSubscription>
+      <DnsDetails ProviderType="%s" IsUsingOurDNS="%t">
+        %s
+      </DnsDetails>
+    </DomainGetInfoResult>
+  </CommandResponse>
+</ApiResponse>`, domain, isPremium, isPremiumDNS, providerType, isOurDNS, strings.Join(ns, "\n        "))
+}
+
+// dsDomainRow is a single portfolio row for building a getList response.
+type dsDomainRow struct {
+	ID, Name, User, Created, Expires, WhoisGuard        string
+	IsExpired, IsLocked, AutoRenew, IsPremium, IsOurDNS bool
+}
+
+func xmlGetListPage(rows []dsDomainRow, total, page, pageSize int) string {
+	var lines []string
+	for _, d := range rows {
+		lines = append(lines, fmt.Sprintf(
+			`<Domain ID="%s" Name="%s" User="%s" Created="%s" Expires="%s" IsExpired="%t" IsLocked="%t" AutoRenew="%t" WhoisGuard="%s" IsPremium="%t" IsOurDNS="%t" />`,
+			d.ID, d.Name, d.User, d.Created, d.Expires, d.IsExpired, d.IsLocked, d.AutoRenew, d.WhoisGuard, d.IsPremium, d.IsOurDNS))
+	}
+	return fmt.Sprintf(`<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+  <Errors />
+  <CommandResponse Type="namecheap.domains.getList">
+    <DomainGetListResult>
+      %s
+    </DomainGetListResult>
+    <Paging>
+      <TotalItems>%d</TotalItems>
+      <CurrentPage>%d</CurrentPage>
+      <PageSize>%d</PageSize>
+    </Paging>
+  </CommandResponse>
+</ApiResponse>`, strings.Join(lines, "\n      "), total, page, pageSize)
+}
+
+func xmlDNSGetList(domain string, isUsingOurDNS bool, nameservers []string) string {
+	var ns []string
+	for _, n := range nameservers {
+		ns = append(ns, fmt.Sprintf(`<Nameserver>%s</Nameserver>`, n))
+	}
+	return fmt.Sprintf(`<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+  <Errors />
+  <CommandResponse Type="namecheap.domains.dns.getList">
+    <DomainDNSGetListResult Domain="%s" IsUsingOurDNS="%t" IsPremiumDNS="false" IsUsingFreeDNS="false">
+      %s
+    </DomainDNSGetListResult>
+  </CommandResponse>
+</ApiResponse>`, domain, isUsingOurDNS, strings.Join(ns, "\n      "))
+}
+
+type dsHost struct {
+	Name, Type, Address string
+	MXPref, TTL         int
+}
+
+func xmlDNSGetHosts(domain, emailType string, hosts []dsHost) string {
+	var lines []string
+	for i, h := range hosts {
+		lines = append(lines, fmt.Sprintf(
+			`<host HostId="%d" Name="%s" Type="%s" Address="%s" MXPref="%d" TTL="%d" AssociatedAppTitle="" FriendlyName="" IsActive="true" IsDDNSEnabled="false" />`,
+			i+1, h.Name, h.Type, h.Address, h.MXPref, h.TTL))
+	}
+	return fmt.Sprintf(`<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+  <Errors />
+  <CommandResponse Type="namecheap.domains.dns.getHosts">
+    <DomainDNSGetHostsResult Domain="%s" EmailType="%s" IsUsingOurDNS="true">
+      %s
+    </DomainDNSGetHostsResult>
+  </CommandResponse>
+</ApiResponse>`, domain, emailType, strings.Join(lines, "\n      "))
+}
+
+// --- namecheap_domain --------------------------------------------------------
+
+func TestDataSourceDomainRead_Success(t *testing.T) {
+	const domain = "example.com"
+	client := startDataSourceServer(t, func(command string, _ *http.Request) string {
+		switch command {
+		case "namecheap.domains.getInfo":
+			return xmlGetInfo(domain, true, true, "CUSTOM", false, []string{"ns1.example.net", "ns2.example.net"})
+		case "namecheap.domains.getList":
+			return xmlGetListPage([]dsDomainRow{
+				{ID: "42", Name: domain, User: "u", Created: "06/02/2021", Expires: "06/02/2099", WhoisGuard: "ENABLED", IsLocked: true, AutoRenew: true, IsOurDNS: true},
+			}, 1, 1, domainsPageSize)
+		}
+		return apiErrorXML("1010101", "unexpected command "+command)
+	})
+
+	d := schema.TestResourceDataRaw(t, dataSourceNamecheapDomain().Schema, map[string]interface{}{"domain": domain})
+	diags := dataSourceNamecheapDomainRead(context.Background(), d, client)
+	require.False(t, diags.HasError(), "unexpected diagnostics: %+v", diags)
+
+	// getInfo-sourced fields.
+	assert.Equal(t, "CUSTOM", d.Get("dns_provider_type"))
+	assert.Equal(t, false, d.Get("is_our_dns"))
+	assert.Equal(t, true, d.Get("is_premium"))
+	assert.Equal(t, true, d.Get("is_premium_dns"))
+	assert.Equal(t, []interface{}{"ns1.example.net", "ns2.example.net"}, d.Get("nameservers"))
+	// getList-sourced lifecycle fields (the gap this change closes).
+	assert.Equal(t, "2099-06-02T00:00:00Z", d.Get("expires"))
+	assert.Equal(t, "2021-06-02T00:00:00Z", d.Get("created"))
+	assert.Equal(t, true, d.Get("is_locked"))
+	assert.Equal(t, true, d.Get("auto_renew"))
+	assert.Equal(t, "ENABLED", d.Get("whois_guard"))
+	assert.Equal(t, false, d.Get("is_expired"))
+	assert.Greater(t, d.Get("expires_in_days").(int), 0)
+	assert.Equal(t, domain, d.Id())
+}
+
+func TestDataSourceDomainRead_NotFound(t *testing.T) {
+	const domain = "does-not-exist-abc123.com"
+	client := startDataSourceServer(t, func(command string, _ *http.Request) string {
+		return apiErrorXML("2019166", fmt.Sprintf("Domain %q not found", domain))
+	})
+
+	d := schema.TestResourceDataRaw(t, dataSourceNamecheapDomain().Schema, map[string]interface{}{"domain": domain})
+	diags := dataSourceNamecheapDomainRead(context.Background(), d, client)
+	require.True(t, diags.HasError(), "expected an error for an unknown domain")
+	assert.Contains(t, diags[0].Summary, domain, "diagnostic should name the domain")
+}
+
+func TestDataSourceDomainRead_LifecycleMissing(t *testing.T) {
+	const domain = "example.com"
+	// getInfo confirms the domain exists, but the portfolio listing returns a
+	// different domain, so the exact-match finds nothing: lifecycle fields stay
+	// at their zero values and the read still succeeds.
+	client := startDataSourceServer(t, func(command string, _ *http.Request) string {
+		switch command {
+		case "namecheap.domains.getInfo":
+			return xmlGetInfo(domain, false, false, "NAMECHEAP", true, []string{"dns1.registrar-servers.com"})
+		case "namecheap.domains.getList":
+			return xmlGetListPage([]dsDomainRow{
+				{ID: "7", Name: "other-domain.com", User: "u", Created: "01/01/2020", Expires: "01/01/2030"},
+			}, 1, 1, domainsPageSize)
+		}
+		return apiErrorXML("1010101", "unexpected command "+command)
+	})
+
+	d := schema.TestResourceDataRaw(t, dataSourceNamecheapDomain().Schema, map[string]interface{}{"domain": domain})
+	diags := dataSourceNamecheapDomainRead(context.Background(), d, client)
+	require.False(t, diags.HasError(), "unexpected diagnostics: %+v", diags)
+	assert.Equal(t, "NAMECHEAP", d.Get("dns_provider_type"))
+	assert.Equal(t, "", d.Get("expires"), "lifecycle field should be empty when the domain is absent from the listing")
+	assert.Equal(t, "", d.Get("whois_guard"))
+}
+
+func TestDataSourceDomainRead_GetListError(t *testing.T) {
+	const domain = "example.com"
+	client := startDataSourceServer(t, func(command string, _ *http.Request) string {
+		switch command {
+		case "namecheap.domains.getInfo":
+			return xmlGetInfo(domain, false, false, "NAMECHEAP", true, nil)
+		case "namecheap.domains.getList":
+			return apiErrorXML("4022336", "portfolio listing failed")
+		}
+		return apiErrorXML("1010101", "unexpected command "+command)
+	})
+
+	d := schema.TestResourceDataRaw(t, dataSourceNamecheapDomain().Schema, map[string]interface{}{"domain": domain})
+	diags := dataSourceNamecheapDomainRead(context.Background(), d, client)
+	require.True(t, diags.HasError(), "a getList transport/API error should surface")
+	assert.Contains(t, diags[0].Summary, domain)
+}
+
+// --- namecheap_domains -------------------------------------------------------
+
+func TestDataSourceDomainsRead_MultiPage(t *testing.T) {
+	rows := []dsDomainRow{
+		{ID: "1", Name: "one-example.com", User: "u", Created: "06/02/2021", Expires: "06/02/2099", WhoisGuard: "ENABLED", AutoRenew: true, IsOurDNS: true},
+		{ID: "2", Name: "two-example.com", User: "u", Created: "06/02/2021", Expires: "06/02/2099", WhoisGuard: "ENABLED", AutoRenew: true, IsOurDNS: true},
+		{ID: "3", Name: "three-example.com", User: "u", Created: "06/02/2021", Expires: "01/01/2000", WhoisGuard: "DISABLED", IsExpired: true},
+	}
+	var mu sync.Mutex
+	var calls int
+	const pageSize = 1 // force one row per page -> three pages
+	client := startDataSourceServer(t, func(command string, r *http.Request) string {
+		if command != "namecheap.domains.getList" {
+			return apiErrorXML("1010101", "unexpected command "+command)
+		}
+		mu.Lock()
+		calls++
+		mu.Unlock()
+		page, _ := strconv.Atoi(r.FormValue("Page"))
+		if page < 1 {
+			page = 1
+		}
+		start := (page - 1) * pageSize
+		end := start + pageSize
+		if start > len(rows) {
+			start = len(rows)
+		}
+		if end > len(rows) {
+			end = len(rows)
+		}
+		return xmlGetListPage(rows[start:end], len(rows), page, pageSize)
+	})
+
+	d := schema.TestResourceDataRaw(t, dataSourceNamecheapDomains().Schema, map[string]interface{}{"list_type": "ALL"})
+	diags := dataSourceNamecheapDomainsRead(context.Background(), d, client)
+	require.False(t, diags.HasError(), "unexpected diagnostics: %+v", diags)
+
+	domains := d.Get("domains").([]interface{})
+	require.Len(t, domains, 3, "all three domains across all pages must be returned")
+	assert.GreaterOrEqual(t, calls, 3, "expected at least one getList call per page")
+
+	first := domains[0].(map[string]interface{})
+	assert.Equal(t, "one-example.com", first["name"])
+	assert.Equal(t, "2099-06-02T00:00:00Z", first["expires"])
+	assert.Greater(t, first["expires_in_days"].(int), 0)
+
+	third := domains[2].(map[string]interface{})
+	assert.Equal(t, true, third["is_expired"])
+	assert.Less(t, third["expires_in_days"].(int), 0, "an expired domain should have a negative expires_in_days")
+}
+
+func TestDataSourceDomainsRead_Empty(t *testing.T) {
+	client := startDataSourceServer(t, func(command string, _ *http.Request) string {
+		if command == "namecheap.domains.getList" {
+			return xmlGetListPage(nil, 0, 1, domainsPageSize)
+		}
+		return apiErrorXML("1010101", "unexpected command "+command)
+	})
+
+	d := schema.TestResourceDataRaw(t, dataSourceNamecheapDomains().Schema, map[string]interface{}{"list_type": "ALL"})
+	diags := dataSourceNamecheapDomainsRead(context.Background(), d, client)
+	require.False(t, diags.HasError(), "an empty portfolio must not be an error")
+	assert.Empty(t, d.Get("domains").([]interface{}))
+}
+
+func TestDataSourceDomainsRead_Error(t *testing.T) {
+	client := startDataSourceServer(t, func(command string, _ *http.Request) string {
+		return apiErrorXML("4022336", "listing failed")
+	})
+
+	d := schema.TestResourceDataRaw(t, dataSourceNamecheapDomains().Schema, map[string]interface{}{"list_type": "ALL"})
+	diags := dataSourceNamecheapDomainsRead(context.Background(), d, client)
+	assert.True(t, diags.HasError(), "a getList API error should surface")
+}
+
+// --- namecheap_domain_records ------------------------------------------------
+
+func TestDataSourceDomainRecordsRead_OurDNS(t *testing.T) {
+	const domain = "records-example.com"
+	client := startDataSourceServer(t, func(command string, _ *http.Request) string {
+		switch command {
+		case "namecheap.domains.dns.getList":
+			return xmlDNSGetList(domain, true, nil)
+		case "namecheap.domains.dns.getHosts":
+			return xmlDNSGetHosts(domain, "MX", []dsHost{
+				{Name: "@", Type: "A", Address: "10.0.0.1", MXPref: 10, TTL: 1800},
+				{Name: "www", Type: "CNAME", Address: "records-example.com.", MXPref: 10, TTL: 3600},
+			})
+		}
+		return apiErrorXML("1010101", "unexpected command "+command)
+	})
+
+	d := schema.TestResourceDataRaw(t, dataSourceNamecheapDomainRecords().Schema, map[string]interface{}{"domain": domain})
+	diags := dataSourceNamecheapDomainRecordsRead(context.Background(), d, client)
+	require.False(t, diags.HasError(), "unexpected diagnostics: %+v", diags)
+
+	assert.Equal(t, "MX", d.Get("email_type"))
+	assert.Empty(t, d.Get("nameservers").([]interface{}))
+	records := d.Get("records").([]interface{})
+	require.Len(t, records, 2)
+	first := records[0].(map[string]interface{})
+	assert.Equal(t, "@", first["hostname"])
+	assert.Equal(t, "A", first["type"])
+	assert.Equal(t, "10.0.0.1", first["address"])
+	assert.Equal(t, 1800, first["ttl"])
+	assert.Equal(t, domain, d.Id())
+}
+
+func TestDataSourceDomainRecordsRead_CustomNS(t *testing.T) {
+	const domain = "custom-ns-example.com"
+	client := startDataSourceServer(t, func(command string, _ *http.Request) string {
+		switch command {
+		case "namecheap.domains.dns.getList":
+			return xmlDNSGetList(domain, false, []string{"dns1.p01.nsone.net", "dns2.p01.nsone.net"})
+		case "namecheap.domains.dns.getHosts":
+			return xmlDNSGetHosts(domain, "NONE", nil)
+		}
+		return apiErrorXML("1010101", "unexpected command "+command)
+	})
+
+	d := schema.TestResourceDataRaw(t, dataSourceNamecheapDomainRecords().Schema, map[string]interface{}{"domain": domain})
+	diags := dataSourceNamecheapDomainRecordsRead(context.Background(), d, client)
+	require.False(t, diags.HasError(), "unexpected diagnostics: %+v", diags)
+
+	ns := d.Get("nameservers").([]interface{})
+	require.Len(t, ns, 2)
+	assert.Equal(t, "dns1.p01.nsone.net", ns[0])
+	assert.Empty(t, d.Get("records").([]interface{}))
+}
+
+func TestDataSourceDomainRecordsRead_GetListError(t *testing.T) {
+	const domain = "records-example.com"
+	client := startDataSourceServer(t, func(command string, _ *http.Request) string {
+		return apiErrorXML("2019166", fmt.Sprintf("Domain %q not found", domain))
+	})
+
+	d := schema.TestResourceDataRaw(t, dataSourceNamecheapDomainRecords().Schema, map[string]interface{}{"domain": domain})
+	diags := dataSourceNamecheapDomainRecordsRead(context.Background(), d, client)
+	require.True(t, diags.HasError(), "a dns.getList error should surface")
+	assert.Contains(t, diags[0].Summary, domain)
+}
+
+func TestDataSourceDomainRecordsRead_GetHostsError(t *testing.T) {
+	const domain = "records-example.com"
+	client := startDataSourceServer(t, func(command string, _ *http.Request) string {
+		switch command {
+		case "namecheap.domains.dns.getList":
+			return xmlDNSGetList(domain, true, nil)
+		case "namecheap.domains.dns.getHosts":
+			return apiErrorXML("4022336", "getHosts failed")
+		}
+		return apiErrorXML("1010101", "unexpected command "+command)
+	})
+
+	d := schema.TestResourceDataRaw(t, dataSourceNamecheapDomainRecords().Schema, map[string]interface{}{"domain": domain})
+	diags := dataSourceNamecheapDomainRecordsRead(context.Background(), d, client)
+	require.True(t, diags.HasError(), "a dns.getHosts error should surface")
+	assert.Contains(t, diags[0].Summary, domain)
+}

--- a/namecheap/data_source_test.go
+++ b/namecheap/data_source_test.go
@@ -1,0 +1,108 @@
+package namecheap_provider
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/namecheap/go-namecheap-sdk/v2/namecheap"
+	"github.com/stretchr/testify/assert"
+)
+
+// ncDate builds a *namecheap.DateTime from a Namecheap "MM/DD/YYYY" date string,
+// exercising the same UnmarshalText path the SDK uses to parse API responses.
+func ncDate(t *testing.T, s string) *namecheap.DateTime {
+	t.Helper()
+	dt := &namecheap.DateTime{}
+	if err := dt.UnmarshalText([]byte(s)); err != nil {
+		t.Fatalf("failed to parse date %q: %v", s, err)
+	}
+	return dt
+}
+
+// TestDataSourcesRegistered asserts the provider exposes the three data sources.
+func TestDataSourcesRegistered(t *testing.T) {
+	p := Provider()
+	for _, name := range []string{"namecheap_domain", "namecheap_domains", "namecheap_domain_records"} {
+		ds, ok := p.DataSourcesMap[name]
+		assert.True(t, ok, "data source %s should be registered", name)
+		assert.NotNil(t, ds, "data source %s should be non-nil", name)
+	}
+}
+
+// TestDataSourcesInternalValidate makes sure the registered data-source schemas
+// pass the SDK's internal validation (part of Provider().InternalValidate, but
+// asserted explicitly here for a targeted failure signal).
+func TestDataSourcesInternalValidate(t *testing.T) {
+	assert.NoError(t, Provider().InternalValidate())
+}
+
+// TestDomainRecordFieldParity asserts that the record object shape exported by
+// the namecheap_domain_records data source matches the record block of the
+// namecheap_domain_records resource attribute-for-attribute, so a data-source
+// record composes into a resource record block without field remapping.
+func TestDomainRecordFieldParity(t *testing.T) {
+	resourceRecord := resourceNamecheapDomainRecords().Schema["record"]
+	resourceElem := resourceRecord.Elem.(*schema.Resource).Schema
+
+	dataElem := domainRecordElemSchema()
+
+	assert.Equal(t, len(resourceElem), len(dataElem),
+		"data source record object must have the same number of attributes as the resource record block")
+
+	for name, resAttr := range resourceElem {
+		dsAttr, ok := dataElem[name]
+		assert.True(t, ok, "data source record object is missing attribute %q present on the resource", name)
+		if ok {
+			assert.Equal(t, resAttr.Type, dsAttr.Type,
+				"attribute %q should have the same type on the data source and the resource", name)
+		}
+	}
+	for name := range dataElem {
+		_, ok := resourceElem[name]
+		assert.True(t, ok, "data source record object has extra attribute %q not present on the resource", name)
+	}
+}
+
+func TestFormatDateTime(t *testing.T) {
+	assert.Equal(t, "", formatDateTime(nil), "nil DateTime should render as empty string")
+
+	dt := ncDate(t, "06/02/2027")
+	assert.Equal(t, "2027-06-02T00:00:00Z", formatDateTime(dt),
+		"a Namecheap date should render as an RFC3339 midnight-UTC timestamp")
+}
+
+func TestDaysUntil(t *testing.T) {
+	// Pin "now" to an arbitrary time-of-day to prove the calculation ignores
+	// the wall-clock time and is purely calendar-date based.
+	now := time.Date(2026, 7, 9, 15, 30, 0, 0, time.UTC)
+
+	cases := []struct {
+		name   string
+		target time.Time
+		want   int
+	}{
+		{"same calendar day, earlier time", time.Date(2026, 7, 9, 0, 0, 0, 0, time.UTC), 0},
+		{"same calendar day, later time", time.Date(2026, 7, 9, 23, 59, 59, 0, time.UTC), 0},
+		{"tomorrow", time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC), 1},
+		{"yesterday", time.Date(2026, 7, 8, 0, 0, 0, 0, time.UTC), -1},
+		{"thirty days out", time.Date(2026, 8, 8, 0, 0, 0, 0, time.UTC), 30},
+		{"one year in the past", time.Date(2025, 7, 9, 0, 0, 0, 0, time.UTC), -365},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, daysUntil(tc.target, now))
+		})
+	}
+}
+
+// TestDaysUntilTimezoneSafe proves that a target expressed in a non-UTC zone is
+// reduced to its UTC calendar date before counting, so the result does not drift
+// with the input timezone.
+func TestDaysUntilTimezoneSafe(t *testing.T) {
+	now := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+	// 2026-07-10T01:00:00+05:00 is 2026-07-09T20:00:00Z -> same UTC day as now.
+	loc := time.FixedZone("UTC+5", 5*60*60)
+	target := time.Date(2026, 7, 10, 1, 0, 0, 0, loc)
+	assert.Equal(t, 0, daysUntil(target, now))
+}

--- a/namecheap/mock_data_source_test.go
+++ b/namecheap/mock_data_source_test.go
@@ -12,8 +12,10 @@ import (
 )
 
 // TestAccMockDataSourceDomain reads a single domain via namecheap_domain against
-// the stateful mock (namecheap.domains.getInfo) and asserts the exported
-// attributes match the seeded getInfo response.
+// the stateful mock and asserts the exported attributes. It exercises the
+// two-call design end-to-end: the DNS-oriented fields come from
+// namecheap.domains.getInfo and the lifecycle fields (created/expires/is_locked/
+// auto_renew/whois_guard/is_expired) come from namecheap.domains.getList.
 func TestAccMockDataSourceDomain(t *testing.T) {
 	m := newNamecheapMock(t)
 	const domain = "info-example.com"
@@ -24,6 +26,10 @@ func TestAccMockDataSourceDomain(t *testing.T) {
 		IsUsingOurDNS: false,
 		Nameservers:   []string{"ns1.example.net", "ns2.example.net"},
 	})
+	// Seed the portfolio listing so the getList-sourced lifecycle fields resolve.
+	m.seedPortfolio(0,
+		mockPortfolioDomain{ID: "10", Name: domain, User: "mock-user", Created: "06/02/2021", Expires: "06/02/2099", WhoisGuard: "ENABLED", IsExpired: false, IsLocked: true, AutoRenew: true, IsPremium: true, IsOurDNS: false},
+	)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { mockPreCheck(t, m) },
@@ -36,6 +42,7 @@ data "namecheap_domain" "test" {
 }
 `, domain),
 				Check: resource.ComposeTestCheckFunc(
+					// getInfo-sourced.
 					resource.TestCheckResourceAttr("data.namecheap_domain.test", "dns_provider_type", "CUSTOM"),
 					resource.TestCheckResourceAttr("data.namecheap_domain.test", "is_our_dns", "false"),
 					resource.TestCheckResourceAttr("data.namecheap_domain.test", "is_premium", "true"),
@@ -43,6 +50,13 @@ data "namecheap_domain" "test" {
 					resource.TestCheckResourceAttr("data.namecheap_domain.test", "nameservers.#", "2"),
 					resource.TestCheckResourceAttr("data.namecheap_domain.test", "nameservers.0", "ns1.example.net"),
 					resource.TestCheckResourceAttr("data.namecheap_domain.test", "nameservers.1", "ns2.example.net"),
+					// getList-sourced lifecycle fields.
+					resource.TestCheckResourceAttr("data.namecheap_domain.test", "created", "2021-06-02T00:00:00Z"),
+					resource.TestCheckResourceAttr("data.namecheap_domain.test", "expires", "2099-06-02T00:00:00Z"),
+					resource.TestCheckResourceAttr("data.namecheap_domain.test", "is_expired", "false"),
+					resource.TestCheckResourceAttr("data.namecheap_domain.test", "is_locked", "true"),
+					resource.TestCheckResourceAttr("data.namecheap_domain.test", "auto_renew", "true"),
+					resource.TestCheckResourceAttr("data.namecheap_domain.test", "whois_guard", "ENABLED"),
 				),
 			},
 		},

--- a/namecheap/mock_data_source_test.go
+++ b/namecheap/mock_data_source_test.go
@@ -1,0 +1,290 @@
+//go:build testacc
+
+package namecheap_provider
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+// TestAccMockDataSourceDomain reads a single domain via namecheap_domain against
+// the stateful mock (namecheap.domains.getInfo) and asserts the exported
+// attributes match the seeded getInfo response.
+func TestAccMockDataSourceDomain(t *testing.T) {
+	m := newNamecheapMock(t)
+	const domain = "info-example.com"
+	m.seedInfo(domain, mockDomainInfo{
+		IsPremium:     true,
+		IsPremiumDNS:  true,
+		ProviderType:  "CUSTOM",
+		IsUsingOurDNS: false,
+		Nameservers:   []string{"ns1.example.net", "ns2.example.net"},
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { mockPreCheck(t, m) },
+		ProviderFactories: mockProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+data "namecheap_domain" "test" {
+  domain = "%s"
+}
+`, domain),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.namecheap_domain.test", "dns_provider_type", "CUSTOM"),
+					resource.TestCheckResourceAttr("data.namecheap_domain.test", "is_our_dns", "false"),
+					resource.TestCheckResourceAttr("data.namecheap_domain.test", "is_premium", "true"),
+					resource.TestCheckResourceAttr("data.namecheap_domain.test", "is_premium_dns", "true"),
+					resource.TestCheckResourceAttr("data.namecheap_domain.test", "nameservers.#", "2"),
+					resource.TestCheckResourceAttr("data.namecheap_domain.test", "nameservers.0", "ns1.example.net"),
+					resource.TestCheckResourceAttr("data.namecheap_domain.test", "nameservers.1", "ns2.example.net"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccMockDataSourceDomainNotFound asserts that looking up a domain the
+// account does not own yields a diagnostic that names the domain.
+func TestAccMockDataSourceDomainNotFound(t *testing.T) {
+	m := newNamecheapMock(t)
+	const missing = "does-not-exist-9f8e7d.com"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { mockPreCheck(t, m) },
+		ProviderFactories: mockProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+data "namecheap_domain" "missing" {
+  domain = "%s"
+}
+`, missing),
+				ExpectError: regexp.MustCompile(regexp.QuoteMeta(missing)),
+			},
+		},
+	})
+}
+
+// TestAccMockDataSourceDomainsEmpty asserts an empty portfolio reads cleanly as
+// a zero-length list.
+func TestAccMockDataSourceDomainsEmpty(t *testing.T) {
+	m := newNamecheapMock(t)
+	m.seedPortfolio(0) // no domains
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { mockPreCheck(t, m) },
+		ProviderFactories: mockProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: `
+data "namecheap_domains" "all" {
+  list_type = "ALL"
+}
+`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.namecheap_domains.all", "domains.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccMockDataSourceDomainsSinglePage reads a small portfolio that fits in a
+// single page and asserts the mapped fields (including the RFC3339 date and
+// expires_in_days convenience).
+func TestAccMockDataSourceDomainsSinglePage(t *testing.T) {
+	m := newNamecheapMock(t)
+	m.seedPortfolio(0,
+		mockPortfolioDomain{ID: "1", Name: "alpha-example.com", User: "mock-user", Created: "06/02/2021", Expires: "06/02/2099", WhoisGuard: "ENABLED", IsExpired: false, IsLocked: true, AutoRenew: true, IsPremium: false, IsOurDNS: true},
+		mockPortfolioDomain{ID: "2", Name: "beta-example.net", User: "mock-user", Created: "01/15/2020", Expires: "01/15/2021", WhoisGuard: "DISABLED", IsExpired: true, IsLocked: false, AutoRenew: false, IsPremium: true, IsOurDNS: false},
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { mockPreCheck(t, m) },
+		ProviderFactories: mockProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: `
+data "namecheap_domains" "all" {
+  list_type = "ALL"
+}
+`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.namecheap_domains.all", "domains.#", "2"),
+					resource.TestCheckResourceAttr("data.namecheap_domains.all", "domains.0.name", "alpha-example.com"),
+					resource.TestCheckResourceAttr("data.namecheap_domains.all", "domains.0.expires", "2099-06-02T00:00:00Z"),
+					resource.TestCheckResourceAttr("data.namecheap_domains.all", "domains.0.is_locked", "true"),
+					resource.TestCheckResourceAttr("data.namecheap_domains.all", "domains.0.is_expired", "false"),
+					resource.TestCheckResourceAttr("data.namecheap_domains.all", "domains.0.is_our_dns", "true"),
+					resource.TestCheckResourceAttr("data.namecheap_domains.all", "domains.1.name", "beta-example.net"),
+					resource.TestCheckResourceAttr("data.namecheap_domains.all", "domains.1.is_expired", "true"),
+					resource.TestCheckResourceAttr("data.namecheap_domains.all", "domains.1.whois_guard", "DISABLED"),
+					// beta expired on 2021-01-15, well in the past -> negative.
+					resource.TestCheckResourceAttrWith("data.namecheap_domains.all", "domains.1.expires_in_days", func(v string) error {
+						if v == "" || v[0] != '-' {
+							return fmt.Errorf("expected a negative expires_in_days for an expired domain, got %q", v)
+						}
+						return nil
+					}),
+				),
+			},
+		},
+	})
+}
+
+// TestAccMockDataSourceDomainsPagination proves the data source paginates the
+// full portfolio: with a mock page-size cap of 1 and three seeded domains, all
+// three must be returned and the mock must have served getList at least once per
+// page (a positive multiple of three).
+func TestAccMockDataSourceDomainsPagination(t *testing.T) {
+	m := newNamecheapMock(t)
+	m.seedPortfolio(1, // cap page size to 1 -> forces 3 pages
+		mockPortfolioDomain{ID: "1", Name: "one-example.com", User: "mock-user", Created: "06/02/2021", Expires: "06/02/2099", WhoisGuard: "ENABLED", AutoRenew: true, IsOurDNS: true},
+		mockPortfolioDomain{ID: "2", Name: "two-example.com", User: "mock-user", Created: "06/02/2021", Expires: "06/02/2099", WhoisGuard: "ENABLED", AutoRenew: true, IsOurDNS: true},
+		mockPortfolioDomain{ID: "3", Name: "three-example.com", User: "mock-user", Created: "06/02/2021", Expires: "06/02/2099", WhoisGuard: "ENABLED", AutoRenew: true, IsOurDNS: true},
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { mockPreCheck(t, m) },
+		ProviderFactories: mockProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: `
+data "namecheap_domains" "all" {
+  list_type = "ALL"
+}
+`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.namecheap_domains.all", "domains.#", "3"),
+					func(*terraform.State) error {
+						got := m.getListCallCount()
+						if got < 3 || got%3 != 0 {
+							return fmt.Errorf("expected getList calls to be a positive multiple of 3 (one per page, proving full pagination), got %d", got)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// TestAccMockDataSourceDomainRecords reads a domain's live record set, email
+// type and nameservers via namecheap_domain_records, covering both a
+// Namecheap-DNS domain (records exposed) and a custom-nameserver domain
+// (nameservers exposed).
+func TestAccMockDataSourceDomainRecords(t *testing.T) {
+	m := newNamecheapMock(t)
+
+	const ourDNS = "records-example.com"
+	m.seed(ourDNS, []hostEntry{
+		{Name: "@", Type: "A", Address: "10.0.0.1", MXPref: 10, TTL: 1800},
+		{Name: "www", Type: "CNAME", Address: "records-example.com.", MXPref: 10, TTL: 3600},
+	}, "MX", nil)
+
+	const customNS = "custom-ns-example.com"
+	m.seed(customNS, nil, "NONE", []string{"dns1.p01.nsone.net", "dns2.p01.nsone.net"})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { mockPreCheck(t, m) },
+		ProviderFactories: mockProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+data "namecheap_domain_records" "ourdns" {
+  domain = "%s"
+}
+
+data "namecheap_domain_records" "customns" {
+  domain = "%s"
+}
+`, ourDNS, customNS),
+				Check: resource.ComposeTestCheckFunc(
+					// Namecheap-DNS domain: records exposed, no nameservers.
+					resource.TestCheckResourceAttr("data.namecheap_domain_records.ourdns", "email_type", "MX"),
+					resource.TestCheckResourceAttr("data.namecheap_domain_records.ourdns", "nameservers.#", "0"),
+					resource.TestCheckResourceAttr("data.namecheap_domain_records.ourdns", "records.#", "2"),
+					resource.TestCheckResourceAttr("data.namecheap_domain_records.ourdns", "records.0.hostname", "@"),
+					resource.TestCheckResourceAttr("data.namecheap_domain_records.ourdns", "records.0.type", "A"),
+					resource.TestCheckResourceAttr("data.namecheap_domain_records.ourdns", "records.0.address", "10.0.0.1"),
+					resource.TestCheckResourceAttr("data.namecheap_domain_records.ourdns", "records.0.ttl", "1800"),
+					resource.TestCheckResourceAttr("data.namecheap_domain_records.ourdns", "records.1.hostname", "www"),
+					resource.TestCheckResourceAttr("data.namecheap_domain_records.ourdns", "records.1.type", "CNAME"),
+					// Custom-nameserver domain: nameservers exposed, no records.
+					resource.TestCheckResourceAttr("data.namecheap_domain_records.customns", "nameservers.#", "2"),
+					resource.TestCheckResourceAttr("data.namecheap_domain_records.customns", "nameservers.0", "dns1.p01.nsone.net"),
+					resource.TestCheckResourceAttr("data.namecheap_domain_records.customns", "records.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccMockDataSourcePortfolioComposition exercises the headline composition
+// pattern end-to-end: a namecheap_domains data source drives the creation of a
+// uniform SPF record on every domain in the portfolio (data source -> 3 mock
+// domains -> 3 planned record resources), asserting all three are applied
+// against the mock backend and cleared on destroy.
+//
+// The documented user-facing pattern uses for_each keyed by domain name (see
+// docs/data-sources/domains.md). The acceptance test uses count instead because
+// the SDKv2 acceptance-test harness (terraform-plugin-testing's legacy state
+// shim in helper/resource) cannot represent string-keyed for_each instances -
+// count yields integer-indexed instances that the shim supports while
+// exercising the identical data-source-driven composition.
+func TestAccMockDataSourcePortfolioComposition(t *testing.T) {
+	m := newNamecheapMock(t)
+	domains := []string{"alpha-example.com", "beta-example.net", "gamma-example.org"}
+	m.seedPortfolio(0,
+		mockPortfolioDomain{ID: "1", Name: domains[0], User: "mock-user", Created: "06/02/2021", Expires: "06/02/2099", WhoisGuard: "ENABLED", AutoRenew: true, IsOurDNS: true},
+		mockPortfolioDomain{ID: "2", Name: domains[1], User: "mock-user", Created: "06/02/2021", Expires: "06/02/2099", WhoisGuard: "ENABLED", AutoRenew: true, IsOurDNS: true},
+		mockPortfolioDomain{ID: "3", Name: domains[2], User: "mock-user", Created: "06/02/2021", Expires: "06/02/2099", WhoisGuard: "ENABLED", AutoRenew: true, IsOurDNS: true},
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { mockPreCheck(t, m) },
+		ProviderFactories: mockProviderFactories(),
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			mockCheckHostsCleared(m, domains[0]),
+			mockCheckHostsCleared(m, domains[1]),
+			mockCheckHostsCleared(m, domains[2]),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: `
+data "namecheap_domains" "all" {
+  list_type = "ALL"
+}
+
+resource "namecheap_domain_records" "spf" {
+  count = length(data.namecheap_domains.all.domains)
+
+  domain = data.namecheap_domains.all.domains[count.index].name
+  mode   = "OVERWRITE"
+
+  record {
+    hostname = "@"
+    type     = "TXT"
+    address  = "v=spf1 include:example.com -all"
+    ttl      = 1800
+  }
+}
+`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.namecheap_domains.all", "domains.#", "3"),
+					resource.TestCheckResourceAttr("namecheap_domain_records.spf.0", "record.#", "1"),
+					mockCheckHostCount(m, domains[0], 1),
+					mockCheckHostCount(m, domains[1], 1),
+					mockCheckHostCount(m, domains[2], 1),
+					mockCheckHostContains(m, domains[0], "@", "TXT", "v=spf1 include:example.com -all"),
+				),
+			},
+		},
+	})
+}

--- a/namecheap/mock_server_test.go
+++ b/namecheap/mock_server_test.go
@@ -47,12 +47,52 @@ type namecheapMock struct {
 	mu      sync.Mutex
 	domains map[string]*mockDomainState
 
+	// Portfolio (namecheap.domains.getList) state. portfolio holds the domains
+	// the account "owns"; pageSizeCap, when >0, caps the effective page size so
+	// a test can force multi-page pagination with a small seed; getListCalls
+	// counts getList requests so a test can prove full pagination.
+	portfolio    []mockPortfolioDomain
+	pageSizeCap  int
+	getListCalls int
+
+	// getInfo (namecheap.domains.getInfo) state, keyed by domain name. A getInfo
+	// request for a domain absent from this map returns a "Domain not found"
+	// API error, exercising the not-found diagnostic.
+	infos map[string]mockDomainInfo
+
 	// Optional fault injection: when failCommand is set, any request whose
 	// Command equals it returns an API error with failCode/failMessage instead
 	// of the normal response. Used to exercise the provider's error-surfacing.
 	failCommand string
 	failCode    string
 	failMessage string
+}
+
+// mockPortfolioDomain is one entry of the account portfolio returned by the
+// stateful mock's namecheap.domains.getList handler. Created/Expires use the
+// Namecheap "MM/DD/YYYY" wire format.
+type mockPortfolioDomain struct {
+	ID         string
+	Name       string
+	User       string
+	Created    string
+	Expires    string
+	WhoisGuard string
+	IsExpired  bool
+	IsLocked   bool
+	AutoRenew  bool
+	IsPremium  bool
+	IsOurDNS   bool
+}
+
+// mockDomainInfo is the per-domain response of the mock's
+// namecheap.domains.getInfo handler.
+type mockDomainInfo struct {
+	IsPremium     bool
+	IsPremiumDNS  bool
+	ProviderType  string
+	IsUsingOurDNS bool
+	Nameservers   []string
 }
 
 // newNamecheapMock starts a stateful mock server and registers its shutdown
@@ -113,6 +153,33 @@ func (m *namecheapMock) seed(domain string, hosts []hostEntry, emailType string,
 	}
 }
 
+// seedPortfolio sets the account portfolio returned by getList. cap, when >0,
+// caps the per-page size so a small seed still spans multiple pages (used to
+// exercise pagination end-to-end).
+func (m *namecheapMock) seedPortfolio(cap int, domains ...mockPortfolioDomain) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.portfolio = domains
+	m.pageSizeCap = cap
+}
+
+// seedInfo registers the getInfo response for a domain.
+func (m *namecheapMock) seedInfo(domain string, info mockDomainInfo) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.infos == nil {
+		m.infos = map[string]mockDomainInfo{}
+	}
+	m.infos[domain] = info
+}
+
+// getListCallCount returns how many getList requests the mock has served.
+func (m *namecheapMock) getListCallCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.getListCalls
+}
+
 func (m *namecheapMock) handler(w http.ResponseWriter, r *http.Request) {
 	if err := r.ParseForm(); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -130,6 +197,26 @@ func (m *namecheapMock) handler(w http.ResponseWriter, r *http.Request) {
 	// Fault injection: return an API error for the configured command.
 	if m.failCommand != "" && command == m.failCommand {
 		_, _ = io.WriteString(w, apiErrorXML(m.failCode, m.failMessage))
+		return
+	}
+
+	// Portfolio and getInfo commands are account-/domain-scoped rather than
+	// keyed on the DNS SLD.TLD state, so handle them before touching st.
+	switch command {
+	case "namecheap.domains.getList":
+		m.getListCalls++
+		page, _ := strconv.Atoi(r.FormValue("Page"))
+		if page < 1 {
+			page = 1
+		}
+		pageSize, _ := strconv.Atoi(r.FormValue("PageSize"))
+		if pageSize <= 0 {
+			pageSize = 20
+		}
+		_, _ = io.WriteString(w, m.renderGetPortfolioXML(page, pageSize))
+		return
+	case "namecheap.domains.getInfo":
+		_, _ = io.WriteString(w, m.renderGetInfoXML(r.FormValue("DomainName")))
 		return
 	}
 
@@ -312,6 +399,78 @@ func renderNSInfoXML(domain, nameserver, ip string) string {
     </DomainNSInfoResult>
   </CommandResponse>
 </ApiResponse>`, domain, nameserver, ip)
+}
+
+// renderGetPortfolioXML renders a namecheap.domains.getList response for the
+// requested page. It honors pageSizeCap (when set) to force multi-page results
+// from a small seed, and reports TotalItems/CurrentPage/PageSize so the provider
+// can paginate to completion.
+func (m *namecheapMock) renderGetPortfolioXML(page, pageSize int) string {
+	eff := pageSize
+	if m.pageSizeCap > 0 && m.pageSizeCap < eff {
+		eff = m.pageSizeCap
+	}
+	total := len(m.portfolio)
+	start := (page - 1) * eff
+	if start > total {
+		start = total
+	}
+	end := start + eff
+	if end > total {
+		end = total
+	}
+
+	var lines []string
+	for _, d := range m.portfolio[start:end] {
+		lines = append(lines, fmt.Sprintf(
+			`<Domain ID="%s" Name="%s" User="%s" Created="%s" Expires="%s" IsExpired="%t" IsLocked="%t" AutoRenew="%t" WhoisGuard="%s" IsPremium="%t" IsOurDNS="%t" />`,
+			d.ID, mockXMLAttrEscaper.Replace(d.Name), d.User, d.Created, d.Expires,
+			d.IsExpired, d.IsLocked, d.AutoRenew, d.WhoisGuard, d.IsPremium, d.IsOurDNS))
+	}
+
+	return fmt.Sprintf(`<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+  <Errors />
+  <CommandResponse Type="namecheap.domains.getList">
+    <DomainGetListResult>
+      %s
+    </DomainGetListResult>
+    <Paging>
+      <TotalItems>%d</TotalItems>
+      <CurrentPage>%d</CurrentPage>
+      <PageSize>%d</PageSize>
+    </Paging>
+  </CommandResponse>
+</ApiResponse>`, strings.Join(lines, "\n      "), total, page, eff)
+}
+
+// renderGetInfoXML renders a namecheap.domains.getInfo response for the given
+// domain, or a "Domain not found" API error when the domain was not seeded.
+func (m *namecheapMock) renderGetInfoXML(domain string) string {
+	info, ok := m.infos[domain]
+	if !ok {
+		return apiErrorXML("2019166", fmt.Sprintf("Domain %q not found", domain))
+	}
+
+	var nsLines []string
+	for _, ns := range info.Nameservers {
+		nsLines = append(nsLines, fmt.Sprintf(`<Nameserver>%s</Nameserver>`, ns))
+	}
+
+	return fmt.Sprintf(`<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+  <Errors />
+  <CommandResponse Type="namecheap.domains.getInfo">
+    <DomainGetInfoResult DomainName="%s" IsPremium="%t">
+      <PremiumDnsSubscription>
+        <IsActive>%t</IsActive>
+      </PremiumDnsSubscription>
+      <DnsDetails ProviderType="%s" IsUsingOurDNS="%t">
+        %s
+      </DnsDetails>
+    </DomainGetInfoResult>
+  </CommandResponse>
+</ApiResponse>`, domain, info.IsPremium, info.IsPremiumDNS, info.ProviderType, info.IsUsingOurDNS, strings.Join(nsLines, "\n        "))
 }
 
 // renderResultXML renders a generic success CommandResponse for write commands

--- a/namecheap/provider.go
+++ b/namecheap/provider.go
@@ -107,6 +107,11 @@ func Provider() *schema.Provider {
 			"namecheap_domain_records":      resourceNamecheapDomainRecords(),
 			"namecheap_personal_nameserver": resourceNamecheapPersonalNameserver(),
 		},
+		DataSourcesMap: map[string]*schema.Resource{
+			"namecheap_domain":         dataSourceNamecheapDomain(),
+			"namecheap_domains":        dataSourceNamecheapDomains(),
+			"namecheap_domain_records": dataSourceNamecheapDomainRecords(),
+		},
 		ConfigureContextFunc: configureContext,
 	}
 }


### PR DESCRIPTION
## What & why

The provider had **zero data sources**, blocking every read-only composition pattern (reference an existing domain's nameservers/expiry, iterate the portfolio with `for_each`, merge an existing record set, gate on domain properties). This adds the first three data sources using the existing SDKv2 (`terraform-plugin-sdk/v2`) and `go-namecheap-sdk/v2 v2.7.0` — no SDK bump, pure provider work. `DataSourcesMap` is added to `Provider()`.

## Data sources & exact SDK methods

| Data source | SDK method(s) | Exports |
|---|---|---|
| `namecheap_domain` | `Domains.GetInfoWithContext` (`namecheap.domains.getInfo`) **+** `Domains.GetListWithContext` (`namecheap.domains.getList`) | `dns_provider_type`, `is_our_dns`, `is_premium`, `is_premium_dns`, `nameservers` (from getInfo); `created`, `expires`, `expires_in_days`, `is_expired`, `is_locked`, `auto_renew`, `whois_guard` (from getList) |
| `namecheap_domains` | `Domains.GetListWithContext` (`namecheap.domains.getList`), auto-paginated across all pages | `domains = list(object({ id, name, user, created, expires, expires_in_days, is_expired, is_locked, auto_renew, whois_guard, is_premium, is_our_dns }))`; filters `search_term`, `list_type` (ALL/EXPIRING/EXPIRED) |
| `namecheap_domain_records` | `DomainsDNS.GetHostsWithContext` + `DomainsDNS.GetListWithContext` | `records = list(object({ hostname, type, address, mx_pref, ttl }))`, `nameservers`, `email_type` |

## `namecheap_domain` exports the full spec (two-call design)

`namecheap.domains.getInfo` returns only DNS-oriented data; it does **not** return the domain lifecycle fields. Rather than drop those fields, `namecheap_domain` now issues a second `namecheap.domains.getList` call, `SearchTerm`-narrowed and exact-matched client-side (SearchTerm is a substring filter, not an exact lookup), and copies the lifecycle fields via the shared `flattenPortfolioDomain` helper. `getInfo` remains the authoritative existence check (its not-found diagnostic names the domain), so a portfolio miss leaves the lifecycle fields at their zero values rather than failing the read. The two-call cost is documented on the registry page; callers needing lifecycle data for many domains at once should prefer the one-listing `namecheap_domains` portfolio source.

## Field parity

The `records` element schema is produced by a shared builder (`domainRecordElemSchema`) and matches the `namecheap_domain_records` resource `record` block attribute-for-attribute, so outputs feed into resource inputs (incl. a `dynamic "record"` block) with no remapping. Enforced by `TestDomainRecordFieldParity`.

## Dates

`created`/`expires` are exported as RFC3339 UTC strings; `expires_in_days` is a timezone-safe whole-calendar-day convenience (negative when expired). `is_expired` comes straight from the API. Boundary behaviour is unit-tested (`TestFormatDateTime`, `TestDaysUntil`, `TestDaysUntilTimezoneSafe`).

## Testing performed

- `gofmt -l namecheap/` clean, `go build ./...`, `go vet ./...` (incl. `-tags testacc`), `golangci-lint run` → 0 issues, `make build` OK.
- **Unit tests (`go test ./namecheap/...`, no build tag → observed by the coverage upload):** data-source registration, record field parity, date/`expires_in_days` helpers incl. timezone boundaries, **plus new `data_source_read_test.go`** that drives all three `ReadContext` functions against an in-process `httptest` server through the real SDK client (`client.BaseURL`), covering success, not-found (diagnostic names the domain), empty portfolio, multi-page pagination, and API-error paths. Project coverage **83.6% → 91.5%** (above the pre-PR baseline), fixing the `codecov/project` gate that the earlier revision tripped (the mock suite below is `testacc`-gated and therefore invisible to codecov).
- Mock-backed acceptance tests (`make testacc-mock`, extends the existing stateful mock with `getInfo`/`getList`): happy path for all three (the `namecheap_domain` case now asserts the getList-sourced lifecycle fields end-to-end); **not-found → diagnostic naming the domain**; **empty, single-page, and multi-page portfolio with a getList call-count assertion proving full pagination**; and an end-to-end **portfolio → 3 mock domains → 3 record resources** composition (asserted against the mock backend + cleared on destroy).
  - Note: the acceptance test drives that composition with `count` rather than `for_each`, because the SDKv2 acceptance harness (`terraform-plugin-testing`'s legacy state shim) cannot represent string-keyed `for_each` instances. The identical data-source-driven composition is exercised; the idiomatic `for_each` form is documented as the recommended user pattern in `docs/data-sources/domains.md`.

## Docs

Registry docs for all three under `docs/data-sources/`, including the portfolio-wide `for_each` guide and a merge/augment `dynamic` block example. `docs/data-sources/domain.md` documents the two-call cost and the full attribute set.

## Not done (out of scope per issue)

Pricing/balance and TLD-list data sources are explicitly out of scope. There is no `examples/` tree in this repo, so runnable examples live inline in the `docs/data-sources/` pages (matching the existing docs-only layout).

Closes #254
