### PR TITLE
ci: bump ec2-github-runner pin to v4.0.2 (#68/#69)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -504,7 +504,7 @@ jobs:
           echo "Pre-attached ${SANDBOX_EIP_ALLOCATION_ID} to stopped warm-pool instance ${target}."
       - name: Start EC2 runner
         id: start-ec2-runner
-        uses: namecheap/ec2-github-runner@65fbe4f0c1181c60d4df2bd3b33b8893e21fbb43 # v4.0.1 @ 2026-07-08: warm-pool reuse:stop registration fixes (#62/#64/#65/#66)
+        uses: namecheap/ec2-github-runner@54ee3e45b519c062993c2b01eb77552fcc329b9d # v4.0.2 @ 2026-07-10: warm-pool reuse:stop reliability fixes (#67/#68/#69)
         with:
           mode: start
           github-token: ${{ steps.app-token.outputs.token }}
@@ -769,7 +769,7 @@ jobs:
         # "Configure AWS credentials" above doesn't skip stopping the
         # instance.
         if: always()
-        uses: namecheap/ec2-github-runner@65fbe4f0c1181c60d4df2bd3b33b8893e21fbb43 # v4.0.1 @ 2026-07-08: warm-pool reuse:stop registration fixes (#62/#64/#65/#66)
+        uses: namecheap/ec2-github-runner@54ee3e45b519c062993c2b01eb77552fcc329b9d # v4.0.2 @ 2026-07-10: warm-pool reuse:stop reliability fixes (#67/#68/#69)
         with:
           mode: stop
           reuse: stop

--- a/.github/workflows/cleanup-ec2-runners.yml
+++ b/.github/workflows/cleanup-ec2-runners.yml
@@ -113,7 +113,7 @@ jobs:
         # reaper-stopped-max-age is deliberately tiny (1) so the day's pool
         # instance -- stopped anywhere from seconds to ~24h earlier -- is
         # always older than the threshold and gets terminated.
-        uses: namecheap/ec2-github-runner@65fbe4f0c1181c60d4df2bd3b33b8893e21fbb43 # v4.0.1 @ 2026-07-08: warm-pool reuse:stop registration fixes (#62/#64/#65/#66)
+        uses: namecheap/ec2-github-runner@54ee3e45b519c062993c2b01eb77552fcc329b9d # v4.0.2 @ 2026-07-10: warm-pool reuse:stop reliability fixes (#67/#68/#69)
         with:
           mode: cleanup
           github-token: ${{ steps.app-token.outputs.token }}
@@ -129,7 +129,7 @@ jobs:
         # threshold applies, per the issue's "default thresholds" requirement
         # for this pass.
         if: ${{ (github.event_name == 'schedule' || inputs.dry_run == false) && steps.pass.outputs.kind == 'leak-reap' }}
-        uses: namecheap/ec2-github-runner@65fbe4f0c1181c60d4df2bd3b33b8893e21fbb43 # v4.0.1 @ 2026-07-08: warm-pool reuse:stop registration fixes (#62/#64/#65/#66)
+        uses: namecheap/ec2-github-runner@54ee3e45b519c062993c2b01eb77552fcc329b9d # v4.0.2 @ 2026-07-10: warm-pool reuse:stop reliability fixes (#67/#68/#69)
         with:
           mode: cleanup
           github-token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## What

Bumps the pinned `namecheap/ec2-github-runner` SHA from `65fbe4f` (v4.0.1) to `54ee3e4` (**v4.0.2**, newly cut) in all four pin sites: `ci.yml`'s start-runner and stop-runner steps, and both passes in `cleanup-ec2-runners.yml`.

## Why now

v4.0.1 predates two merged fixes on the action repo that neither had a release tag yet:

- **#68** — the start step now requires the runner to report online on multiple *consecutive* polls (3 warm / 2 cold) before declaring success. Previously a warm-restart runner could flap online-then-offline on the very first poll, the start step would exit green, and the leaked instance would sit running (holding its whitelisted EIP) while the dependent job stayed queued forever.
- **#69** — `mode: stop` now waits for the instance to actually reach `stopped` before returning (`StopInstances` alone only moves it to `stopping`). This is the action-side half of the stopping-state race #290 fixed workflow-side in this repo on 2026-07-10 (a tightly-queued run saw an empty warm pool and cold-launched a duplicate instance).

Since v4.0.1 had no tag covering either fix, I cut and pushed **v4.0.2** on the action repo at `54ee3e4` (both fixes included) rather than pinning to a bare `main` commit — [release notes](https://github.com/namecheap/ec2-github-runner/releases/tag/v4.0.2).

## Validation

- `actionlint` clean on both workflow files.
- Diff is exactly the four pin-line replacements — no other content touched.
- Next CI run on this repo exercises the new pin directly (start-runner + stop-runner); next scheduled cleanup run exercises it for both cleanup passes.