### PR TITLE
ci: harden the release-please versioning workflow

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -15,7 +15,7 @@ jobs:
     name: Conventional PR Title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v5.5.3
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -13,15 +13,26 @@ on:
       - master
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
+# Serialize release-please runs: back-to-back merges to master produce
+# overlapping CI successes that would otherwise race on the same release PR.
+concurrency:
+  group: release-please
+  cancel-in-progress: false
+
+# The default GITHUB_TOKEN needs nothing — every write goes through the App
+# token generated below.
+permissions: {}
 
 jobs:
   release-please:
     # Only act on a green master (or a manual dispatch). workflow_run fires for
-    # failed CI runs too, so the conclusion guard is required.
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    # failed CI runs too, so the conclusion guard is required. The branch filter
+    # matches the run's HEAD branch name, which a fork PR can spoof by naming
+    # its branch "master" — hence the head_repository guard.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.head_repository.full_name == github.repository)
     runs-on: ubuntu-latest
     steps:
       # A GitHub App token (not the default GITHUB_TOKEN) is mandatory here:


### PR DESCRIPTION
Ports the hardening applied to go-namecheap-sdk's release pipeline (out of a review there):

- **Concurrency group** — back-to-back merges to `master` produce overlapping CI successes whose `workflow_run` events race release-please against itself on the same release PR. Serialized, no cancel.
- **Fork-spoof guard** — `workflow_run`'s `branches:` filter matches the run's *head branch name*; a fork PR from a branch named `master` triggers this credentialed workflow. Added `head_repository.full_name == github.repository` to the job guard.
- **`permissions: {}`** — the default `GITHUB_TOKEN` had `contents: write` + `pull-requests: write` it never uses; all writes go through the App token.
- **Comment fix** — the `action-semantic-pull-request` pin comment said v5.5.3; SHA `48f2562` is actually v6.1.1.

## Related repo-settings gaps (not fixable in a diff)

- `squash_merge_commit_title` is `COMMIT_OR_PR_TITLE` — a single-commit PR lands its raw commit subject, bypassing the PR-title check release-please depends on. Should be `PR_TITLE`.
- `squash_merge_commit_message` is `COMMIT_MESSAGES` — a stray `BREAKING CHANGE:` footer in an intermediate commit triggers an unintended major bump. Should be `PR_BODY` or blank.
- Rebase merging is enabled, and the "Protect master" ruleset allows all three merge methods incl. plain merge commits — both defeat the PR-title-as-commit-subject scheme. Restrict to squash.
- `Conventional PR Title` is not a required status check — enforcement is advisory.