### PR TITLE
ci: serialize release-please runs, document release troubleshooting

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -17,6 +17,13 @@ permissions:
   contents: write
   pull-requests: write
 
+# Two quick merges to master each complete CI and would run release-please
+# concurrently, racing on the release branch/tag. Serialize; never cancel a
+# running release job.
+concurrency:
+  group: release-please-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release-please:
     # Only act on a green master (or a manual dispatch). workflow_run fires for

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -37,9 +37,32 @@ release-please parses to compute the version bump.
 > `GITHUB_TOKEN` — only App-authored events re-trigger `release.yml`. The App
 > must grant `contents: write` and `pull-requests: write`.
 
+## If a release doesn't appear (troubleshooting)
+
+`versioning.yml` only runs after a successful CI run on `master`, and
+release-please state is **cumulative** — every run re-scans all commits since
+the last tag, so a missed trigger delays a release rather than losing it.
+Known cases:
+
+- **CI failed or was flaky on a merge commit** (including the Release PR's
+  own merge commit): re-run the failed CI run — `workflow_run` fires again
+  when a re-run completes — or trigger versioning manually (Actions →
+  Versioning → Run workflow). A merged Release PR whose tag was never created
+  is reconciled the same way on the next successful run.
+- **GoReleaser failed after the tag was created** (bad GPG key, upload
+  error): the GitHub Release exists without binaries. The Terraform Registry
+  will not ingest an artifact-less version, so nothing broken is served —
+  fix the cause and re-run the failed `release.yml` run for the tag.
+
 ## Manual / emergency release
 
 If release-please is unavailable, bump `.release-please-manifest.json` and
-`CHANGELOG.md`, commit to `master`, then tag and push:
+`CHANGELOG.md`, merge to `master` **before tagging** (a tag pushed against a
+stale manifest makes the next release-please run recompute the same version
+and fail on the existing tag), re-sync (`git checkout master && git pull`),
+then tag and push:
 `git tag -a vX.Y.Z -m "Release vX.Y.Z" && git push origin vX.Y.Z`. `release.yml`
-runs on the tag; the next release-please run reconciles its state.
+runs on the tag; the next release-please run reconciles its state. Caveat: in
+this path GoReleaser creates the GitHub Release with an **empty body** (its
+changelog is disabled — release-please owns release notes in the normal flow);
+edit the Release afterwards and paste the CHANGELOG entry in by hand.


### PR DESCRIPTION
## Why

An automated review of the identical release-please setup in [namecheap/terraform-provider-jenkins#181](https://github.com/namecheap/terraform-provider-jenkins/pull/181) surfaced findings that apply here. This repo's setup is the most polished of the three providers (App scopes already documented, no `paths-ignore` gap, SHA-pinned actions), so only two items carry over.

## What

- **`versioning.yml`: concurrency group** (behavioral) — two quick merges to master each complete CI and run release-please concurrently, racing on the release branch/tag; one run then fails on a git ref-update conflict. `cancel-in-progress: false` so a running release job is never killed.
- **`RELEASE.md`: troubleshooting section** — flaky-CI-gated versioning runs and GoReleaser failure after tagging are delays with a documented recovery (release-please state is cumulative — merged-but-untagged Release PRs are reconciled on the next successful run), not lost releases.
- **`RELEASE.md`: manual/emergency path fixes** — merge the manifest bump *before* tagging (stale-manifest tag collision), re-sync before tagging, and the empty-Release-body caveat (GoReleaser's changelog is disabled).