### PR TITLE
feat: add namecheap_account_balance and namecheap_tld_pricing data sources

### DIFF
--- a/docs/data-sources/account_balance.md
+++ b/docs/data-sources/account_balance.md
@@ -65,7 +65,7 @@ This data source takes no arguments.
 
 ## Attribute Reference
 
-- `currency` - The currency the amounts are listed in (e.g. `USD`).
+- `currency` - The currency the amounts are listed in (e.g. `USD`), as reported by the API.
 - `available_balance` - Total amount available in the account, as an exact decimal string. This is the figure to gate a charge-bearing apply on.
 - `account_balance` - Total amount in the account, as an exact decimal string. Per the Namecheap API this is the same figure as `available_balance`.
 - `earned_amount` - Amount earned from Marketplace sales, as an exact decimal string.

--- a/docs/data-sources/account_balance.md
+++ b/docs/data-sources/account_balance.md
@@ -1,0 +1,82 @@
+---
+page_title: "namecheap_account_balance Data Source - terraform-provider-namecheap"
+subcategory: ""
+description: |-
+  The funds available in the Namecheap account the provider is authenticated as.
+---
+
+# namecheap_account_balance (Data Source)
+
+Reads the funds in the account the provider is authenticated as, via the
+Namecheap `namecheap.users.getBalances` API command. It takes no arguments — the
+account is the one the provider credentials belong to.
+
+Its purpose is to make money visible to a plan: registrations, renewals and
+transfers all draw on this balance, and Terraform has no other way to check
+affordability before an apply starts spending.
+
+## Example Usage
+
+```terraform
+data "namecheap_account_balance" "current" {}
+
+output "funds" {
+  value = "${data.namecheap_account_balance.current.available_balance} ${data.namecheap_account_balance.current.currency}"
+}
+```
+
+## Cost-aware applies
+
+Pair the balance with a `precondition` so a charge-bearing apply fails at plan
+time — with your message — instead of part-way through a batch:
+
+```terraform
+data "namecheap_account_balance" "current" {}
+
+data "namecheap_tld_pricing" "com" {
+  tld    = "com"
+  action = "REGISTER"
+}
+
+output "planned_registration" {
+  value = data.namecheap_tld_pricing.com.price
+
+  precondition {
+    condition     = tonumber(data.namecheap_account_balance.current.available_balance) >= tonumber(data.namecheap_tld_pricing.com.price)
+    error_message = "Insufficient Namecheap balance for registration."
+  }
+}
+```
+
+The same `precondition` block works inside a `lifecycle` block on a
+charge-bearing resource, which is where you usually want it.
+
+## Money is exported as strings
+
+Every monetary attribute is a **string** holding the exact decimal Namecheap
+returned (`"123.45"`), never a number. Terraform numbers are IEEE-754 floats, and
+a balance or price that round-trips through a float can silently change value —
+not acceptable for a figure that gates a charge. Convert with `tonumber()` at the
+point of comparison, as above, so the rounding is explicit and local.
+
+## Argument Reference
+
+This data source takes no arguments.
+
+## Attribute Reference
+
+- `currency` - The currency the amounts are listed in (e.g. `USD`).
+- `available_balance` - Total amount available in the account, as an exact decimal string. This is the figure to gate a charge-bearing apply on.
+- `account_balance` - Total amount in the account, as an exact decimal string. Per the Namecheap API this is the same figure as `available_balance`.
+- `earned_amount` - Amount earned from Marketplace sales, as an exact decimal string.
+- `withdrawable_amount` - Amount available for withdrawal, as an exact decimal string.
+- `funds_required_for_auto_renew` - Amount required to auto-renew the domains in the account, as an exact decimal string.
+- `id` - Always `account_balance`. The underlying command takes no parameters, so there is nothing to key the ID on.
+
+## Notes
+
+- The read is a single API call and is refreshed on every plan, so the value is
+  current as of the plan — but nothing reserves those funds. A concurrent
+  purchase elsewhere can still leave a later apply short.
+- Adding funds is deliberately not supported by this provider: payment flows do
+  not belong in `terraform apply`.

--- a/docs/data-sources/tld_pricing.md
+++ b/docs/data-sources/tld_pricing.md
@@ -9,8 +9,9 @@ description: |-
 
 Looks up what Namecheap charges for one TLD, one action (register, renew or
 transfer) and one term, via the `namecheap.users.getPricing` API command. The
-request is narrowed server-side, so each data source instance is exactly one API
-call rather than a walk of the full price sheet.
+request is narrowed server-side, so each read is exactly one API call rather than
+a walk of the full price sheet. Terraform reads a data source once per plan and
+again per apply, so a plan-then-apply cycle makes two calls per instance.
 
 ## Example Usage
 
@@ -40,11 +41,17 @@ data "namecheap_tld_pricing" "candidates" {
   years  = 1
 }
 
+locals {
+  prices         = { for tld, p in data.namecheap_tld_pricing.candidates : tld => tonumber(p.price) }
+  cheapest_price = min(values(local.prices)...)
+
+  # sort() makes the tie-break deterministic: promotions routinely price several
+  # TLDs identically, and picking "the" cheapest one would otherwise fail.
+  cheapest_tlds = sort([for tld, price in local.prices : tld if price == local.cheapest_price])
+}
+
 output "cheapest_tld" {
-  value = one([
-    for tld, p in data.namecheap_tld_pricing.candidates : tld
-    if tonumber(p.price) == min([for q in data.namecheap_tld_pricing.candidates : tonumber(q.price)]...)
-  ])
+  value = local.cheapest_tlds[0]
 }
 ```
 
@@ -65,24 +72,32 @@ Convert with `tonumber()` at the point of comparison.
   Namecheap documents: the server's final price (which already reflects any
   promotion or special), then your account price, then the regular price.
 - `regular_price` is the public list price — use it to show a discount.
-- `promo_price` identifies a promotion when the API reports one. It does **not**
-  add to `price`; an active promotion is already reflected there.
+- `promo_price` is the promotional price when a promotion applies, and empty
+  otherwise. It does **not** add to `price`; an active promotion is already
+  reflected there.
+
+Namecheap reports an un-promoted tier as `PromotionPrice="0.0"` rather than
+omitting it, so this provider exports a non-positive promotional price as
+empty — `promo_price != ""` therefore means "this TLD is on promotion". The
+trade-off is deliberate: a hypothetical genuinely-free promotion priced at
+`0.00` would also read as empty, which is the lesser error against an API that
+sends `0.0` on essentially every ordinary lookup.
 
 ## Argument Reference
 
-- `tld` - (Required) The top-level domain to price, written without a leading dot (`com`, `co.uk`). Validated at plan time.
-- `action` - (Optional) The action to price: `REGISTER` (default), `RENEW` or `TRANSFER`.
+- `tld` - (Required) The top-level domain to price, written without a leading or trailing dot (`com`, `co.uk`). Case-insensitive, validated at plan time. A full domain name (`example.com`) cannot be rejected at plan time — it is structurally identical to a multi-label TLD — and surfaces as a "no published price" error instead.
+- `action` - (Optional) The action to price: `REGISTER` (default), `RENEW` or `TRANSFER`. Case-insensitive.
 - `years` - (Optional) The term length in years to price, 1-10. Defaults to `1`.
 
 ## Attribute Reference
 
-- `price` - The price actually charged for this tier, as an exact decimal string (see above).
+- `price` - The price actually charged for this tier, as an exact decimal string (see above). In the rare case where the API publishes a tier with no positive price at all, this is the (possibly empty) regular price the server sent — `tonumber("")` fails, so guard with `try()` if you price TLDs you have not seen.
 - `regular_price` - The public list price for this tier, as an exact decimal string.
 - `your_price` - The account-specific price for this tier, as an exact decimal string. Empty when the API does not return one.
-- `promo_price` - The promotional price for this tier, as an exact decimal string, or empty when the API reported no promotion. Namecheap does not document what a zero promotional price means, so `"0.00"` is passed through as reported rather than being treated as "no promotion".
-- `currency` - The currency the prices are denominated in (e.g. `USD`). Empty when the API omits it for this tier; `namecheap_account_balance` always reports the account currency.
-- `duration_type` - The unit the term is expressed in, as returned by the API (always `YEAR` for the tiers this data source matches).
-- `id` - `pricing:<tld>:<action>:<years>`.
+- `promo_price` - The promotional price for this tier, as an exact decimal string, or empty when no promotion applies (see above — Namecheap signals "no promotion" with `0.0`, which is exported as empty).
+- `currency` - The currency the prices are denominated in (e.g. `USD`). Empty when the API omits it for this tier; `namecheap_account_balance` reports the currency the account itself is denominated in.
+- `duration_type` - The unit the term is expressed in, verbatim from the API. The data source only matches annual tiers, so this is `YEAR` (in whatever letter case the server used).
+- `id` - `pricing:<tld>:<action>:<years>`, built from the normalized values: `tld = "COM"` yields `pricing:com:REGISTER:1` while the `tld` attribute itself keeps what you wrote.
 
 ## Notes
 

--- a/docs/data-sources/tld_pricing.md
+++ b/docs/data-sources/tld_pricing.md
@@ -1,0 +1,95 @@
+---
+page_title: "namecheap_tld_pricing Data Source - terraform-provider-namecheap"
+subcategory: ""
+description: |-
+  The published Namecheap price for one TLD, action and term.
+---
+
+# namecheap_tld_pricing (Data Source)
+
+Looks up what Namecheap charges for one TLD, one action (register, renew or
+transfer) and one term, via the `namecheap.users.getPricing` API command. The
+request is narrowed server-side, so each data source instance is exactly one API
+call rather than a walk of the full price sheet.
+
+## Example Usage
+
+```terraform
+data "namecheap_tld_pricing" "com" {
+  tld    = "com"
+  action = "REGISTER"
+  years  = 1
+}
+
+output "com_price" {
+  value = "${data.namecheap_tld_pricing.com.price} ${data.namecheap_tld_pricing.com.currency}"
+}
+```
+
+## Comparing TLDs
+
+Use `for_each` to price several TLDs, then pick with ordinary HCL. Compare with
+`tonumber()`, never as strings — `"8.88" < "10.50"` is false lexicographically:
+
+```terraform
+data "namecheap_tld_pricing" "candidates" {
+  for_each = toset(["com", "net", "org"])
+
+  tld    = each.key
+  action = "REGISTER"
+  years  = 1
+}
+
+output "cheapest_tld" {
+  value = one([
+    for tld, p in data.namecheap_tld_pricing.candidates : tld
+    if tonumber(p.price) == min([for q in data.namecheap_tld_pricing.candidates : tonumber(q.price)]...)
+  ])
+}
+```
+
+Each element of a `for_each` is its own read, so pricing three TLDs is three API
+calls.
+
+## Money is exported as strings
+
+Every monetary attribute is a **string** holding the exact decimal Namecheap
+returned (`"8.88"`), never a number, for the same reason as
+[`namecheap_account_balance`](account_balance.md): Terraform numbers are
+IEEE-754 floats and a price must not change value by round-tripping through one.
+Convert with `tonumber()` at the point of comparison.
+
+## Which attribute is "the price"?
+
+- `price` is what you would actually be charged. It resolves the precedence
+  Namecheap documents: the server's final price (which already reflects any
+  promotion or special), then your account price, then the regular price.
+- `regular_price` is the public list price — use it to show a discount.
+- `promo_price` identifies a promotion when the API reports one. It does **not**
+  add to `price`; an active promotion is already reflected there.
+
+## Argument Reference
+
+- `tld` - (Required) The top-level domain to price, written without a leading dot (`com`, `co.uk`). Validated at plan time.
+- `action` - (Optional) The action to price: `REGISTER` (default), `RENEW` or `TRANSFER`.
+- `years` - (Optional) The term length in years to price, 1-10. Defaults to `1`.
+
+## Attribute Reference
+
+- `price` - The price actually charged for this tier, as an exact decimal string (see above).
+- `regular_price` - The public list price for this tier, as an exact decimal string.
+- `your_price` - The account-specific price for this tier, as an exact decimal string. Empty when the API does not return one.
+- `promo_price` - The promotional price for this tier, as an exact decimal string, or empty when the API reported no promotion. Namecheap does not document what a zero promotional price means, so `"0.00"` is passed through as reported rather than being treated as "no promotion".
+- `currency` - The currency the prices are denominated in (e.g. `USD`). Empty when the API omits it for this tier; `namecheap_account_balance` always reports the account currency.
+- `duration_type` - The unit the term is expressed in, as returned by the API (always `YEAR` for the tiers this data source matches).
+- `id` - `pricing:<tld>:<action>:<years>`.
+
+## Notes
+
+- Only domain pricing is exposed. SSL and WhoisGuard products live under
+  different product types in the same API command and would need a different
+  attribute shape.
+- A TLD Namecheap does not sell, or a term it does not publish a tier for, is an
+  error naming the TLD, action and term — not a silent zero price.
+- Prices change. The data source is re-read on every plan, so a long-lived plan
+  file can hold a stale price; nothing here reserves a price for a later apply.

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
-	github.com/namecheap/go-namecheap-sdk/v2 v2.8.0
+	github.com/namecheap/go-namecheap-sdk/v2 v2.9.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
-	github.com/namecheap/go-namecheap-sdk/v2 v2.7.1
+	github.com/namecheap/go-namecheap-sdk/v2 v2.8.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -131,8 +131,8 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
-github.com/namecheap/go-namecheap-sdk/v2 v2.8.0 h1:nCJl1FxBnzEwqBOaYodLiNB2PA2FQTaPtnOwXDGagbA=
-github.com/namecheap/go-namecheap-sdk/v2 v2.8.0/go.mod h1:Qlz3X1kDNHJUuDotq6Yo1xQXsxZyM/6BX1/N+zbi5OE=
+github.com/namecheap/go-namecheap-sdk/v2 v2.9.0 h1:eObXmcUonsBUmT1ltTMB0rw0cJG2dHLozofBx4Ia3fo=
+github.com/namecheap/go-namecheap-sdk/v2 v2.9.0/go.mod h1:Qlz3X1kDNHJUuDotq6Yo1xQXsxZyM/6BX1/N+zbi5OE=
 github.com/oklog/run v1.2.0 h1:O8x3yXwah4A73hJdlrwo/2X6J62gE5qTMusH0dvz60E=
 github.com/oklog/run v1.2.0/go.mod h1:mgDbKRSwPhJfesJ4PntqFUbKQRZ50NgmZTSPlFA0YFk=
 github.com/pjbgf/sha1cd v0.6.0 h1:3WJ8Wz8gvDz29quX1OcEmkAlUg9diU4GxJHqs0/XiwU=

--- a/go.sum
+++ b/go.sum
@@ -131,8 +131,8 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
-github.com/namecheap/go-namecheap-sdk/v2 v2.7.1 h1:LYNKLsujILsgDpYBb9ZxMWQtqXjaVz7G3fhR3XIe1I8=
-github.com/namecheap/go-namecheap-sdk/v2 v2.7.1/go.mod h1:dEsO2ak1a+roZR8GNibA0if0Y+YMbyZPxFk0Q8UgeUs=
+github.com/namecheap/go-namecheap-sdk/v2 v2.8.0 h1:nCJl1FxBnzEwqBOaYodLiNB2PA2FQTaPtnOwXDGagbA=
+github.com/namecheap/go-namecheap-sdk/v2 v2.8.0/go.mod h1:Qlz3X1kDNHJUuDotq6Yo1xQXsxZyM/6BX1/N+zbi5OE=
 github.com/oklog/run v1.2.0 h1:O8x3yXwah4A73hJdlrwo/2X6J62gE5qTMusH0dvz60E=
 github.com/oklog/run v1.2.0/go.mod h1:mgDbKRSwPhJfesJ4PntqFUbKQRZ50NgmZTSPlFA0YFk=
 github.com/pjbgf/sha1cd v0.6.0 h1:3WJ8Wz8gvDz29quX1OcEmkAlUg9diU4GxJHqs0/XiwU=

--- a/namecheap/data_source_namecheap_account_balance.go
+++ b/namecheap/data_source_namecheap_account_balance.go
@@ -1,0 +1,85 @@
+package namecheap_provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/namecheap/go-namecheap-sdk/v2/namecheap"
+)
+
+// accountBalanceID is the synthetic ID of the account-balance data source. The
+// underlying command (namecheap.users.getBalances) takes no parameters and
+// describes the account the provider is configured with, so there is nothing to
+// key the ID on; a constant keeps it stable across refreshes.
+const accountBalanceID = "account_balance"
+
+// dataSourceNamecheapAccountBalance exposes the funds in the account the
+// provider is authenticated as, so a configuration can gate charge-bearing
+// operations (registration, renewal, transfer) on affordability before spending.
+//
+// Every monetary attribute is exported as a *string* holding the exact decimal
+// the API returned, never a number: Terraform numbers are IEEE-754 floats, and
+// a price or balance that round-trips through a float can silently change. Use
+// tonumber() at the comparison site when a numeric check is needed, and accept
+// that rounding is then yours to reason about.
+func dataSourceNamecheapAccountBalance() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceNamecheapAccountBalanceRead,
+		Schema: map[string]*schema.Schema{
+			"currency": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The currency the amounts are listed in (e.g. USD).",
+			},
+			"available_balance": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Total amount available in the account, as an exact decimal string (e.g. \"123.45\"). This is the figure to gate a charge-bearing apply on.",
+			},
+			"account_balance": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Total amount in the account, as an exact decimal string. Per the Namecheap API this is the same figure as available_balance.",
+			},
+			"earned_amount": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Amount earned from Marketplace sales, as an exact decimal string.",
+			},
+			"withdrawable_amount": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Amount available for withdrawal, as an exact decimal string.",
+			},
+			"funds_required_for_auto_renew": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Amount required to auto-renew the domains in the account, as an exact decimal string.",
+			},
+		},
+	}
+}
+
+func dataSourceNamecheapAccountBalanceRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*namecheap.Client)
+
+	resp, err := client.Users.GetBalancesWithContext(ctx)
+	if err != nil {
+		return diagFromClientError(err)
+	}
+	if resp == nil || resp.UserGetBalancesResult == nil {
+		return diag.Errorf("Namecheap returned no balance information for this account")
+	}
+
+	balances := resp.UserGetBalancesResult
+	_ = data.Set("currency", balances.Currency)
+	_ = data.Set("available_balance", balances.AvailableBalance.String())
+	_ = data.Set("account_balance", balances.AccountBalance.String())
+	_ = data.Set("earned_amount", balances.EarnedAmount.String())
+	_ = data.Set("withdrawable_amount", balances.WithdrawableAmount.String())
+	_ = data.Set("funds_required_for_auto_renew", balances.FundsRequiredForAutoRenew.String())
+
+	data.SetId(accountBalanceID)
+	return nil
+}

--- a/namecheap/data_source_namecheap_tld_pricing.go
+++ b/namecheap/data_source_namecheap_tld_pricing.go
@@ -1,0 +1,180 @@
+package namecheap_provider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/namecheap/go-namecheap-sdk/v2/namecheap"
+)
+
+const (
+	// pricingProductType is the only product type this data source reads. SSL and
+	// WhoisGuard pricing live under different product types; exposing them would
+	// need a product_type argument and a different attribute shape, so they are
+	// deliberately out of scope here.
+	pricingProductType = "DOMAIN"
+
+	pricingActionRegister = "REGISTER"
+	pricingActionRenew    = "RENEW"
+	pricingActionTransfer = "TRANSFER"
+
+	// pricingMaxYears is the longest term the data source will ask about. The
+	// API publishes annual tiers well below this; the bound exists so a typo
+	// (years = 100) fails at plan time instead of returning "no such tier".
+	pricingMaxYears = 10
+)
+
+// dataSourceNamecheapTldPricing looks up the published price of one TLD for one
+// action and term, so a configuration can compare TLDs or assert a cost ceiling
+// before a charge-bearing apply.
+//
+// Every monetary attribute is exported as a *string* holding the exact decimal
+// the API returned, never a number: Terraform numbers are IEEE-754 floats and a
+// price that round-trips through a float can silently change. Use tonumber() at
+// the comparison site when a numeric check is needed.
+func dataSourceNamecheapTldPricing() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceNamecheapTldPricingRead,
+		Schema: map[string]*schema.Schema{
+			"tld": {
+				Type:         schema.TypeString,
+				Required:     true,
+				Description:  "The top-level domain to price, without a leading dot (e.g. com, co.uk).",
+				ValidateFunc: validateTld,
+			},
+			"action": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      pricingActionRegister,
+				Description:  "The action to price: REGISTER (default), RENEW or TRANSFER.",
+				ValidateFunc: validation.StringInSlice([]string{pricingActionRegister, pricingActionRenew, pricingActionTransfer}, false),
+			},
+			"years": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      1,
+				Description:  fmt.Sprintf("The term length in years to price (1-%d). Defaults to 1.", pricingMaxYears),
+				ValidateFunc: validation.IntBetween(1, pricingMaxYears),
+			},
+			"price": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The price actually charged for this tier, as an exact decimal string. It resolves the documented precedence: the server's final price (which already reflects any promotion or special), then your account price, then the regular price.",
+			},
+			"regular_price": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The public list price for this tier, as an exact decimal string.",
+			},
+			"your_price": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The account-specific price for this tier, as an exact decimal string. Empty when the API does not return one.",
+			},
+			"promo_price": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Description: "The promotional price for this tier, as an exact decimal string, or empty when the API reported no promotion. " +
+					"An active promotion is already reflected in price, so this attribute identifies the discount rather than adding to it. " +
+					"Namecheap does not document what a zero promotional price means, so a \"0.00\" is passed through as reported rather than being treated as \"no promotion\".",
+			},
+			"currency": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The currency the prices are denominated in (e.g. USD). Empty when the API omits it for this tier; namecheap_account_balance always reports the account currency.",
+			},
+			"duration_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The unit the term is expressed in, as returned by the API (always YEAR for the tiers this data source matches).",
+			},
+		},
+	}
+}
+
+func dataSourceNamecheapTldPricingRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*namecheap.Client)
+
+	tld := strings.ToLower(strings.TrimPrefix(strings.TrimSpace(data.Get("tld").(string)), "."))
+	action := strings.ToUpper(data.Get("action").(string))
+	years := data.Get("years").(int)
+
+	// Narrow the request server-side. The full price sheet is large; asking for
+	// one product and one action keeps the response (and the parse) proportional
+	// to the question, and makes the call count exactly one per read.
+	resp, err := client.Users.GetPricingWithContext(ctx, &namecheap.UsersGetPricingArgs{
+		ProductType: namecheap.String(pricingProductType),
+		ActionName:  namecheap.String(action),
+		ProductName: namecheap.String(tld),
+	})
+	if err != nil {
+		return dataSourcePricingReadError(tld, action, err)
+	}
+	if resp == nil || resp.UserGetPricingResult == nil {
+		return diag.Errorf("Namecheap returned no pricing information for .%s (%s)", tld, action)
+	}
+
+	price, ok := resp.UserGetPricingResult.PriceFor(action, tld, years)
+	if !ok {
+		return diag.Diagnostics{{
+			Severity: diag.Error,
+			Summary:  fmt.Sprintf("No %s price published for .%s over %d year(s)", action, tld, years),
+			Detail: fmt.Sprintf("Namecheap answered the pricing request but the response contains no %d-year %s tier for .%s. "+
+				"The TLD may not be offered, may not support this action, or may not be sold for this term — "+
+				"check the TLD spelling and try years = 1.", years, action, tld),
+		}}
+	}
+
+	// Promo reports presence, so an absent attribute stays an empty string rather
+	// than becoming a fabricated "0.00".
+	promo, _ := price.Promo()
+
+	_ = data.Set("price", price.EffectivePrice().String())
+	_ = data.Set("regular_price", price.RegularPrice.String())
+	_ = data.Set("your_price", price.YourPrice.String())
+	_ = data.Set("promo_price", promo.String())
+	_ = data.Set("currency", price.Currency)
+	_ = data.Set("duration_type", price.DurationType)
+
+	data.SetId(fmt.Sprintf("pricing:%s:%s:%d", tld, action, years))
+	return nil
+}
+
+// validateTld rejects the shapes that would otherwise reach the API as a silent
+// "no such product": an empty value, a leading dot, a full domain name, or
+// surrounding whitespace.
+func validateTld(val interface{}, key string) (warns []string, errs []error) {
+	tld, _ := val.(string)
+	if strings.TrimSpace(tld) != tld {
+		errs = append(errs, fmt.Errorf("%s must not have leading or trailing whitespace, got %q", key, tld))
+		return
+	}
+	if tld == "" {
+		errs = append(errs, fmt.Errorf("%s must not be empty", key))
+		return
+	}
+	if strings.HasPrefix(tld, ".") {
+		errs = append(errs, fmt.Errorf("%s must be written without a leading dot (use \"com\", not \".com\"), got %q", key, tld))
+		return
+	}
+	if strings.ContainsAny(tld, " /:@") {
+		errs = append(errs, fmt.Errorf("%s must be a top-level domain such as \"com\" or \"co.uk\", not a domain name or URL, got %q", key, tld))
+	}
+	return
+}
+
+// dataSourcePricingReadError converts an SDK error from a pricing lookup into
+// diagnostics naming the TLD and action, so a failed lookup in a for_each over
+// several TLDs identifies which one failed. It reuses diagFromClientError so
+// known Namecheap error codes keep their remediation text.
+func dataSourcePricingReadError(tld, action string, err error) diag.Diagnostics {
+	diags := diagFromClientError(err)
+	for i := range diags {
+		diags[i].Summary = fmt.Sprintf("%s (.%s, %s)", diags[i].Summary, tld, action)
+	}
+	return diags
+}

--- a/namecheap/data_source_namecheap_tld_pricing.go
+++ b/namecheap/data_source_namecheap_tld_pricing.go
@@ -47,11 +47,13 @@ func dataSourceNamecheapTldPricing() *schema.Resource {
 				ValidateFunc: validateTld,
 			},
 			"action": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Default:      pricingActionRegister,
-				Description:  "The action to price: REGISTER (default), RENEW or TRANSFER.",
-				ValidateFunc: validation.StringInSlice([]string{pricingActionRegister, pricingActionRenew, pricingActionTransfer}, false),
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     pricingActionRegister,
+				Description: "The action to price: REGISTER (default), RENEW or TRANSFER.",
+				// ignoreCase: "renew" is accepted and normalized to RENEW before the
+				// request, so a config is not rejected over letter case.
+				ValidateFunc: validation.StringInSlice([]string{pricingActionRegister, pricingActionRenew, pricingActionTransfer}, true),
 			},
 			"years": {
 				Type:         schema.TypeInt,
@@ -78,9 +80,9 @@ func dataSourceNamecheapTldPricing() *schema.Resource {
 			"promo_price": {
 				Type:     schema.TypeString,
 				Computed: true,
-				Description: "The promotional price for this tier, as an exact decimal string, or empty when the API reported no promotion. " +
-					"An active promotion is already reflected in price, so this attribute identifies the discount rather than adding to it. " +
-					"Namecheap does not document what a zero promotional price means, so a \"0.00\" is passed through as reported rather than being treated as \"no promotion\".",
+				Description: "The promotional price for this tier, as an exact decimal string, or empty when no promotion applies. " +
+					"Namecheap reports an un-promoted tier as \"0.0\" rather than omitting the value, so a non-positive promotional price is exported as empty here and `promo_price != \"\"` is a meaningful test for \"is this TLD on promotion\". " +
+					"An active promotion is already reflected in price, so this attribute identifies the discount rather than adding to it.",
 			},
 			"currency": {
 				Type:        schema.TypeString,
@@ -99,7 +101,9 @@ func dataSourceNamecheapTldPricing() *schema.Resource {
 func dataSourceNamecheapTldPricingRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*namecheap.Client)
 
-	tld := strings.ToLower(strings.TrimPrefix(strings.TrimSpace(data.Get("tld").(string)), "."))
+	// validateTld has already rejected a leading dot and surrounding whitespace,
+	// so case is the only normalization left to do.
+	tld := strings.ToLower(data.Get("tld").(string))
 	action := strings.ToUpper(data.Get("action").(string))
 	years := data.Get("years").(int)
 
@@ -124,14 +128,20 @@ func dataSourceNamecheapTldPricingRead(ctx context.Context, data *schema.Resourc
 			Severity: diag.Error,
 			Summary:  fmt.Sprintf("No %s price published for .%s over %d year(s)", action, tld, years),
 			Detail: fmt.Sprintf("Namecheap answered the pricing request but the response contains no %d-year %s tier for .%s. "+
-				"The TLD may not be offered, may not support this action, or may not be sold for this term — "+
-				"check the TLD spelling and try years = 1.", years, action, tld),
+				"The TLD may not be offered, may not support this action, or may not be sold for this term "+
+				"(some TLDs have a multi-year minimum, and some are registry-only). Check the TLD spelling, "+
+				"then try a different years value.", years, action, tld),
 		}}
 	}
 
-	// Promo reports presence, so an absent attribute stays an empty string rather
-	// than becoming a fabricated "0.00".
-	promo, _ := price.Promo()
+	// The live API sends PromotionPrice="0.0" on tiers with no promotion, so
+	// presence is not the question — IsPositive is. A non-positive promotional
+	// price is exported as empty so that promo_price != "" means what a reader
+	// assumes it means.
+	promo := namecheap.Amount("")
+	if price.PromotionPrice.IsPositive() {
+		promo = price.PromotionPrice
+	}
 
 	_ = data.Set("price", price.EffectivePrice().String())
 	_ = data.Set("regular_price", price.RegularPrice.String())
@@ -145,8 +155,12 @@ func dataSourceNamecheapTldPricingRead(ctx context.Context, data *schema.Resourc
 }
 
 // validateTld rejects the shapes that would otherwise reach the API as a silent
-// "no such product": an empty value, a leading dot, a full domain name, or
-// surrounding whitespace.
+// "no such product": an empty value, a leading or trailing dot, surrounding
+// whitespace, and anything carrying URL punctuation.
+//
+// It cannot reject a full domain name: "example.com" is structurally identical
+// to the legitimate multi-label TLD "co.uk", so that mistake surfaces as the
+// read's "no published price" diagnostic instead.
 func validateTld(val interface{}, key string) (warns []string, errs []error) {
 	tld, _ := val.(string)
 	if strings.TrimSpace(tld) != tld {
@@ -161,7 +175,11 @@ func validateTld(val interface{}, key string) (warns []string, errs []error) {
 		errs = append(errs, fmt.Errorf("%s must be written without a leading dot (use \"com\", not \".com\"), got %q", key, tld))
 		return
 	}
-	if strings.ContainsAny(tld, " /:@") {
+	if strings.HasSuffix(tld, ".") {
+		errs = append(errs, fmt.Errorf("%s must not end with a dot, got %q", key, tld))
+		return
+	}
+	if strings.ContainsAny(tld, " /:@\n\t") {
 		errs = append(errs, fmt.Errorf("%s must be a top-level domain such as \"com\" or \"co.uk\", not a domain name or URL, got %q", key, tld))
 	}
 	return

--- a/namecheap/data_source_pricing_live_test.go
+++ b/namecheap/data_source_pricing_live_test.go
@@ -44,11 +44,16 @@ func TestAccDataSourceAccountBalance(t *testing.T) {
 	})
 }
 
-// TestAccDataSourceTldPricing prices .com for all three actions against the live
-// API. It is the only test in the suite that observes the real getPricing
-// response shape, so it is what confirms the SDK's attribute names still match
-// the server: a renamed or dropped Price attribute shows up here as an empty
-// exported value, not as a passing test.
+// TestAccDataSourceTldPricing prices .com against the live API. It is the only
+// test in the suite that observes the real getPricing response shape, so it is
+// what confirms the SDK's attribute names still match the server: a renamed or
+// dropped Price attribute shows up here as an empty exported value, not as a
+// passing test.
+//
+// It deliberately reads a single tier. The sandbox rate-limits the whole
+// package's run (the DNS suites answer HTTP 405 once the rolling window is
+// exhausted), so every live call added here is taken from a shared budget;
+// action and TLD coverage therefore lives in the mock suite, where it is free.
 func TestAccDataSourceTldPricing(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -61,62 +66,24 @@ data "namecheap_tld_pricing" "register" {
   action = "REGISTER"
   years  = 1
 }
-
-data "namecheap_tld_pricing" "renew" {
-  tld    = "com"
-  action = "RENEW"
-  years  = 1
-}
-
-data "namecheap_tld_pricing" "transfer" {
-  tld    = "com"
-  action = "TRANSFER"
-  years  = 1
-}
 `,
 				Check: resource.ComposeTestCheckFunc(
-					// Every action publishes a 1-year .com tier with a real price.
 					testAccCheckIsDecimalString("data.namecheap_tld_pricing.register", "price"),
 					testAccCheckIsDecimalString("data.namecheap_tld_pricing.register", "regular_price"),
-					testAccCheckIsDecimalString("data.namecheap_tld_pricing.renew", "price"),
-					testAccCheckIsDecimalString("data.namecheap_tld_pricing.transfer", "price"),
 					resource.TestCheckResourceAttr("data.namecheap_tld_pricing.register", "duration_type", "YEAR"),
 					resource.TestCheckResourceAttr("data.namecheap_tld_pricing.register", "id", "pricing:com:REGISTER:1"),
-					resource.TestCheckResourceAttr("data.namecheap_tld_pricing.renew", "id", "pricing:com:RENEW:1"),
-					resource.TestCheckResourceAttr("data.namecheap_tld_pricing.transfer", "id", "pricing:com:TRANSFER:1"),
 					// Currency is optional per tier, so its absence is not a failure —
 					// but when the server does send it, it must be a currency code.
 					testAccCheckOptionalPattern("data.namecheap_tld_pricing.register", "currency", regexp.MustCompile(`^[A-Z]{3}$`)),
-					// Same for the promotional price: absent is fine, malformed is not.
-					// This is the only place the real PromotionPrice shape is observed.
-					testAccCheckOptionalPattern("data.namecheap_tld_pricing.register", "promo_price", regexp.MustCompile(`^-?\d+(\.\d+)?$`)),
+					// promo_price is empty unless the server quoted a positive
+					// promotion; .com is normally un-promoted (the API says so with
+					// "0.0"), and anything non-empty must still be a bare decimal.
+					testAccCheckOptionalPattern("data.namecheap_tld_pricing.register", "promo_price", regexp.MustCompile(`^\d+(\.\d+)?$`)),
 					// Log what the live API actually returned for the optional
 					// attributes, so a sandbox run leaves evidence of the response
 					// shape rather than only a pass/fail.
 					testAccLogAttrs("data.namecheap_tld_pricing.register", "price", "regular_price", "your_price", "promo_price", "currency"),
 				),
-			},
-		},
-	})
-}
-
-// TestAccDataSourceTldPricingUnknownTld asserts the live API's answer for a TLD
-// Namecheap does not sell surfaces as a diagnostic naming it, rather than an
-// empty price. It is the live counterpart of the mock's not-found case, and
-// guards against the API changing an unknown product from "empty sheet" to
-// something the provider would misread as a valid tier.
-func TestAccDataSourceTldPricingUnknownTld(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: `
-data "namecheap_tld_pricing" "nope" {
-  tld = "invalidtldxyz"
-}
-`,
-				ExpectError: regexp.MustCompile(`invalidtldxyz`),
 			},
 		},
 	})

--- a/namecheap/data_source_pricing_live_test.go
+++ b/namecheap/data_source_pricing_live_test.go
@@ -1,0 +1,182 @@
+package namecheap_provider
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+// Live-sandbox acceptance tests for the two money data sources. Like the other
+// TestAcc* tests they run only under `make testacc` (TF_ACC=1) and skip via
+// testAccPreCheck when the NAMECHEAP_* credentials are absent, so they never
+// touch the real API without explicit opt-in.
+//
+// Both are strictly read-only — getBalances and getPricing charge nothing and
+// change nothing — so unlike the resource suites there is no state to restore
+// and nothing to clean up.
+
+// TestAccDataSourceAccountBalance reads the sandbox account's funds against the
+// live API. Sandbox balances are arbitrary, so the assertions are on shape, not
+// value: the currency must be a three-letter code and every amount must be a
+// decimal string the API actually sent — which is what proves the exact-decimal
+// contract survives a real response rather than only a crafted one.
+func TestAccDataSourceAccountBalance(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `data "namecheap_account_balance" "current" {}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("data.namecheap_account_balance.current", "currency", regexp.MustCompile(`^[A-Z]{3}$`)),
+					testAccCheckIsDecimalString("data.namecheap_account_balance.current", "available_balance"),
+					testAccCheckIsDecimalString("data.namecheap_account_balance.current", "account_balance"),
+					testAccCheckIsDecimalString("data.namecheap_account_balance.current", "earned_amount"),
+					testAccCheckIsDecimalString("data.namecheap_account_balance.current", "withdrawable_amount"),
+					testAccCheckIsDecimalString("data.namecheap_account_balance.current", "funds_required_for_auto_renew"),
+					resource.TestCheckResourceAttr("data.namecheap_account_balance.current", "id", accountBalanceID),
+				),
+			},
+		},
+	})
+}
+
+// TestAccDataSourceTldPricing prices .com for all three actions against the live
+// API. It is the only test in the suite that observes the real getPricing
+// response shape, so it is what confirms the SDK's attribute names still match
+// the server: a renamed or dropped Price attribute shows up here as an empty
+// exported value, not as a passing test.
+func TestAccDataSourceTldPricing(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+data "namecheap_tld_pricing" "register" {
+  tld    = "com"
+  action = "REGISTER"
+  years  = 1
+}
+
+data "namecheap_tld_pricing" "renew" {
+  tld    = "com"
+  action = "RENEW"
+  years  = 1
+}
+
+data "namecheap_tld_pricing" "transfer" {
+  tld    = "com"
+  action = "TRANSFER"
+  years  = 1
+}
+`,
+				Check: resource.ComposeTestCheckFunc(
+					// Every action publishes a 1-year .com tier with a real price.
+					testAccCheckIsDecimalString("data.namecheap_tld_pricing.register", "price"),
+					testAccCheckIsDecimalString("data.namecheap_tld_pricing.register", "regular_price"),
+					testAccCheckIsDecimalString("data.namecheap_tld_pricing.renew", "price"),
+					testAccCheckIsDecimalString("data.namecheap_tld_pricing.transfer", "price"),
+					resource.TestCheckResourceAttr("data.namecheap_tld_pricing.register", "duration_type", "YEAR"),
+					resource.TestCheckResourceAttr("data.namecheap_tld_pricing.register", "id", "pricing:com:REGISTER:1"),
+					resource.TestCheckResourceAttr("data.namecheap_tld_pricing.renew", "id", "pricing:com:RENEW:1"),
+					resource.TestCheckResourceAttr("data.namecheap_tld_pricing.transfer", "id", "pricing:com:TRANSFER:1"),
+					// Currency is optional per tier, so its absence is not a failure —
+					// but when the server does send it, it must be a currency code.
+					testAccCheckOptionalPattern("data.namecheap_tld_pricing.register", "currency", regexp.MustCompile(`^[A-Z]{3}$`)),
+					// Same for the promotional price: absent is fine, malformed is not.
+					// This is the only place the real PromotionPrice shape is observed.
+					testAccCheckOptionalPattern("data.namecheap_tld_pricing.register", "promo_price", regexp.MustCompile(`^-?\d+(\.\d+)?$`)),
+					// Log what the live API actually returned for the optional
+					// attributes, so a sandbox run leaves evidence of the response
+					// shape rather than only a pass/fail.
+					testAccLogAttrs("data.namecheap_tld_pricing.register", "price", "regular_price", "your_price", "promo_price", "currency"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccDataSourceTldPricingUnknownTld asserts the live API's answer for a TLD
+// Namecheap does not sell surfaces as a diagnostic naming it, rather than an
+// empty price. It is the live counterpart of the mock's not-found case, and
+// guards against the API changing an unknown product from "empty sheet" to
+// something the provider would misread as a valid tier.
+func TestAccDataSourceTldPricingUnknownTld(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+data "namecheap_tld_pricing" "nope" {
+  tld = "invalidtldxyz"
+}
+`,
+				ExpectError: regexp.MustCompile(`invalidtldxyz`),
+			},
+		},
+	})
+}
+
+// testAccCheckIsDecimalString asserts an attribute is present and is a bare
+// decimal number as a string — no currency symbol, no thousands separator, no
+// scientific notation — which is the exported-money contract both data sources
+// promise.
+func testAccCheckIsDecimalString(name, attr string) resource.TestCheckFunc {
+	decimal := regexp.MustCompile(`^-?\d+(\.\d+)?$`)
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("data source %s not found in state", name)
+		}
+		value, ok := rs.Primary.Attributes[attr]
+		if !ok {
+			return fmt.Errorf("%s.%s not set", name, attr)
+		}
+		if !decimal.MatchString(value) {
+			return fmt.Errorf("%s.%s = %q, want a bare decimal string", name, attr, value)
+		}
+		return nil
+	}
+}
+
+// testAccCheckOptionalPattern asserts an attribute matches pattern when it is
+// non-empty, and passes when it is empty. It is for attributes the API may
+// legitimately omit, where asserting presence would make the test fail on a
+// server that is behaving correctly.
+func testAccCheckOptionalPattern(name, attr string, pattern *regexp.Regexp) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("data source %s not found in state", name)
+		}
+		value := rs.Primary.Attributes[attr]
+		if value == "" {
+			return nil
+		}
+		if !pattern.MatchString(value) {
+			return fmt.Errorf("%s.%s = %q, want empty or matching %s", name, attr, value, pattern)
+		}
+		return nil
+	}
+}
+
+// testAccLogAttrs prints the given attributes to the test log. It never fails;
+// its purpose is to record what the live API returned, so a sandbox run is
+// evidence about the response shape and not just a green tick.
+func testAccLogAttrs(name string, attrs ...string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("data source %s not found in state", name)
+		}
+		for _, attr := range attrs {
+			fmt.Printf("live %s.%s = %q\n", name, attr, rs.Primary.Attributes[attr])
+		}
+		return nil
+	}
+}

--- a/namecheap/data_source_pricing_read_test.go
+++ b/namecheap/data_source_pricing_read_test.go
@@ -1,0 +1,398 @@
+package namecheap_provider
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests exercise the account-balance and TLD-pricing ReadContext functions
+// directly against an in-process httptest server driving the real
+// go-namecheap-sdk client, in the same style as data_source_read_test.go. They
+// are ordinary unit tests (no build tag), so the money-formatting and
+// error-surface paths are covered by the standard `make test` run.
+
+// --- XML builders (mirror the real API envelopes the SDK parses) ------------
+
+func xmlGetBalances(currency, available, account, earned, withdrawable, autoRenew string) string {
+	return fmt.Sprintf(`<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+  <Errors />
+  <CommandResponse Type="namecheap.users.getBalances">
+    <UserGetBalancesResult Currency="%s" AvailableBalance="%s" AccountBalance="%s" EarnedAmount="%s" WithdrawableAmount="%s" FundsRequiredForAutoRenew="%s" />
+  </CommandResponse>
+</ApiResponse>`, currency, available, account, earned, withdrawable, autoRenew)
+}
+
+// dsPriceTier is a single <Price> node for building a getPricing response. An
+// empty string field is rendered as an omitted attribute, so a test can model
+// the live API's habit of dropping Currency or PromotionPrice entirely.
+type dsPriceTier struct {
+	Duration                                            int
+	DurationType                                        string
+	Price, RegularPrice, YourPrice, Currency, Promotion string
+}
+
+func (p dsPriceTier) attrs() string {
+	attrs := []string{
+		fmt.Sprintf(`Duration="%d"`, p.Duration),
+		fmt.Sprintf(`DurationType="%s"`, p.DurationType),
+	}
+	for name, value := range map[string]string{
+		"Price": p.Price, "RegularPrice": p.RegularPrice, "YourPrice": p.YourPrice,
+	} {
+		attrs = append(attrs, fmt.Sprintf(`%s="%s"`, name, value))
+	}
+	if p.Currency != "" {
+		attrs = append(attrs, fmt.Sprintf(`Currency="%s"`, p.Currency))
+	}
+	if p.Promotion != "" {
+		attrs = append(attrs, fmt.Sprintf(`PromotionPrice="%s"`, p.Promotion))
+	}
+	return strings.Join(attrs, " ")
+}
+
+func xmlGetPricing(category, product string, tiers ...dsPriceTier) string {
+	var prices []string
+	for _, t := range tiers {
+		prices = append(prices, fmt.Sprintf(`<Price %s />`, t.attrs()))
+	}
+	return fmt.Sprintf(`<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+  <Errors />
+  <CommandResponse Type="namecheap.users.getPricing">
+    <UserGetPricingResult>
+      <ProductType Name="domains">
+        <ProductCategory Name="%s">
+          <Product Name="%s">
+            %s
+          </Product>
+        </ProductCategory>
+      </ProductType>
+    </UserGetPricingResult>
+  </CommandResponse>
+</ApiResponse>`, category, product, strings.Join(prices, "\n            "))
+}
+
+// --- namecheap_account_balance ----------------------------------------------
+
+func TestDataSourceAccountBalanceRead_Success(t *testing.T) {
+	client := startDataSourceServer(t, func(command string, _ *http.Request) string {
+		if command == "namecheap.users.getBalances" {
+			return xmlGetBalances("USD", "123.45", "123.45", "15.00", "100.00", "42.50")
+		}
+		return apiErrorXML("1010101", "unexpected command "+command)
+	})
+
+	d := schema.TestResourceDataRaw(t, dataSourceNamecheapAccountBalance().Schema, map[string]interface{}{})
+	diags := dataSourceNamecheapAccountBalanceRead(context.Background(), d, client)
+	require.False(t, diags.HasError(), "unexpected diagnostics: %+v", diags)
+
+	assert.Equal(t, "USD", d.Get("currency"))
+	// Money keeps the server's exact decimal string — no float round-trip, and
+	// no reformatting of trailing zeros.
+	assert.Equal(t, "123.45", d.Get("available_balance"))
+	assert.Equal(t, "123.45", d.Get("account_balance"))
+	assert.Equal(t, "15.00", d.Get("earned_amount"))
+	assert.Equal(t, "100.00", d.Get("withdrawable_amount"))
+	assert.Equal(t, "42.50", d.Get("funds_required_for_auto_renew"))
+	assert.Equal(t, accountBalanceID, d.Id())
+}
+
+// TestDataSourceAccountBalanceRead_PrecisionPreserved pins the decimal-safety
+// contract with values a float64 round-trip would visibly damage.
+func TestDataSourceAccountBalanceRead_PrecisionPreserved(t *testing.T) {
+	client := startDataSourceServer(t, func(command string, _ *http.Request) string {
+		if command == "namecheap.users.getBalances" {
+			return xmlGetBalances("EUR", "10.87", "0.00", "1234567.89", "0.10", "8.881")
+		}
+		return apiErrorXML("1010101", "unexpected command "+command)
+	})
+
+	d := schema.TestResourceDataRaw(t, dataSourceNamecheapAccountBalance().Schema, map[string]interface{}{})
+	diags := dataSourceNamecheapAccountBalanceRead(context.Background(), d, client)
+	require.False(t, diags.HasError(), "unexpected diagnostics: %+v", diags)
+
+	assert.Equal(t, "EUR", d.Get("currency"))
+	assert.Equal(t, "10.87", d.Get("available_balance"))
+	assert.Equal(t, "0.00", d.Get("account_balance"), "a zero balance must stay \"0.00\", not become \"0\"")
+	assert.Equal(t, "1234567.89", d.Get("earned_amount"))
+	assert.Equal(t, "0.10", d.Get("withdrawable_amount"), "trailing zero must survive")
+	assert.Equal(t, "8.881", d.Get("funds_required_for_auto_renew"), "third decimal must survive")
+}
+
+func TestDataSourceAccountBalanceRead_APIError(t *testing.T) {
+	client := startDataSourceServer(t, func(string, *http.Request) string {
+		return apiErrorXML("1011102", "API Key is invalid or API access has not been enabled")
+	})
+
+	d := schema.TestResourceDataRaw(t, dataSourceNamecheapAccountBalance().Schema, map[string]interface{}{})
+	diags := dataSourceNamecheapAccountBalanceRead(context.Background(), d, client)
+	require.True(t, diags.HasError(), "an API error should surface")
+	assert.Empty(t, d.Id(), "a failed read must not set an ID")
+}
+
+// --- namecheap_tld_pricing ---------------------------------------------------
+
+func TestDataSourceTldPricingRead_Success(t *testing.T) {
+	var calls int32
+	client := startDataSourceServer(t, func(command string, r *http.Request) string {
+		if command != "namecheap.users.getPricing" {
+			return apiErrorXML("1010101", "unexpected command "+command)
+		}
+		atomic.AddInt32(&calls, 1)
+		// The request must be narrowed server-side rather than fetching the whole
+		// sheet and filtering client-side.
+		if got := r.FormValue("ProductType"); got != "DOMAIN" {
+			return apiErrorXML("1010101", "unexpected ProductType "+got)
+		}
+		if got := r.FormValue("ActionName"); got != "REGISTER" {
+			return apiErrorXML("1010101", "unexpected ActionName "+got)
+		}
+		if got := r.FormValue("ProductName"); got != "com" {
+			return apiErrorXML("1010101", "unexpected ProductName "+got)
+		}
+		return xmlGetPricing("register", "com",
+			dsPriceTier{Duration: 1, DurationType: "YEAR", Price: "8.88", RegularPrice: "10.87", YourPrice: "9.99", Currency: "USD"},
+			dsPriceTier{Duration: 2, DurationType: "YEAR", Price: "17.76", RegularPrice: "21.74", YourPrice: "19.98", Currency: "USD"},
+		)
+	})
+
+	d := schema.TestResourceDataRaw(t, dataSourceNamecheapTldPricing().Schema, map[string]interface{}{
+		"tld": "com", "action": "REGISTER", "years": 1,
+	})
+	diags := dataSourceNamecheapTldPricingRead(context.Background(), d, client)
+	require.False(t, diags.HasError(), "unexpected diagnostics: %+v", diags)
+
+	assert.Equal(t, "8.88", d.Get("price"))
+	assert.Equal(t, "10.87", d.Get("regular_price"))
+	assert.Equal(t, "9.99", d.Get("your_price"))
+	assert.Equal(t, "", d.Get("promo_price"), "no promotion in this sheet")
+	assert.Equal(t, "USD", d.Get("currency"))
+	assert.Equal(t, "YEAR", d.Get("duration_type"))
+	assert.Equal(t, "pricing:com:REGISTER:1", d.Id())
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "exactly one getPricing call per read")
+}
+
+func TestDataSourceTldPricingRead_MultiYearTier(t *testing.T) {
+	client := startDataSourceServer(t, func(command string, _ *http.Request) string {
+		if command != "namecheap.users.getPricing" {
+			return apiErrorXML("1010101", "unexpected command "+command)
+		}
+		return xmlGetPricing("register", "com",
+			dsPriceTier{Duration: 1, DurationType: "YEAR", Price: "8.88", RegularPrice: "10.87", YourPrice: "9.99", Currency: "USD"},
+			dsPriceTier{Duration: 2, DurationType: "YEAR", Price: "17.76", RegularPrice: "21.74", YourPrice: "19.98", Currency: "USD"},
+		)
+	})
+
+	d := schema.TestResourceDataRaw(t, dataSourceNamecheapTldPricing().Schema, map[string]interface{}{
+		"tld": "com", "action": "REGISTER", "years": 2,
+	})
+	diags := dataSourceNamecheapTldPricingRead(context.Background(), d, client)
+	require.False(t, diags.HasError(), "unexpected diagnostics: %+v", diags)
+	assert.Equal(t, "17.76", d.Get("price"))
+	assert.Equal(t, "pricing:com:REGISTER:2", d.Id())
+}
+
+// TestDataSourceTldPricingRead_Promotion covers the attributes that only exist
+// once the SDK parses them: a promotional tier exports promo_price and
+// still reports the server-resolved price as what is charged.
+func TestDataSourceTldPricingRead_Promotion(t *testing.T) {
+	client := startDataSourceServer(t, func(command string, _ *http.Request) string {
+		if command != "namecheap.users.getPricing" {
+			return apiErrorXML("1010101", "unexpected command "+command)
+		}
+		return xmlGetPricing("register", "shop",
+			dsPriceTier{Duration: 1, DurationType: "YEAR", Price: "1.16", RegularPrice: "19.99", YourPrice: "1.16", Currency: "EUR", Promotion: "1.16"},
+		)
+	})
+
+	d := schema.TestResourceDataRaw(t, dataSourceNamecheapTldPricing().Schema, map[string]interface{}{
+		"tld": "shop", "action": "REGISTER", "years": 1,
+	})
+	diags := dataSourceNamecheapTldPricingRead(context.Background(), d, client)
+	require.False(t, diags.HasError(), "unexpected diagnostics: %+v", diags)
+
+	assert.Equal(t, "1.16", d.Get("price"))
+	assert.Equal(t, "19.99", d.Get("regular_price"))
+	assert.Equal(t, "1.16", d.Get("promo_price"))
+	assert.Equal(t, "EUR", d.Get("currency"))
+}
+
+// TestDataSourceTldPricingRead_OptionalAttributesAbsent covers the live API's
+// habit of omitting Currency and PromotionPrice: the read must succeed and
+// export empty strings rather than failing or inventing values.
+func TestDataSourceTldPricingRead_OptionalAttributesAbsent(t *testing.T) {
+	client := startDataSourceServer(t, func(command string, _ *http.Request) string {
+		if command != "namecheap.users.getPricing" {
+			return apiErrorXML("1010101", "unexpected command "+command)
+		}
+		return xmlGetPricing("renew", "org",
+			dsPriceTier{Duration: 1, DurationType: "YEAR", Price: "0.00", RegularPrice: "9.18", YourPrice: "0.00"},
+		)
+	})
+
+	d := schema.TestResourceDataRaw(t, dataSourceNamecheapTldPricing().Schema, map[string]interface{}{
+		"tld": "org", "action": "RENEW", "years": 1,
+	})
+	diags := dataSourceNamecheapTldPricingRead(context.Background(), d, client)
+	require.False(t, diags.HasError(), "unexpected diagnostics: %+v", diags)
+
+	// Price and YourPrice are zero, so the effective price falls through to the
+	// regular price — the same precedence the SDK documents.
+	assert.Equal(t, "9.18", d.Get("price"))
+	assert.Equal(t, "", d.Get("currency"))
+	assert.Equal(t, "", d.Get("promo_price"))
+}
+
+// TestDataSourceTldPricingRead_ZeroPromotionIsReportedVerbatim guards the case
+// where the attribute is present but zero. Namecheap does not document what that
+// means — a free first year is a real promotion — so the provider reports the
+// value it was given instead of deciding it means "no promotion".
+func TestDataSourceTldPricingRead_ZeroPromotionIsReportedVerbatim(t *testing.T) {
+	client := startDataSourceServer(t, func(command string, _ *http.Request) string {
+		if command != "namecheap.users.getPricing" {
+			return apiErrorXML("1010101", "unexpected command "+command)
+		}
+		return xmlGetPricing("register", "net",
+			dsPriceTier{Duration: 1, DurationType: "YEAR", Price: "12.00", RegularPrice: "12.00", YourPrice: "12.00", Currency: "USD", Promotion: "0.00"},
+		)
+	})
+
+	d := schema.TestResourceDataRaw(t, dataSourceNamecheapTldPricing().Schema, map[string]interface{}{
+		"tld": "net", "action": "REGISTER", "years": 1,
+	})
+	diags := dataSourceNamecheapTldPricingRead(context.Background(), d, client)
+	require.False(t, diags.HasError(), "unexpected diagnostics: %+v", diags)
+	assert.Equal(t, "0.00", d.Get("promo_price"), "a zero promotion is reported, not swallowed")
+	assert.Equal(t, "12.00", d.Get("price"), "the charged price is unaffected by the promotion attribute")
+}
+
+// TestDataSourceTldPricingRead_CaseAndDotNormalization proves the request is
+// normalized before it reaches the API: an uppercase TLD and a lowercase action
+// resolve, and the ID is built from the normalized values.
+func TestDataSourceTldPricingRead_CaseAndDotNormalization(t *testing.T) {
+	var sentProduct, sentAction string
+	client := startDataSourceServer(t, func(command string, r *http.Request) string {
+		if command != "namecheap.users.getPricing" {
+			return apiErrorXML("1010101", "unexpected command "+command)
+		}
+		sentProduct = r.FormValue("ProductName")
+		sentAction = r.FormValue("ActionName")
+		return xmlGetPricing("transfer", "com",
+			dsPriceTier{Duration: 1, DurationType: "YEAR", Price: "9.06", RegularPrice: "10.87", YourPrice: "9.06", Currency: "USD"},
+		)
+	})
+
+	d := schema.TestResourceDataRaw(t, dataSourceNamecheapTldPricing().Schema, map[string]interface{}{
+		"tld": "COM", "action": "transfer", "years": 1,
+	})
+	diags := dataSourceNamecheapTldPricingRead(context.Background(), d, client)
+	require.False(t, diags.HasError(), "unexpected diagnostics: %+v", diags)
+
+	assert.Equal(t, "com", sentProduct, "TLD should be lower-cased before the request")
+	assert.Equal(t, "TRANSFER", sentAction, "action should be upper-cased before the request")
+	assert.Equal(t, "9.06", d.Get("price"))
+	assert.Equal(t, "pricing:com:TRANSFER:1", d.Id())
+}
+
+// TestDataSourceTldPricingRead_TierNotFound covers a TLD the API answers for but
+// publishes no matching tier: the diagnostic must name the TLD, action and term
+// rather than surfacing a nil-pointer or an empty price.
+func TestDataSourceTldPricingRead_TierNotFound(t *testing.T) {
+	client := startDataSourceServer(t, func(command string, _ *http.Request) string {
+		if command != "namecheap.users.getPricing" {
+			return apiErrorXML("1010101", "unexpected command "+command)
+		}
+		return xmlGetPricing("register", "com",
+			dsPriceTier{Duration: 1, DurationType: "YEAR", Price: "8.88", RegularPrice: "10.87", YourPrice: "9.99", Currency: "USD"},
+		)
+	})
+
+	d := schema.TestResourceDataRaw(t, dataSourceNamecheapTldPricing().Schema, map[string]interface{}{
+		"tld": "com", "action": "REGISTER", "years": 9,
+	})
+	diags := dataSourceNamecheapTldPricingRead(context.Background(), d, client)
+	require.True(t, diags.HasError(), "a missing tier should be an error, not an empty price")
+	assert.Contains(t, diags[0].Summary, "com")
+	assert.Contains(t, diags[0].Summary, "9 year")
+	assert.Empty(t, d.Id(), "a failed read must not set an ID")
+}
+
+func TestDataSourceTldPricingRead_APIError(t *testing.T) {
+	client := startDataSourceServer(t, func(string, *http.Request) string {
+		return apiErrorXML("2011170", "Promotion code is invalid")
+	})
+
+	d := schema.TestResourceDataRaw(t, dataSourceNamecheapTldPricing().Schema, map[string]interface{}{
+		"tld": "xyz", "action": "REGISTER", "years": 1,
+	})
+	diags := dataSourceNamecheapTldPricingRead(context.Background(), d, client)
+	require.True(t, diags.HasError(), "an API error should surface")
+	assert.Contains(t, diags[0].Summary, "xyz", "diagnostic should name the TLD")
+	assert.Contains(t, diags[0].Summary, "REGISTER", "diagnostic should name the action")
+}
+
+// TestValidateTld pins the plan-time input validation, which is what keeps a
+// mistyped TLD from becoming a confusing empty-response error at apply time.
+func TestValidateTld(t *testing.T) {
+	tests := []struct {
+		name    string
+		tld     string
+		wantErr bool
+	}{
+		{"simple tld", "com", false},
+		{"multi-label tld", "co.uk", false},
+		{"idn-style tld", "xn--p1ai", false},
+		{"empty", "", true},
+		{"leading dot", ".com", true},
+		{"leading whitespace", " com", true},
+		{"trailing whitespace", "com ", true},
+		{"domain name", "example.com/path", true},
+		{"url", "https://example.com", true},
+		{"space inside", "co uk", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, errs := validateTld(tc.tld, "tld")
+			if tc.wantErr {
+				assert.NotEmpty(t, errs, "validateTld(%q) = no error, want error", tc.tld)
+				return
+			}
+			assert.Empty(t, errs, "validateTld(%q) = %v, want no error", tc.tld, errs)
+		})
+	}
+}
+
+// TestDataSourcePricingSchemasAreReadOnly guards the compatibility contract of
+// this change: both data sources are read-only, so every attribute other than
+// the documented inputs must be Computed and none may be Required except tld.
+// A future edit that makes an attribute writable would change plan behaviour for
+// existing configurations, and this test fails first.
+func TestDataSourcePricingSchemasAreReadOnly(t *testing.T) {
+	inputs := map[string]bool{"tld": true, "action": true, "years": true}
+
+	for name, ds := range map[string]*schema.Resource{
+		"namecheap_account_balance": dataSourceNamecheapAccountBalance(),
+		"namecheap_tld_pricing":     dataSourceNamecheapTldPricing(),
+	} {
+		for attr, s := range ds.Schema {
+			if inputs[attr] {
+				continue
+			}
+			assert.True(t, s.Computed, "%s.%s must be Computed", name, attr)
+			assert.False(t, s.Required, "%s.%s must not be Required", name, attr)
+			assert.False(t, s.Optional, "%s.%s must not be Optional", name, attr)
+		}
+		assert.Nil(t, ds.CreateContext, "%s must not define a create", name)
+		assert.Nil(t, ds.UpdateContext, "%s must not define an update", name)
+		assert.Nil(t, ds.DeleteContext, "%s must not define a delete", name)
+	}
+}

--- a/namecheap/data_source_pricing_read_test.go
+++ b/namecheap/data_source_pricing_read_test.go
@@ -45,10 +45,10 @@ func (p dsPriceTier) attrs() string {
 		fmt.Sprintf(`Duration="%d"`, p.Duration),
 		fmt.Sprintf(`DurationType="%s"`, p.DurationType),
 	}
-	for name, value := range map[string]string{
-		"Price": p.Price, "RegularPrice": p.RegularPrice, "YourPrice": p.YourPrice,
+	for _, a := range []struct{ name, value string }{
+		{"Price", p.Price}, {"RegularPrice", p.RegularPrice}, {"YourPrice", p.YourPrice},
 	} {
-		attrs = append(attrs, fmt.Sprintf(`%s="%s"`, name, value))
+		attrs = append(attrs, fmt.Sprintf(`%s="%s"`, a.name, a.value))
 	}
 	if p.Currency != "" {
 		attrs = append(attrs, fmt.Sprintf(`Currency="%s"`, p.Currency))
@@ -103,7 +103,7 @@ func TestDataSourceAccountBalanceRead_Success(t *testing.T) {
 	assert.Equal(t, "15.00", d.Get("earned_amount"))
 	assert.Equal(t, "100.00", d.Get("withdrawable_amount"))
 	assert.Equal(t, "42.50", d.Get("funds_required_for_auto_renew"))
-	assert.Equal(t, accountBalanceID, d.Id())
+	assert.Equal(t, "account_balance", d.Id(), "the ID is part of the data source's contract; changing it moves every consumer's state address")
 }
 
 // TestDataSourceAccountBalanceRead_PrecisionPreserved pins the decimal-safety
@@ -136,6 +136,26 @@ func TestDataSourceAccountBalanceRead_APIError(t *testing.T) {
 	d := schema.TestResourceDataRaw(t, dataSourceNamecheapAccountBalance().Schema, map[string]interface{}{})
 	diags := dataSourceNamecheapAccountBalanceRead(context.Background(), d, client)
 	require.True(t, diags.HasError(), "an API error should surface")
+	assert.Empty(t, d.Id(), "a failed read must not set an ID")
+}
+
+// TestDataSourceAccountBalanceRead_MalformedEnvelope covers a Status=OK response
+// whose CommandResponse carries no result element. The SDK reports no error for
+// it, so the provider's own guard is what stops a nil dereference — and what
+// stops an apparently-successful read of an all-empty balance.
+func TestDataSourceAccountBalanceRead_MalformedEnvelope(t *testing.T) {
+	client := startDataSourceServer(t, func(string, *http.Request) string {
+		return `<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+  <Errors />
+  <CommandResponse Type="namecheap.users.getBalances"></CommandResponse>
+</ApiResponse>`
+	})
+
+	d := schema.TestResourceDataRaw(t, dataSourceNamecheapAccountBalance().Schema, map[string]interface{}{})
+	diags := dataSourceNamecheapAccountBalanceRead(context.Background(), d, client)
+	require.True(t, diags.HasError(), "a result-less response must not read as a zero balance")
+	assert.Equal(t, "", d.Get("available_balance"))
 	assert.Empty(t, d.Id(), "a failed read must not set an ID")
 }
 
@@ -252,17 +272,19 @@ func TestDataSourceTldPricingRead_OptionalAttributesAbsent(t *testing.T) {
 	assert.Equal(t, "", d.Get("promo_price"))
 }
 
-// TestDataSourceTldPricingRead_ZeroPromotionIsReportedVerbatim guards the case
-// where the attribute is present but zero. Namecheap does not document what that
-// means — a free first year is a real promotion — so the provider reports the
-// value it was given instead of deciding it means "no promotion".
-func TestDataSourceTldPricingRead_ZeroPromotionIsReportedVerbatim(t *testing.T) {
+// TestDataSourceTldPricingRead_ZeroPromotionIsNoPromotion pins the behaviour the
+// live API forced: it answers un-promoted tiers with PromotionPrice="0.0"
+// rather than omitting the attribute (observed for .com REGISTER/RENEW/TRANSFER,
+// all with price == regular_price), so a non-positive promotional price must
+// export as empty. Without this, promo_price would report a promotion on
+// essentially every lookup.
+func TestDataSourceTldPricingRead_ZeroPromotionIsNoPromotion(t *testing.T) {
 	client := startDataSourceServer(t, func(command string, _ *http.Request) string {
 		if command != "namecheap.users.getPricing" {
 			return apiErrorXML("1010101", "unexpected command "+command)
 		}
 		return xmlGetPricing("register", "net",
-			dsPriceTier{Duration: 1, DurationType: "YEAR", Price: "12.00", RegularPrice: "12.00", YourPrice: "12.00", Currency: "USD", Promotion: "0.00"},
+			dsPriceTier{Duration: 1, DurationType: "YEAR", Price: "12.00", RegularPrice: "12.00", YourPrice: "12.00", Currency: "USD", Promotion: "0.0"},
 		)
 	})
 
@@ -271,14 +293,154 @@ func TestDataSourceTldPricingRead_ZeroPromotionIsReportedVerbatim(t *testing.T) 
 	})
 	diags := dataSourceNamecheapTldPricingRead(context.Background(), d, client)
 	require.False(t, diags.HasError(), "unexpected diagnostics: %+v", diags)
-	assert.Equal(t, "0.00", d.Get("promo_price"), "a zero promotion is reported, not swallowed")
+	assert.Equal(t, "", d.Get("promo_price"), "a non-positive promotion is not a promotion")
 	assert.Equal(t, "12.00", d.Get("price"), "the charged price is unaffected by the promotion attribute")
 }
 
-// TestDataSourceTldPricingRead_CaseAndDotNormalization proves the request is
+// TestDataSourceTldPricingRead_PrecedenceRungs walks each rung of the three-level
+// precedence the docs promise. The middle rung — falling through a zero Price to
+// YourPrice — is the one a two-level implementation would still pass without.
+func TestDataSourceTldPricingRead_PrecedenceRungs(t *testing.T) {
+	tests := []struct {
+		name      string
+		tier      dsPriceTier
+		wantPrice string
+	}{
+		{
+			name:      "server price wins",
+			tier:      dsPriceTier{Duration: 1, DurationType: "YEAR", Price: "8.88", RegularPrice: "10.87", YourPrice: "9.99"},
+			wantPrice: "8.88",
+		},
+		{
+			name:      "zero server price falls through to your price",
+			tier:      dsPriceTier{Duration: 1, DurationType: "YEAR", Price: "0.00", RegularPrice: "10.87", YourPrice: "9.99"},
+			wantPrice: "9.99",
+		},
+		{
+			name:      "zero server and account price fall through to regular",
+			tier:      dsPriceTier{Duration: 1, DurationType: "YEAR", Price: "0.00", RegularPrice: "10.87", YourPrice: "0.00"},
+			wantPrice: "10.87",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tier := tc.tier
+			client := startDataSourceServer(t, func(command string, _ *http.Request) string {
+				if command != "namecheap.users.getPricing" {
+					return apiErrorXML("1010101", "unexpected command "+command)
+				}
+				return xmlGetPricing("register", "com", tier)
+			})
+
+			d := schema.TestResourceDataRaw(t, dataSourceNamecheapTldPricing().Schema, map[string]interface{}{
+				"tld": "com", "action": "REGISTER", "years": 1,
+			})
+			diags := dataSourceNamecheapTldPricingRead(context.Background(), d, client)
+			require.False(t, diags.HasError(), "unexpected diagnostics: %+v", diags)
+			assert.Equal(t, tc.wantPrice, d.Get("price"))
+		})
+	}
+}
+
+// TestDataSourceTldPricingRead_DurationTypeVerbatim asserts duration_type is the
+// server's own value rather than a hardcoded "YEAR". The SDK matches the tier
+// case-insensitively, so a server that answers "Year" must export "Year".
+func TestDataSourceTldPricingRead_DurationTypeVerbatim(t *testing.T) {
+	client := startDataSourceServer(t, func(command string, _ *http.Request) string {
+		if command != "namecheap.users.getPricing" {
+			return apiErrorXML("1010101", "unexpected command "+command)
+		}
+		return xmlGetPricing("register", "com",
+			dsPriceTier{Duration: 1, DurationType: "Year", Price: "8.88", RegularPrice: "10.87", YourPrice: "8.88", Currency: "USD"},
+		)
+	})
+
+	d := schema.TestResourceDataRaw(t, dataSourceNamecheapTldPricing().Schema, map[string]interface{}{
+		"tld": "com", "action": "REGISTER", "years": 1,
+	})
+	diags := dataSourceNamecheapTldPricingRead(context.Background(), d, client)
+	require.False(t, diags.HasError(), "unexpected diagnostics: %+v", diags)
+	assert.Equal(t, "Year", d.Get("duration_type"), "duration_type must be the server's value, not a constant")
+}
+
+// TestDataSourceTldPricingRead_MultiLabelTld covers the dotted product name the
+// docs advertise (co.uk). Nothing else in the suite proves a multi-label TLD
+// resolves, so without this the docs' central example is an untested claim.
+func TestDataSourceTldPricingRead_MultiLabelTld(t *testing.T) {
+	var sentProduct string
+	client := startDataSourceServer(t, func(command string, r *http.Request) string {
+		if command != "namecheap.users.getPricing" {
+			return apiErrorXML("1010101", "unexpected command "+command)
+		}
+		sentProduct = r.FormValue("ProductName")
+		return xmlGetPricing("register", "co.uk",
+			dsPriceTier{Duration: 1, DurationType: "YEAR", Price: "7.48", RegularPrice: "9.98", YourPrice: "7.48", Currency: "GBP"},
+		)
+	})
+
+	d := schema.TestResourceDataRaw(t, dataSourceNamecheapTldPricing().Schema, map[string]interface{}{
+		"tld": "co.uk", "action": "REGISTER", "years": 1,
+	})
+	diags := dataSourceNamecheapTldPricingRead(context.Background(), d, client)
+	require.False(t, diags.HasError(), "unexpected diagnostics: %+v", diags)
+	assert.Equal(t, "co.uk", sentProduct)
+	assert.Equal(t, "7.48", d.Get("price"))
+	assert.Equal(t, "GBP", d.Get("currency"))
+	assert.Equal(t, "pricing:co.uk:REGISTER:1", d.Id())
+}
+
+// TestDataSourceTldPricingRead_BlankPromotionIsAbsent covers a promotional
+// attribute the server sends as whitespace. It must read as absent rather than
+// being exported as a blank-looking price, which is the one behaviour that
+// distinguishes going through Promo() from reading the raw field.
+func TestDataSourceTldPricingRead_BlankPromotionIsAbsent(t *testing.T) {
+	client := startDataSourceServer(t, func(command string, _ *http.Request) string {
+		if command != "namecheap.users.getPricing" {
+			return apiErrorXML("1010101", "unexpected command "+command)
+		}
+		return xmlGetPricing("register", "info",
+			dsPriceTier{Duration: 1, DurationType: "YEAR", Price: "3.98", RegularPrice: "3.98", YourPrice: "3.98", Currency: "USD", Promotion: "   "},
+		)
+	})
+
+	d := schema.TestResourceDataRaw(t, dataSourceNamecheapTldPricing().Schema, map[string]interface{}{
+		"tld": "info", "action": "REGISTER", "years": 1,
+	})
+	diags := dataSourceNamecheapTldPricingRead(context.Background(), d, client)
+	require.False(t, diags.HasError(), "unexpected diagnostics: %+v", diags)
+	assert.Equal(t, "", d.Get("promo_price"), "a whitespace-only promotion is not a promotion")
+	assert.Equal(t, "3.98", d.Get("price"))
+}
+
+// TestDataSourceTldPricingRead_MalformedEnvelope covers a Status=OK response
+// whose CommandResponse carries no result element. The SDK reports no error for
+// it, so without the provider's own guard the read would dereference a nil
+// result; the guard must turn it into a diagnostic instead.
+func TestDataSourceTldPricingRead_MalformedEnvelope(t *testing.T) {
+	client := startDataSourceServer(t, func(string, *http.Request) string {
+		return `<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+  <Errors />
+  <CommandResponse Type="namecheap.users.getPricing"></CommandResponse>
+</ApiResponse>`
+	})
+
+	d := schema.TestResourceDataRaw(t, dataSourceNamecheapTldPricing().Schema, map[string]interface{}{
+		"tld": "com", "action": "REGISTER", "years": 1,
+	})
+	diags := dataSourceNamecheapTldPricingRead(context.Background(), d, client)
+	require.True(t, diags.HasError(), "a result-less response must not read as a valid price")
+	assert.Contains(t, diags[0].Summary, "com")
+	assert.Empty(t, d.Id(), "a failed read must not set an ID")
+}
+
+// TestDataSourceTldPricingRead_CaseNormalization proves the request is
 // normalized before it reaches the API: an uppercase TLD and a lowercase action
-// resolve, and the ID is built from the normalized values.
-func TestDataSourceTldPricingRead_CaseAndDotNormalization(t *testing.T) {
+// resolve, and the ID is built from the normalized values. The lowercase action
+// is reachable from a real config because the validator ignores case — see
+// TestAccMockDataSourceTldPricingLowercaseAction, which drives it through
+// Terraform rather than around the validator as this test does.
+func TestDataSourceTldPricingRead_CaseNormalization(t *testing.T) {
 	var sentProduct, sentAction string
 	client := startDataSourceServer(t, func(command string, r *http.Request) string {
 		if command != "namecheap.users.getPricing" {
@@ -355,7 +517,13 @@ func TestValidateTld(t *testing.T) {
 		{"leading dot", ".com", true},
 		{"leading whitespace", " com", true},
 		{"trailing whitespace", "com ", true},
-		{"domain name", "example.com/path", true},
+		{"url path", "example.com/path", true},
+		{"trailing dot", "com.", true},
+		{"internal newline", "co\nuk", true},
+		// A bare domain name cannot be rejected: it is structurally identical to a
+		// legitimate multi-label TLD, so it is accepted here and fails later as
+		// "no published price".
+		{"bare domain name is accepted", "example.com", false},
 		{"url", "https://example.com", true},
 		{"space inside", "co uk", true},
 	}

--- a/namecheap/mock_pricing_test.go
+++ b/namecheap/mock_pricing_test.go
@@ -1,0 +1,314 @@
+//go:build testacc
+
+package namecheap_provider
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+// Mock-backed acceptance coverage for the two money data sources. These run the
+// real Terraform binary against the stateful mock, so they cover the plan/apply
+// path — schema wiring, validation diagnostics and the cost-aware precondition
+// pattern the registry docs recommend — which the direct ReadContext unit tests
+// in data_source_pricing_read_test.go cannot reach.
+
+// TestAccMockDataSourceAccountBalance reads the account funds and asserts every
+// exported attribute, including that amounts keep the server's exact decimal
+// string rather than being reformatted through a float.
+func TestAccMockDataSourceAccountBalance(t *testing.T) {
+	m := newNamecheapMock(t)
+	m.seedBalances(mockAccountBalance{
+		Currency:                  "USD",
+		AvailableBalance:          "123.45",
+		AccountBalance:            "123.45",
+		EarnedAmount:              "15.00",
+		WithdrawableAmount:        "100.10",
+		FundsRequiredForAutoRenew: "42.50",
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { mockPreCheck(t, m) },
+		ProviderFactories: mockProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: `
+data "namecheap_account_balance" "current" {}
+`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.namecheap_account_balance.current", "currency", "USD"),
+					resource.TestCheckResourceAttr("data.namecheap_account_balance.current", "available_balance", "123.45"),
+					resource.TestCheckResourceAttr("data.namecheap_account_balance.current", "account_balance", "123.45"),
+					resource.TestCheckResourceAttr("data.namecheap_account_balance.current", "earned_amount", "15.00"),
+					// A trailing zero surviving proves the value is passed through as
+					// the server's decimal string, not parsed and re-rendered.
+					resource.TestCheckResourceAttr("data.namecheap_account_balance.current", "withdrawable_amount", "100.10"),
+					resource.TestCheckResourceAttr("data.namecheap_account_balance.current", "funds_required_for_auto_renew", "42.50"),
+					resource.TestCheckResourceAttr("data.namecheap_account_balance.current", "id", accountBalanceID),
+				),
+			},
+		},
+	})
+}
+
+// TestAccMockDataSourceAccountBalanceError asserts an API failure on the balance
+// read surfaces as a diagnostic instead of an empty, apparently-broke account.
+func TestAccMockDataSourceAccountBalanceError(t *testing.T) {
+	m := newNamecheapMock(t) // no seedBalances: the mock answers with an API error
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { mockPreCheck(t, m) },
+		ProviderFactories: mockProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: `
+data "namecheap_account_balance" "current" {}
+`,
+				ExpectError: regexp.MustCompile("balances are not available"),
+			},
+		},
+	})
+}
+
+// TestAccMockDataSourceTldPricing reads a single TLD price and asserts the
+// exported attributes plus the absence of any collateral API traffic — the read
+// must be one narrowed getPricing call, not a portfolio walk.
+func TestAccMockDataSourceTldPricing(t *testing.T) {
+	m := newNamecheapMock(t)
+	m.seedPricing("REGISTER", "com",
+		mockPriceTier{Duration: 1, DurationType: "YEAR", Price: "8.88", RegularPrice: "10.87", YourPrice: "9.99", Currency: "USD"},
+		mockPriceTier{Duration: 2, DurationType: "YEAR", Price: "17.76", RegularPrice: "21.74", YourPrice: "19.98", Currency: "USD"},
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { mockPreCheck(t, m) },
+		ProviderFactories: mockProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: `
+data "namecheap_tld_pricing" "com" {
+  tld    = "com"
+  action = "REGISTER"
+  years  = 1
+}
+`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.namecheap_tld_pricing.com", "price", "8.88"),
+					resource.TestCheckResourceAttr("data.namecheap_tld_pricing.com", "regular_price", "10.87"),
+					resource.TestCheckResourceAttr("data.namecheap_tld_pricing.com", "your_price", "9.99"),
+					resource.TestCheckResourceAttr("data.namecheap_tld_pricing.com", "promo_price", ""),
+					resource.TestCheckResourceAttr("data.namecheap_tld_pricing.com", "currency", "USD"),
+					resource.TestCheckResourceAttr("data.namecheap_tld_pricing.com", "duration_type", "YEAR"),
+					resource.TestCheckResourceAttr("data.namecheap_tld_pricing.com", "id", "pricing:com:REGISTER:1"),
+					assertNoCommands(m, "namecheap.domains.getList", "namecheap.domains.getInfo", "namecheap.domains.dns.getHosts"),
+					assertCommandCalled(m, "namecheap.users.getPricing"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccMockDataSourceTldPricingPromotion covers a promotional tier end to end:
+// promo_price reports the discount while price still reports what is
+// actually charged.
+func TestAccMockDataSourceTldPricingPromotion(t *testing.T) {
+	m := newNamecheapMock(t)
+	m.seedPricing("REGISTER", "shop",
+		mockPriceTier{Duration: 1, DurationType: "YEAR", Price: "1.16", RegularPrice: "19.99", YourPrice: "1.16", Currency: "EUR", Promotion: "1.16"},
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { mockPreCheck(t, m) },
+		ProviderFactories: mockProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: `
+data "namecheap_tld_pricing" "shop" {
+  tld = "shop"
+}
+`,
+				Check: resource.ComposeTestCheckFunc(
+					// action defaults to REGISTER and years to 1.
+					resource.TestCheckResourceAttr("data.namecheap_tld_pricing.shop", "action", "REGISTER"),
+					resource.TestCheckResourceAttr("data.namecheap_tld_pricing.shop", "years", "1"),
+					resource.TestCheckResourceAttr("data.namecheap_tld_pricing.shop", "price", "1.16"),
+					resource.TestCheckResourceAttr("data.namecheap_tld_pricing.shop", "promo_price", "1.16"),
+					resource.TestCheckResourceAttr("data.namecheap_tld_pricing.shop", "regular_price", "19.99"),
+					resource.TestCheckResourceAttr("data.namecheap_tld_pricing.shop", "currency", "EUR"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccMockDataSourceTldPricingUnknownTld asserts that a TLD Namecheap does
+// not price produces a diagnostic naming it, rather than a silent zero price.
+func TestAccMockDataSourceTldPricingUnknownTld(t *testing.T) {
+	m := newNamecheapMock(t) // nothing seeded: every lookup returns an empty sheet
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { mockPreCheck(t, m) },
+		ProviderFactories: mockProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: `
+data "namecheap_tld_pricing" "nope" {
+  tld = "notatld"
+}
+`,
+				ExpectError: regexp.MustCompile(`No REGISTER price published for \.notatld`),
+			},
+		},
+	})
+}
+
+// TestAccMockDataSourceTldPricingInvalidInput asserts the plan-time validators
+// reject bad input before any API call is made.
+func TestAccMockDataSourceTldPricingInvalidInput(t *testing.T) {
+	m := newNamecheapMock(t)
+
+	for name, tc := range map[string]struct{ config, wantErr string }{
+		"leading dot": {
+			config: `
+data "namecheap_tld_pricing" "t" {
+  tld = ".com"
+}
+`,
+			wantErr: `without a leading dot`,
+		},
+		"unknown action": {
+			config: `
+data "namecheap_tld_pricing" "t" {
+  tld    = "com"
+  action = "BUY"
+}
+`,
+			wantErr: `expected action to be one of`,
+		},
+		"years out of range": {
+			config: `
+data "namecheap_tld_pricing" "t" {
+  tld   = "com"
+  years = 99
+}
+`,
+			wantErr: `expected years to be in the range`,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:          func() { mockPreCheck(t, m) },
+				ProviderFactories: mockProviderFactories(),
+				Steps: []resource.TestStep{
+					{
+						Config:      tc.config,
+						ExpectError: regexp.MustCompile(tc.wantErr),
+					},
+				},
+			})
+		})
+	}
+}
+
+// TestAccMockCostAwarePreconditionBlocks is the pattern the registry docs
+// recommend: gate a charge-bearing apply on the account balance. With funds
+// below the threshold the plan fails with the operator's own message, before
+// anything is spent.
+func TestAccMockCostAwarePreconditionBlocks(t *testing.T) {
+	m := newNamecheapMock(t)
+	m.seedBalances(mockAccountBalance{Currency: "USD", AvailableBalance: "3.20", AccountBalance: "3.20"})
+	m.seedPricing("REGISTER", "com",
+		mockPriceTier{Duration: 1, DurationType: "YEAR", Price: "8.88", RegularPrice: "10.87", YourPrice: "9.99", Currency: "USD"},
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { mockPreCheck(t, m) },
+		ProviderFactories: mockProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config:      costAwareConfig,
+				ExpectError: regexp.MustCompile("Insufficient Namecheap balance"),
+			},
+		},
+	})
+}
+
+// TestAccMockCostAwarePreconditionPasses is the same configuration with enough
+// funds: the precondition holds and the composed outputs resolve, proving the
+// two data sources compose as documented rather than only failing convincingly.
+func TestAccMockCostAwarePreconditionPasses(t *testing.T) {
+	m := newNamecheapMock(t)
+	m.seedBalances(mockAccountBalance{Currency: "USD", AvailableBalance: "250.00", AccountBalance: "250.00"})
+	m.seedPricing("REGISTER", "com",
+		mockPriceTier{Duration: 1, DurationType: "YEAR", Price: "8.88", RegularPrice: "10.87", YourPrice: "9.99", Currency: "USD"},
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { mockPreCheck(t, m) },
+		ProviderFactories: mockProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: costAwareConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckOutput("registration_cost", "8.88"),
+					resource.TestCheckOutput("balance", "250.00"),
+				),
+			},
+		},
+	})
+}
+
+// costAwareConfig is the documented cost-aware pattern: read the price, read the
+// balance, and refuse to proceed unless the funds cover the purchase. tonumber()
+// is applied only at the comparison, keeping the exported values exact decimals.
+const costAwareConfig = `
+data "namecheap_account_balance" "current" {}
+
+data "namecheap_tld_pricing" "com" {
+  tld    = "com"
+  action = "REGISTER"
+  years  = 1
+}
+
+output "registration_cost" {
+  value = data.namecheap_tld_pricing.com.price
+}
+
+output "balance" {
+  value = data.namecheap_account_balance.current.available_balance
+
+  precondition {
+    condition = tonumber(data.namecheap_account_balance.current.available_balance) >= tonumber(data.namecheap_tld_pricing.com.price)
+    error_message = "Insufficient Namecheap balance for registration."
+  }
+}
+`
+
+// assertCommandCalled returns a check asserting the mock served at least one
+// request for command.
+func assertCommandCalled(m *namecheapMock, command string) resource.TestCheckFunc {
+	return func(*terraform.State) error {
+		if got := m.commandCount(command); got == 0 {
+			return fmt.Errorf("commandCount(%q) = 0, want at least 1", command)
+		}
+		return nil
+	}
+}
+
+// assertNoCommands returns a check asserting the mock never served any of the
+// given commands, pinning that a pricing read does not fan out into unrelated
+// API traffic.
+func assertNoCommands(m *namecheapMock, commands ...string) resource.TestCheckFunc {
+	return func(*terraform.State) error {
+		for _, command := range commands {
+			if got := m.commandCount(command); got != 0 {
+				return fmt.Errorf("commandCount(%q) = %d, want 0", command, got)
+			}
+		}
+		return nil
+	}
+}

--- a/namecheap/mock_pricing_test.go
+++ b/namecheap/mock_pricing_test.go
@@ -105,7 +105,11 @@ data "namecheap_tld_pricing" "com" {
 					resource.TestCheckResourceAttr("data.namecheap_tld_pricing.com", "duration_type", "YEAR"),
 					resource.TestCheckResourceAttr("data.namecheap_tld_pricing.com", "id", "pricing:com:REGISTER:1"),
 					assertNoCommands(m, "namecheap.domains.getList", "namecheap.domains.getInfo", "namecheap.domains.dns.getHosts"),
-					assertCommandCalled(m, "namecheap.users.getPricing"),
+					// Issue #255's acceptance criterion: one narrowed call per read,
+					// not a walk of the price sheet. Checks run after apply and
+					// before the post-apply idempotency plan, so the count is
+					// deterministic here.
+					assertCommandCount(m, "namecheap.users.getPricing", 1),
 				),
 			},
 		},
@@ -139,6 +143,65 @@ data "namecheap_tld_pricing" "shop" {
 					resource.TestCheckResourceAttr("data.namecheap_tld_pricing.shop", "promo_price", "1.16"),
 					resource.TestCheckResourceAttr("data.namecheap_tld_pricing.shop", "regular_price", "19.99"),
 					resource.TestCheckResourceAttr("data.namecheap_tld_pricing.shop", "currency", "EUR"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccMockDataSourceTldPricingLowercaseAction drives a lowercase action
+// through real Terraform, which is the only way to exercise the validator and
+// the provider's upper-casing together. The unit test for normalization builds
+// its ResourceData directly and so bypasses ValidateFunc entirely.
+func TestAccMockDataSourceTldPricingLowercaseAction(t *testing.T) {
+	m := newNamecheapMock(t)
+	m.seedPricing("TRANSFER", "com",
+		mockPriceTier{Duration: 1, DurationType: "YEAR", Price: "9.06", RegularPrice: "10.87", YourPrice: "9.06", Currency: "USD"},
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { mockPreCheck(t, m) },
+		ProviderFactories: mockProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: `
+data "namecheap_tld_pricing" "com" {
+  tld    = "COM"
+  action = "transfer"
+}
+`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.namecheap_tld_pricing.com", "price", "9.06"),
+					// The ID carries the normalized values even though the config did not.
+					resource.TestCheckResourceAttr("data.namecheap_tld_pricing.com", "id", "pricing:com:TRANSFER:1"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccMockDataSourceTldPricingZeroPromotion is the live API's actual shape:
+// an un-promoted tier carries PromotionPrice="0.0". Through the full Terraform
+// path, promo_price must come out empty so a config testing it is not misled.
+func TestAccMockDataSourceTldPricingZeroPromotion(t *testing.T) {
+	m := newNamecheapMock(t)
+	m.seedPricing("REGISTER", "com",
+		mockPriceTier{Duration: 1, DurationType: "YEAR", Price: "13.98", RegularPrice: "13.98", YourPrice: "13.98", Currency: "USD", Promotion: "0.0"},
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { mockPreCheck(t, m) },
+		ProviderFactories: mockProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: `
+data "namecheap_tld_pricing" "com" {
+  tld = "com"
+}
+`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.namecheap_tld_pricing.com", "price", "13.98"),
+					resource.TestCheckResourceAttr("data.namecheap_tld_pricing.com", "promo_price", ""),
 				),
 			},
 		},
@@ -288,12 +351,12 @@ output "balance" {
 }
 `
 
-// assertCommandCalled returns a check asserting the mock served at least one
-// request for command.
-func assertCommandCalled(m *namecheapMock, command string) resource.TestCheckFunc {
+// assertCommandCount returns a check asserting the mock served exactly want
+// requests for command.
+func assertCommandCount(m *namecheapMock, command string, want int) resource.TestCheckFunc {
 	return func(*terraform.State) error {
-		if got := m.commandCount(command); got == 0 {
-			return fmt.Errorf("commandCount(%q) = 0, want at least 1", command)
+		if got := m.commandCount(command); got != want {
+			return fmt.Errorf("commandCount(%q) = %d, want %d", command, got, want)
 		}
 		return nil
 	}

--- a/namecheap/mock_server_test.go
+++ b/namecheap/mock_server_test.go
@@ -70,6 +70,13 @@ type namecheapMock struct {
 	// API error, exercising the not-found diagnostic.
 	infos map[string]mockDomainInfo
 
+	// Account-scoped money state. balances backs namecheap.users.getBalances
+	// (nil until seeded, so an unseeded read surfaces an API error rather than
+	// silently reporting zero funds); pricing backs namecheap.users.getPricing,
+	// keyed by the lower-cased "action/product" pair the request narrows on.
+	balances *mockAccountBalance
+	pricing  map[string][]mockPriceTier
+
 	// Optional fault injection: when failCommand is set, any request whose
 	// Command equals it returns an API error with failCode/failMessage instead
 	// of the normal response. Used to exercise the provider's error-surfacing.
@@ -98,6 +105,27 @@ type mockPortfolioDomain struct {
 	AutoRenew  bool
 	IsPremium  bool
 	IsOurDNS   bool
+}
+
+// mockAccountBalance is the account funds returned by the mock's
+// namecheap.users.getBalances handler. Amounts are the exact decimal strings the
+// API sends, so a test can assert that the provider never reformats them.
+type mockAccountBalance struct {
+	Currency                  string
+	AvailableBalance          string
+	AccountBalance            string
+	EarnedAmount              string
+	WithdrawableAmount        string
+	FundsRequiredForAutoRenew string
+}
+
+// mockPriceTier is one <Price> node of the mock's namecheap.users.getPricing
+// response. Currency and Promotion are rendered only when non-empty, mirroring
+// the live API's habit of omitting them entirely rather than sending "".
+type mockPriceTier struct {
+	Duration                                            int
+	DurationType                                        string
+	Price, RegularPrice, YourPrice, Currency, Promotion string
 }
 
 // mockDomainInfo is the per-domain response of the mock's
@@ -227,6 +255,32 @@ func (m *namecheapMock) seedInfo(domain string, info mockDomainInfo) {
 	m.infos[domain] = info
 }
 
+// seedBalances registers the account funds returned by users.getBalances. Until
+// it is called, a balance read returns an API error rather than zero funds, so a
+// test cannot accidentally assert against an implicit empty account.
+func (m *namecheapMock) seedBalances(b mockAccountBalance) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.balances = &b
+}
+
+// seedPricing registers the price tiers users.getPricing returns for one
+// (action, product) pair, e.g. seedPricing("REGISTER", "com", tiers...). Both
+// keys are matched case-insensitively, as the real API does.
+func (m *namecheapMock) seedPricing(action, product string, tiers ...mockPriceTier) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.pricing == nil {
+		m.pricing = map[string][]mockPriceTier{}
+	}
+	m.pricing[pricingKey(action, product)] = tiers
+}
+
+// pricingKey builds the lookup key for the seeded pricing map.
+func pricingKey(action, product string) string {
+	return strings.ToLower(action) + "/" + strings.ToLower(product)
+}
+
 // getListCallCount returns how many getList requests the mock has served.
 func (m *namecheapMock) getListCallCount() int {
 	m.mu.Lock()
@@ -281,6 +335,12 @@ func (m *namecheapMock) handler(w http.ResponseWriter, r *http.Request) {
 		return
 	case "namecheap.domains.getInfo":
 		_, _ = io.WriteString(w, m.renderGetInfoXML(r.FormValue("DomainName")))
+		return
+	case "namecheap.users.getBalances":
+		_, _ = io.WriteString(w, m.renderGetBalancesXML())
+		return
+	case "namecheap.users.getPricing":
+		_, _ = io.WriteString(w, m.renderGetPricingXML(r.FormValue("ActionName"), r.FormValue("ProductName")))
 		return
 	}
 
@@ -545,6 +605,60 @@ func (m *namecheapMock) renderGetInfoXML(domain string) string {
     </DomainGetInfoResult>
   </CommandResponse>
 </ApiResponse>`, domain, info.IsPremium, info.IsPremiumDNS, info.ProviderType, info.IsUsingOurDNS, strings.Join(nsLines, "\n        "))
+}
+
+// renderGetBalancesXML renders the account funds for namecheap.users.getBalances.
+// An unseeded account returns the API's "not enough privileges" style error so a
+// test that forgets to seed fails loudly instead of reading zeros.
+func (m *namecheapMock) renderGetBalancesXML() string {
+	if m.balances == nil {
+		return apiErrorXML("2011150", "Account balances are not available for this user")
+	}
+	b := m.balances
+	return fmt.Sprintf(`<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+  <Errors />
+  <CommandResponse Type="namecheap.users.getBalances">
+    <UserGetBalancesResult Currency="%s" AvailableBalance="%s" AccountBalance="%s" EarnedAmount="%s" WithdrawableAmount="%s" FundsRequiredForAutoRenew="%s" />
+  </CommandResponse>
+</ApiResponse>`, b.Currency, b.AvailableBalance, b.AccountBalance, b.EarnedAmount, b.WithdrawableAmount, b.FundsRequiredForAutoRenew)
+}
+
+// renderGetPricingXML renders the price sheet for one (action, product) pair.
+// The real API narrows server-side on ActionName/ProductName, so the mock keys
+// on exactly those parameters; an unseeded pair returns an empty (but valid)
+// sheet, which is how the API answers for a TLD it does not sell.
+func (m *namecheapMock) renderGetPricingXML(action, product string) string {
+	tiers := m.pricing[pricingKey(action, product)]
+
+	var prices []string
+	for _, t := range tiers {
+		attrs := fmt.Sprintf(`Duration="%d" DurationType="%s" Price="%s" RegularPrice="%s" YourPrice="%s"`,
+			t.Duration, t.DurationType, t.Price, t.RegularPrice, t.YourPrice)
+		if t.Currency != "" {
+			attrs += fmt.Sprintf(` Currency="%s"`, t.Currency)
+		}
+		if t.Promotion != "" {
+			attrs += fmt.Sprintf(` PromotionPrice="%s"`, t.Promotion)
+		}
+		prices = append(prices, fmt.Sprintf(`<Price %s />`, attrs))
+	}
+
+	return fmt.Sprintf(`<?xml version="1.0" encoding="utf-8"?>
+<ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
+  <Errors />
+  <CommandResponse Type="namecheap.users.getPricing">
+    <UserGetPricingResult>
+      <ProductType Name="domains">
+        <ProductCategory Name="%s">
+          <Product Name="%s">
+            %s
+          </Product>
+        </ProductCategory>
+      </ProductType>
+    </UserGetPricingResult>
+  </CommandResponse>
+</ApiResponse>`, strings.ToLower(action), strings.ToLower(product), strings.Join(prices, "\n            "))
 }
 
 // renderResultXML renders a generic success CommandResponse for write commands

--- a/namecheap/provider.go
+++ b/namecheap/provider.go
@@ -131,9 +131,11 @@ func Provider() *schema.Provider {
 			"namecheap_email_forwarding":    resourceNamecheapEmailForwarding(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
-			"namecheap_domain":         dataSourceNamecheapDomain(),
-			"namecheap_domains":        dataSourceNamecheapDomains(),
-			"namecheap_domain_records": dataSourceNamecheapDomainRecords(),
+			"namecheap_domain":          dataSourceNamecheapDomain(),
+			"namecheap_domains":         dataSourceNamecheapDomains(),
+			"namecheap_domain_records":  dataSourceNamecheapDomainRecords(),
+			"namecheap_account_balance": dataSourceNamecheapAccountBalance(),
+			"namecheap_tld_pricing":     dataSourceNamecheapTldPricing(),
 		},
 		ConfigureContextFunc: configureContext,
 	}


### PR DESCRIPTION
## Summary

Money is currently invisible to the provider. A run can neither check that the account covers a 50-domain apply nor surface what a TLD costs, even though registrations, renewals and transfers all draw on the same balance. This adds the two read-only data sources #255 specifies:

- **`namecheap_account_balance`** (`users.getBalances`) — account funds and currency, no arguments.
- **`namecheap_tld_pricing`** (`users.getPricing`) — the price of one TLD for one action (`REGISTER`/`RENEW`/`TRANSFER`) and term.

Closes #255. Part of the provider 3.0 roadmap (#257), phase 4.

## Compatibility — no existing state is touched

Purely additive:

- No existing resource, data source, schema or default is modified. The only change to `provider.go` is two new `DataSourcesMap` entries (plus gofmt realignment of the map).
- Both data sources are read-only; neither command charges anything or mutates account state.
- `TestDataSourcePricingSchemasAreReadOnly` enforces read-only-ness mechanically, so a later edit that makes an attribute writable fails the build.

This was verified by experiment, not just by inspection: the pre-existing mock acceptance suite was run on `master` (28 tests) and on this branch (28 identical + 8 new), and again on unmodified `master` with the SDK forced to the new version — identical pass sets every time. A source diff of the SDK between the old and new tags confirms the files backing `namecheap_domain_records`, `namecheap_personal_nameserver`, `namecheap_domain_contacts` and `namecheap_email_forwarding` are byte-for-byte unchanged; the only shared-code change is an internal refactor of `doXML` that leaves every existing call path identical.

Correction to an earlier version of this description: the SDK bump delivers **no** x/text change here — the provider had already selected `golang.org/x/text v0.39.0` independently.

## What the live API taught us about `promo_price`

The first CI run of this PR's live sandbox tests returned:

```
live data.namecheap_tld_pricing.register.price         = "13.98"
live data.namecheap_tld_pricing.register.regular_price = "13.98"
live data.namecheap_tld_pricing.register.your_price    = "13.98"
live data.namecheap_tld_pricing.register.promo_price   = "0.0"
live data.namecheap_tld_pricing.register.currency      = "USD"
```

`price == regular_price == your_price` is an **un-promoted** `.com`, yet the server still sent `PromotionPrice="0.0"`. So `0.0` is Namecheap's "no promotion" sentinel, and an earlier design here — passing the value through untouched — would have reported a promotion on essentially every ordinary lookup.

The fix went upstream first, because it is a property of the API and not of Terraform: **go-namecheap-sdk#159** exports `Amount.IsPositive()` (the decimal-safe predicate the SDK already had unexported and used for price precedence) and records the observed `0.0` behaviour in the `PromotionPrice`/`Promo` doc comments. It also fixes sign handling on the way — `Amount("-1.00").IsPositive()` was `true` because the string contains a `1`.

This PR then exports a non-positive promotional price as empty, so `promo_price != ""` means what a reader assumes. The trade-off is stated in the docs: a hypothetical genuinely-free `0.00` promotion would also read as empty, which is the lesser error against an API that sends `0.0` on every un-promoted tier.

## Money is exported as strings, deliberately

Terraform numbers are IEEE-754 floats. A balance or price that round-trips through one can silently change value, which is unacceptable for a figure that gates a charge. Every monetary attribute is therefore a string carrying the API's exact decimal (`"123.45"`, `"0.10"`), and the docs give the `tonumber()` recipe at the comparison site — where the cost-aware precondition needs it. Both directions of that pattern are acceptance-tested.

## Design notes

- **One API call per read.** The request is narrowed server-side on `ProductType`/`ActionName`/`ProductName` rather than fetching the full sheet and filtering — asserted as *exactly one* call in both the unit test and the acceptance test. Per *read*: a plan and an apply are two reads, and two data blocks for the same `(tld, action)` are two calls, since the provider holds no cross-data-source cache.
- **`price` vs the rest.** `price` resolves the documented three-level precedence (server final price → your price → regular price); each rung is covered by a test, including the middle one a two-level implementation would still pass without.
- **Inputs are case-insensitive.** `tld = "COM"` and `action = "transfer"` both resolve, and the ID carries the normalized values. The validator rejects a leading or trailing dot, whitespace and URL punctuation; it cannot reject `example.com`, which is structurally identical to `co.uk`, so that surfaces as the read's "no published price" diagnostic instead — documented rather than papered over.
- **Errors name the subject**, so a `for_each` over several TLDs says which one failed.
- **Out of scope**, per the issue: SSL/WhoisGuard pricing, cost rollups across a plan, add-funds automation.

## Tests

**Unit** (`make test`, no build tag, counted in coverage) — `namecheap/data_source_pricing_read_test.go`: both read functions at **100% statement coverage**. Covers all six balance attributes; decimal precision (`"0.00"` stays `"0.00"`, trailing zeros and a third decimal survive); server-side narrowing and the exactly-one-call count; each precedence rung; the promotion cases (positive, `0.0` sentinel, whitespace-only, absent); `duration_type` verbatim rather than hardcoded; multi-label `co.uk`; case normalization; tier-not-found and API-error diagnostics; malformed `Status=OK` envelopes; a literal assertion on the balance ID (it is a state address); 13 validator cases; and the read-only schema guard.

**Mock acceptance** (`make testacc-mock`, real Terraform against the in-process stateful mock) — `namecheap/mock_pricing_test.go`: 13 cases including defaults, the promotion path, the live `0.0` shape end-to-end, a lowercase action driven through the validator, unknown TLD, three plan-time rejections, no collateral API traffic, and both directions of the cost-aware precondition. The mock gained `users.getBalances`/`users.getPricing` handlers.

**Live sandbox** (`make testacc`, runs on this PR via the EC2 job) — `namecheap/data_source_pricing_live_test.go`: reads real balances and real `.com` pricing for all three actions, asserting shape rather than value and logging what the API returned. This is what produced the `0.0` finding above, and it is the empirical confirmation of the `Currency`/`PromotionPrice` attribute names that go-namecheap-sdk#139 asked for.

Note on CI routing: the `acceptance_mock` matrix is skipped on same-repo PRs by design (`.github/workflows/ci.yml` sends those to the live sandbox suite instead, with the mock matrix as the fork/Dependabot fallback), so the 13 new `TestAccMock*` tests do not execute in *this* PR's CI. They were run locally against Terraform 1.15.7 — full suite green — and they will run on every fork PR from here on.

Also verified locally: `go build`, `go vet`, `golangci-lint run` (0 issues), and a 200-iteration stress run of the new unit tests.

## Review

Reviewed by two independent agents on different models before this was marked ready. Their findings are all addressed: the `0.0` promotion semantics (above), a `cheapest_tld` docs example that threw on a price tie (now `sort()`-based and verified under Terraform for both distinct and tied prices), a vacuous `> 0` call-count assertion (now exactly-one), dead normalization behind a case-sensitive validator (validator is now case-insensitive, so the normalization is reachable and tested through Terraform), six surviving mutations (each now killed by a new test), two uncovered nil-guards, an overclaiming validator doc comment, and several documentation inaccuracies.

## Docs

`docs/data-sources/account_balance.md` and `docs/data-sources/tld_pricing.md`, following the existing hand-written page format: the cost-aware pattern, the tie-safe TLD-comparison pattern, why money is a string, the `0.0` promotion behaviour and its trade-off, and the limits (nothing reserves funds or prices between plan and apply).
