### PR TITLE
ci: keep the live acceptance suite inside the account rate quota

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -721,6 +721,13 @@ jobs:
           # Half the quota each keeps the account total inside it. The helper
           # client reads the same variable (see provider_test.go).
           NAMECHEAP_REQUESTS_PER_MINUTE: 10
+          # Halving each client's rate makes requests wait longer for a token,
+          # and that wait counts against the retry budget — so the stock 4
+          # attempts / 2 minutes can expire on a healthy but throttled call,
+          # especially in the deliberately parallel DNS tests. Give retries room
+          # to outlast the rolling window rather than failing inside it.
+          NAMECHEAP_MAX_RETRIES: 8
+          NAMECHEAP_RETRY_MAX_ELAPSED: 5m
 
       - name: Post-job hygiene sweep
         # Last step, if: always() — this is what actually satisfies G6 ("no

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -712,6 +712,15 @@ jobs:
           NAMECHEAP_TEST_DOMAIN: terraform-provider-test.net
           NAMECHEAP_USE_SANDBOX: true
           NAMECHEAP_API_KEY: ${{ secrets.NAMECHEAP_API_KEY }}
+          # The suite drives two independent clients against one account: the
+          # provider under test, and the bare SDK client the test helpers use for
+          # setup/teardown. Each carries its own limiter, so leaving both at the
+          # default 20/min lets the suite emit up to 40/min against Namecheap's
+          # 20/min quota — the API answers 405, the SDK retries four times, and
+          # a healthy test fails as "after 4 attempts: retryable HTTP status".
+          # Half the quota each keeps the account total inside it. The helper
+          # client reads the same variable (see provider_test.go).
+          NAMECHEAP_REQUESTS_PER_MINUTE: 10
 
       - name: Post-job hygiene sweep
         # Last step, if: always() — this is what actually satisfies G6 ("no

--- a/namecheap/provider_test.go
+++ b/namecheap/provider_test.go
@@ -55,6 +55,37 @@ func acceptanceRequestsPerMinute() int {
 	return n
 }
 
+// acceptanceMaxRetries returns the retry-attempt budget for the live suite,
+// read from the same NAMECHEAP_MAX_RETRIES variable the provider honours.
+// Anything unusable falls back to the provider's own default.
+func acceptanceMaxRetries() int {
+	raw := os.Getenv("NAMECHEAP_MAX_RETRIES")
+	if raw == "" {
+		return defaultMaxRetries
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 1 {
+		return defaultMaxRetries
+	}
+	return n
+}
+
+// acceptanceRetryMaxElapsed returns the wall-clock retry budget for the live
+// suite, read from the same NAMECHEAP_RETRY_MAX_ELAPSED variable the provider
+// honours. Anything unusable falls back to the provider's own default.
+func acceptanceRetryMaxElapsed() time.Duration {
+	fallback, _ := time.ParseDuration(defaultRetryMaxElapsed)
+	raw := os.Getenv("NAMECHEAP_RETRY_MAX_ELAPSED")
+	if raw == "" {
+		return fallback
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil || d <= 0 {
+		return fallback
+	}
+	return d
+}
+
 func init() {
 	testAccNamecheapProvider = Provider()
 	testAccProviderFactories = map[string]func() (*schema.Provider, error){
@@ -77,6 +108,14 @@ func init() {
 		// provider is given (NAMECHEAP_REQUESTS_PER_MINUTE), so the two together
 		// stay inside the quota.
 		RateLimit: &namecheap.RateLimitOptions{PerMinute: acceptanceRequestsPerMinute()},
+		// Sharing the quota makes each request wait longer for a token, and that
+		// wait counts against the retry budget. The helper client therefore takes
+		// the same enlarged budget the provider is given, so a throttled call is
+		// retried until the window reopens instead of giving up mid-suite.
+		Retry: &namecheap.RetryOptions{
+			MaxAttempts: acceptanceMaxRetries(),
+			MaxElapsed:  acceptanceRetryMaxElapsed(),
+		},
 	})
 
 	testDomain := os.Getenv("NAMECHEAP_TEST_DOMAIN")
@@ -675,4 +714,51 @@ func TestAcceptanceClientBudgetFitsQuota(t *testing.T) {
 	perClient := acceptanceRequestsPerMinute()
 	assert.LessOrEqual(t, perClient*2, maxRequestsPerMinute,
 		"helper client + provider must stay within the %d/min account quota", maxRequestsPerMinute)
+}
+
+// TestAcceptanceRetryBudget pins the retry budget the live suite runs with.
+// Sharing the account quota lengthens the wait for a rate-limit token, and that
+// wait is charged against the retry budget, so the budget has to be able to
+// outlast the rolling window rather than expiring inside it.
+func TestAcceptanceRetryBudget(t *testing.T) {
+	defaultElapsed, err := time.ParseDuration(defaultRetryMaxElapsed)
+	assert.NoError(t, err)
+
+	t.Run("attempts", func(t *testing.T) {
+		for _, tc := range []struct {
+			name string
+			env  string
+			want int
+		}{
+			{"unset uses the provider default", "", defaultMaxRetries},
+			{"override honoured", "8", 8},
+			{"zero falls back", "0", defaultMaxRetries},
+			{"negative falls back", "-1", defaultMaxRetries},
+			{"non-numeric falls back", "lots", defaultMaxRetries},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Setenv("NAMECHEAP_MAX_RETRIES", tc.env)
+				assert.Equal(t, tc.want, acceptanceMaxRetries())
+			})
+		}
+	})
+
+	t.Run("elapsed", func(t *testing.T) {
+		for _, tc := range []struct {
+			name string
+			env  string
+			want time.Duration
+		}{
+			{"unset uses the provider default", "", defaultElapsed},
+			{"override honoured", "5m", 5 * time.Minute},
+			{"zero falls back", "0s", defaultElapsed},
+			{"negative falls back", "-1m", defaultElapsed},
+			{"unparsable falls back", "five minutes", defaultElapsed},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Setenv("NAMECHEAP_RETRY_MAX_ELAPSED", tc.env)
+				assert.Equal(t, tc.want, acceptanceRetryMaxElapsed())
+			})
+		}
+	})
 }

--- a/namecheap/provider_test.go
+++ b/namecheap/provider_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -35,6 +36,25 @@ func getEnvOrDefault(key, fallback string) string {
 	return fallback
 }
 
+// acceptanceRequestsPerMinute returns the per-client share of the account's
+// request budget for the live suite, read from the same NAMECHEAP_REQUESTS_PER_MINUTE
+// variable the provider itself honours. It falls back to half the documented
+// 20/min quota, because two clients share that quota (see namecheapSDKClient).
+// An unparsable or out-of-range value falls back too rather than failing the
+// suite on a misconfigured environment.
+func acceptanceRequestsPerMinute() int {
+	const fallback = defaultRequestsPerMinute / 2
+	raw := os.Getenv("NAMECHEAP_REQUESTS_PER_MINUTE")
+	if raw == "" {
+		return fallback
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < minRequestsPerMinute || n > maxRequestsPerMinute {
+		return fallback
+	}
+	return n
+}
+
 func init() {
 	testAccNamecheapProvider = Provider()
 	testAccProviderFactories = map[string]func() (*schema.Provider, error){
@@ -48,6 +68,15 @@ func init() {
 		ApiKey:     os.Getenv("NAMECHEAP_API_KEY"),
 		ClientIp:   getEnvOrDefault("NAMECHEAP_CLIENT_IP", testPlaceholderClientIP),
 		UseSandbox: strings.EqualFold(os.Getenv("NAMECHEAP_USE_SANDBOX"), "true"),
+		// Namecheap's rate limit is per account, but limiters are per client, and
+		// the live suite runs two of them: the provider under test, and this one
+		// behind the setup/teardown helpers. Left at the default they would allow
+		// 20/min each against a 20/min quota, so the account exceeds it, the API
+		// answers 405, and the SDK's retries turn a healthy test into "after 4
+		// attempts: retryable HTTP status". This client takes the same budget the
+		// provider is given (NAMECHEAP_REQUESTS_PER_MINUTE), so the two together
+		// stay inside the quota.
+		RateLimit: &namecheap.RateLimitOptions{PerMinute: acceptanceRequestsPerMinute()},
 	})
 
 	testDomain := os.Getenv("NAMECHEAP_TEST_DOMAIN")
@@ -605,4 +634,45 @@ func skipTestIfNoTFAccFlag(t *testing.T) {
 	if os.Getenv("TF_ACC") != "1" {
 		t.Skip("Skipped unless env 'TF_ACC' set")
 	}
+}
+
+// TestAcceptanceRequestsPerMinute pins the live suite's share of the account
+// request budget: a valid override is honoured, and anything unusable falls back
+// to half the quota rather than letting a misconfigured environment either fail
+// the suite or silently restore the double-budget this split exists to prevent.
+func TestAcceptanceRequestsPerMinute(t *testing.T) {
+	const fallback = defaultRequestsPerMinute / 2
+
+	tests := []struct {
+		name string
+		env  string
+		want int
+	}{
+		{"unset falls back to half the quota", "", fallback},
+		{"valid override honoured", "10", 10},
+		{"lower bound honoured", "1", minRequestsPerMinute},
+		{"upper bound honoured", "20", maxRequestsPerMinute},
+		{"zero falls back", "0", fallback},
+		{"negative falls back", "-5", fallback},
+		{"above quota falls back", "50", fallback},
+		{"non-numeric falls back", "many", fallback},
+		{"empty-ish falls back", "  ", fallback},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("NAMECHEAP_REQUESTS_PER_MINUTE", tc.env)
+			assert.Equal(t, tc.want, acceptanceRequestsPerMinute())
+		})
+	}
+}
+
+// TestAcceptanceClientBudgetFitsQuota is the invariant the split protects: the
+// helper client and the provider each take a share, and the two together must
+// not exceed Namecheap's documented per-account quota. Exceeding it is what
+// makes the API answer 405 and the SDK report "after 4 attempts".
+func TestAcceptanceClientBudgetFitsQuota(t *testing.T) {
+	t.Setenv("NAMECHEAP_REQUESTS_PER_MINUTE", "10")
+	perClient := acceptanceRequestsPerMinute()
+	assert.LessOrEqual(t, perClient*2, maxRequestsPerMinute,
+		"helper client + provider must stay within the %d/min account quota", maxRequestsPerMinute)
 }


### PR DESCRIPTION
## Problem

The sandbox acceptance job fails with

```
Error: after 4 attempts: namecheap: retryable HTTP status
```

in `TestAccNamecheapDomainRecords`. It looks like a flaky API, and it has been treated as one — but it is self-inflicted and reproducible.

**Namecheap rate-limits per account; the SDK rate-limits per client.** The live suite runs *two* clients against one account:

1. the provider under test, configured from env (default **20 req/min**);
2. `namecheapSDKClient` in `provider_test.go`, used by `resetDomainRecords`, `setDomainRecords`, `resetDomainNameservers` and the `testAcc*APIFetch` helpers — constructed with no `RateLimit`, so also **20 req/min**.

Two token buckets, one quota: the suite is permitted to emit **40 req/min against a 20/min limit**. Past the quota the API answers HTTP 405, the SDK correctly classifies it as retryable, exhausts its four attempts, and a perfectly healthy test fails.

That explains the shape of the failures — the *first* subtests pass, and the failure lands on whichever test happens to be running when the rolling window is exhausted. Evidence:

- **master**, run 30629473868 (07-31): `resources_with_mx_records_parallel_merge` failed this way, with no pricing tests in the tree.
- On #305, which adds a handful of read-only live calls, the very next suite failed on **three consecutive runs** — moving one step further along the test each time the load was reduced, exactly as a rolling-window exhaustion behaves.

## Fix

Each client takes half the account quota, from the same `NAMECHEAP_REQUESTS_PER_MINUTE` variable the provider already honours (added in #247/#265); the workflow sets it to `10`.

- `namecheap/provider_test.go` — the helper client gets an explicit `RateLimit`, resolved by `acceptanceRequestsPerMinute()`, which reads that variable and falls back to half the documented quota when it is unset or unusable.
- `.github/workflows/ci.yml` — `NAMECHEAP_REQUESTS_PER_MINUTE: 10` on the Acceptance Test step, with the reasoning inline so the next person does not "optimize" it back.

**No shipped behaviour changes.** The provider's own defaults are untouched; this is test and workflow configuration. Users are unaffected, and no test is skipped, weakened or removed.

## Two changes, and why both are needed

**1. Split the quota** — the systemic fix. On its own it took `create_duplicate_records_conflict_merge` from failing on three consecutive runs to **passing**.

**2. Enlarge the retry budget** — the consequence of (1). Halving each client's rate means every request waits longer for a token, and that wait is charged against the retry budget, so the stock 4 attempts / 2 minutes can expire on a call that is healthy but merely queued behind the limiter. That is likeliest in the tests that apply resources in parallel by design, and it is exactly where this PR's first run then failed: `resources_with_mx_records_parallel_merge`, the same test that fails on master. The job now runs 8 attempts with a 5-minute cap, and the helper client takes the same budget.

To be explicit about the revision: an earlier version of this description argued that raising the retry budget would only paper over the breach. That remains true *on its own* — but once the split lengthens the queueing delay, the budget has to outlast the rolling window rather than expire inside it. The split stops the suite provoking 405s; the budget lets a throttled request wait one out.

## Tests

- `TestAcceptanceRequestsPerMinute` — 9 cases: unset, a valid override, both bounds, zero, negative, above-quota, non-numeric and whitespace. Anything unusable falls back rather than failing the suite or silently restoring the double budget.
- `TestAcceptanceClientBudgetFitsQuota` — the invariant itself: two clients' shares must fit inside the documented per-account quota.

`go vet`, `gofmt`, `golangci-lint` (0 issues) and the unit suite are green locally. The real verification is this PR's own sandbox run.

## Follow-up worth considering

A shared limiter would be better than a split budget — the SDK's `RateLimitOptions` exposes only `PerMinute`/`MaxConcurrent`, with no way to inject one limiter across clients. Worth raising upstream if more clients ever appear in the suite.
