### PR TITLE
ci: gate CI jobs on changed paths to skip redundant acceptance runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,14 @@
 name: CI
 
+# No workflow-level paths-ignore here, on purpose. This workflow's jobs are
+# required status checks, and a path-filtered required check is never reported
+# on PRs that touch only excluded files, which blocks them from merging
+# permanently. It would also stop versioning.yml's `workflow_run: [CI]` trigger
+# from firing on pushes that only touch release files, breaking the
+# release-please -> tag -> GoReleaser chain. Instead, the `changes` job below
+# detects what changed and the expensive jobs skip themselves via `if:` —
+# skipped checks DO satisfy branch protection, and the workflow still completes
+# so workflow_run still fires.
 on:
   # Post-merge run only: PR branches are covered by pull_request, so each PR
   # runs CI once. Pre-PR branches: use workflow_dispatch.
@@ -36,9 +45,54 @@ env:
 # queue step in start-runner below.
 
 jobs:
+  # Gate job: decides whether the jobs below actually need to run for this
+  # change. `code` is false only when the diff touches nothing but root-level
+  # markdown (README/CHANGELOG/...), LICENSE, or the release-please manifest —
+  # most notably the release-please Release PR (CHANGELOG.md +
+  # .release-please-manifest.json) and its merge to master, which previously
+  # re-ran the full pipeline — self-hosted EC2 acceptance run included — twice
+  # per release on code that was already tested. docs/** and templates/**
+  # deliberately count as code: docs/ is published to the Terraform Registry at
+  # each release tag, so doc changes get the full pipeline like any
+  # user-visible change.
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read # paths-filter reads PR files via the API on pull_request events
+    outputs:
+      # workflow_dispatch is a maintainer explicitly asking for a full run (the
+      # documented path for live acceptance on Dependabot branches — see
+      # CLAUDE.md), and paths-filter has no base to diff against there anyway,
+      # so dispatch runs always count as code and bypass the filter entirely.
+      code: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.filter-code.outputs.code }}
+    steps:
+      # Checkout is required for push events, where paths-filter diffs with git
+      # (pull_request events use the API and would not need it).
+      - uses: actions/checkout@v7
+        if: ${{ github.event_name != 'workflow_dispatch' }}
+
+      # With predicate-quantifier=every a file counts as `code` only if it
+      # matches ALL patterns, i.e. it is none of the ignored kinds. `*.md`
+      # (no globstar) matches root-level markdown only, so nested markdown —
+      # docs/**, templates/** — still counts as code on purpose.
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        if: ${{ github.event_name != 'workflow_dispatch' }}
+        id: filter-code
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            code:
+              - '!*.md'
+              - '!LICENSE'
+              - '!.release-please-manifest.json'
+
   check:
     name: Check
     runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     steps:
       - uses: actions/checkout@v7
 
@@ -125,6 +179,8 @@ jobs:
     # dev_overrides config, so this job is fork-safe.
     name: Docs
     runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     steps:
       - uses: actions/checkout@v7
 
@@ -163,6 +219,8 @@ jobs:
     # audits) can consume a signed inventory without re-running scans.
     name: Security scan (Trivy)
     runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     steps:
       - uses: actions/checkout@v7
 
@@ -252,6 +310,8 @@ jobs:
     # so detection stays current regardless of the pinned binary version.
     name: Security scan (govulncheck)
     runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     steps:
       - uses: actions/checkout@v7
 
@@ -307,9 +367,11 @@ jobs:
     # in the summary via needs.*.result, so a green comment can never mask a red
     # gate.
     name: Security scan summary
-    needs: [security, govulncheck]
+    needs: [changes, security, govulncheck]
     # Run even when a gate above failed — that's when the summary matters most.
-    if: ${{ !cancelled() }}
+    # But not when the changes gate skipped the scans entirely: there are no
+    # scan artifacts to summarize on a docs-only change.
+    if: ${{ !cancelled() && needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read # checkout + read go.mod for the dependency overview
@@ -413,8 +475,8 @@ jobs:
     # Dependabot PRs (same). Same-repo, non-Dependabot PRs run the live sandbox
     # suite instead, so those two never both run on one PR.
     name: Mock acceptance (${{ matrix.engine }} ${{ matrix.version }})
-    needs: [check]
-    if: ${{ github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]') }}
+    needs: [changes, check]
+    if: ${{ needs.changes.outputs.code == 'true' && github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]') }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -473,14 +535,17 @@ jobs:
 
   start-runner:
     name: Start self-hosted EC2 runner
-    needs: [check, security, govulncheck]
+    needs: [changes, check, security, govulncheck]
     # The live-API sandbox pipeline needs secrets.* (AWS creds, whitelisted EIP,
     # NAMECHEAP_API_KEY), so it only runs where secrets are available AND the
     # code is trusted: same-repo PRs, pushes to master (post-merge), and manual
     # workflow_dispatch (write access required, so always a maintainer). Never
     # fork PRs (redacted secrets; served by acceptance_mock instead) nor
-    # Dependabot events (same).
-    if: ${{ github.actor != 'dependabot[bot]' && ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push' && github.ref == 'refs/heads/master') || github.event_name == 'workflow_dispatch') }}
+    # Dependabot events (same). The changes-gate term additionally skips the
+    # whole EC2 lifecycle — and its per-run AWS cost — when the diff touches
+    # only root markdown/LICENSE/the release-please manifest (most notably the
+    # Release PR and its merge commit).
+    if: ${{ needs.changes.outputs.code == 'true' && github.actor != 'dependabot[bot]' && ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push' && github.ref == 'refs/heads/master') || github.event_name == 'workflow_dispatch') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -643,10 +708,11 @@ jobs:
   acceptance_test:
     name: Acceptance test
     runs-on: ${{ needs.start-runner.outputs.label }} # run the job on the newly created runner
-    needs: start-runner
-    # Same gate as start-runner: same-repo PRs + pushes to master + manual
-    # dispatch, never forks/Dependabot (those get acceptance_mock instead).
-    if: ${{ github.actor != 'dependabot[bot]' && ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push' && github.ref == 'refs/heads/master') || github.event_name == 'workflow_dispatch') }}
+    needs: [changes, start-runner]
+    # Same gate as start-runner: changes-gate `code` + same-repo PRs + pushes
+    # to master + manual dispatch, never forks/Dependabot (those get
+    # acceptance_mock instead).
+    if: ${{ needs.changes.outputs.code == 'true' && github.actor != 'dependabot[bot]' && ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push' && github.ref == 'refs/heads/master') || github.event_name == 'workflow_dispatch') }}
     steps:
       # PRIMARY workspace-hygiene mechanism (git clean -ffdx before checkout).
       # Runs before our own scripts exist on disk, so it — not a custom
@@ -848,7 +914,12 @@ jobs:
     # Runs whenever a runner was actually started, regardless of the triggering
     # event. The instance-id guard is the real safety condition: it is non-empty
     # only when start-runner ran (same-repo PR or push to master), so this
-    # correctly tears the runner down for both those cases and no-ops otherwise.
+    # correctly tears the runner down for both those cases and no-ops otherwise
+    # — including when start-runner was skipped by the changes gate: always()
+    # keeps this condition evaluating even then, and the empty instance-id
+    # makes it skip cleanly rather than fail or hang. Deliberately NOT gated
+    # on needs.changes.outputs.code: if a runner exists it must be stopped,
+    # no matter what the gate said.
     if: ${{ always() && needs.start-runner.outputs.ec2-instance-id != '' }}
     steps:
       - name: Generate GitHub App token
@@ -878,3 +949,38 @@ jobs:
           github-token: ${{ steps.app-token.outputs.token }}
           label: ${{ needs.start-runner.outputs.label }}
           ec2-instance-id: ${{ needs.start-runner.outputs.ec2-instance-id }}
+
+  # Always-run summary job with two purposes:
+  # 1. A workflow run whose jobs were ALL skipped by the gate would otherwise
+  #    have no executed job, making the run-level conclusion (which gates
+  #    versioning.yml via workflow_run) ambiguous. This job always executes,
+  #    so the run always concludes success or failure.
+  # 2. Branch protection can require just this one check instead of listing
+  #    every job: it fails if any needed job failed or was cancelled, and
+  #    passes when jobs succeeded or were legitimately skipped — by the
+  #    changes gate, or by the pre-existing fork/Dependabot/event conditions
+  #    on acceptance_mock and the EC2 jobs.
+  # Every job in this workflow MUST be listed in `needs` below; a job missing
+  # from the list is invisible to the required check.
+  ci-ok:
+    name: CI OK
+    runs-on: ubuntu-latest
+    needs:
+      - changes
+      - check
+      - docs
+      - security
+      - govulncheck
+      - security-report
+      - acceptance_mock
+      - start-runner
+      - acceptance_test
+      - stop-runner
+    if: always()
+    steps:
+      - name: Check results of all jobs
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          echo "$NEEDS" | jq -r 'to_entries[] | "\(.key): \(.value.result)"'
+          echo "$NEEDS" | jq -e 'to_entries | all(.value.result == "success" or .value.result == "skipped")' > /dev/null

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -950,18 +950,23 @@ jobs:
           label: ${{ needs.start-runner.outputs.label }}
           ec2-instance-id: ${{ needs.start-runner.outputs.ec2-instance-id }}
 
-  # Always-run summary job with two purposes:
+  # Summary job with two purposes:
   # 1. A workflow run whose jobs were ALL skipped by the gate would otherwise
   #    have no executed job, making the run-level conclusion (which gates
-  #    versioning.yml via workflow_run) ambiguous. This job always executes,
-  #    so the run always concludes success or failure.
+  #    versioning.yml via workflow_run) ambiguous. This job executes on every
+  #    run that isn't cancelled, so the run always concludes success/failure.
+  #    `!cancelled()` rather than `always()`: a superseded PR run cancelled by
+  #    the concurrency group skips this job instead of spending a runner to
+  #    post a red check on a dead SHA (checks are evaluated per-SHA, so the
+  #    replacement run supplies the required check).
   # 2. Branch protection can require just this one check instead of listing
   #    every job: it fails if any needed job failed or was cancelled, and
   #    passes when jobs succeeded or were legitimately skipped — by the
   #    changes gate, or by the pre-existing fork/Dependabot/event conditions
   #    on acceptance_mock and the EC2 jobs.
-  # Every job in this workflow MUST be listed in `needs` below; a job missing
-  # from the list is invisible to the required check.
+  # Every job in this workflow MUST be listed in `needs` below; the first
+  # step asserts that, so a job missing from the list fails this check
+  # instead of silently escaping it.
   ci-ok:
     name: CI OK
     runs-on: ubuntu-latest
@@ -976,11 +981,29 @@ jobs:
       - start-runner
       - acceptance_test
       - stop-runner
-    if: always()
+    if: ${{ !cancelled() }}
     steps:
+      - uses: actions/checkout@v7
+
+      # "CI OK" only guards the jobs listed in its `needs`. A job added to the
+      # workflow but not to that list could fail without turning this check
+      # red — the exact gap this job exists to close — so assert the two lists
+      # match instead of relying on the note in CI.md.
+      - name: Assert every job is watched by this gate
+        run: |
+          watched=$(yq '.jobs.ci-ok.needs[]' .github/workflows/ci.yml | sort)
+          all=$(yq '.jobs | keys | .[]' .github/workflows/ci.yml | grep -vx 'ci-ok' | sort)
+          if ! diff <(echo "$all") <(echo "$watched"); then
+            echo "::error::ci.yml jobs and ci-ok's needs list have drifted (< missing from needs, > stale entry)."
+            exit 1
+          fi
+
       - name: Check results of all jobs
         env:
           NEEDS: ${{ toJSON(needs) }}
         run: |
           echo "$NEEDS" | jq -r 'to_entries[] | "\(.key): \(.value.result)"'
-          echo "$NEEDS" | jq -e 'to_entries | all(.value.result == "success" or .value.result == "skipped")' > /dev/null
+          if ! echo "$NEEDS" | jq -e 'to_entries | all(.value.result == "success" or .value.result == "skipped")' > /dev/null; then
+            echo "::error::One or more CI jobs failed or were cancelled — see the results above."
+            exit 1
+          fi

--- a/CI.md
+++ b/CI.md
@@ -101,10 +101,14 @@ regardless of anything else in the run. The nightly
 
 ### The CI OK job
 
-`ci-ok` (check name "CI OK") runs `if: always()`, checks every other job's
-result, and fails if any of them failed or was cancelled ("skipped" is fine —
-whether from the gate or from the pre-existing fork/Dependabot conditions).
-It exists because:
+`ci-ok` (check name "CI OK") runs on every non-cancelled run
+(`if: ${{ !cancelled() }}` — a superseded PR run cancelled by the concurrency
+group skips it instead of posting a red check on a dead SHA), checks every
+other job's result, and fails if any of them failed or was cancelled
+("skipped" is fine — whether from the gate or from the pre-existing
+fork/Dependabot conditions). It also asserts that its own `needs:` list
+matches the workflow's job list, so a newly added job can't silently escape
+its watch. It exists because:
 
 - a run whose jobs were **all** skipped needs at least one executed job for
   the run-level conclusion — which gates Versioning — to be a deterministic
@@ -131,7 +135,8 @@ GoReleaser start that much sooner.
 - **Don't add `paths`/`paths-ignore` to `ci.yml` triggers** (see above).
 - **Keep `ci-ok` in `needs` sync**: every job added to `ci.yml` must also be
   added to the `ci-ok` `needs:` list. "CI OK" only guards the jobs it
-  watches.
+  watches. This is enforced — `ci-ok`'s first step diffs its `needs:`
+  against the workflow's job list and fails on drift.
 - **New expensive jobs should take the gate**: `needs: changes` +
   `if: needs.changes.outputs.code == 'true'` (combined with any
   event/actor conditions the job needs, as `start-runner` does).

--- a/CI.md
+++ b/CI.md
@@ -1,0 +1,149 @@
+# CI and release pipeline
+
+Human-oriented map of how a change travels from a pull request to a published
+release, and why the pipeline skips work it doesn't need. For the
+release/registry runbook see [RELEASE.md](RELEASE.md); for the compliance
+gates a PR is judged against see
+[SECURITY_COMPLIANCE.md](SECURITY_COMPLIANCE.md); this document covers the CI
+mechanics.
+
+## Workflows at a glance
+
+| Workflow | File | Trigger | Purpose |
+|---|---|---|---|
+| CI | `.github/workflows/ci.yml` | PR, push to `master`, manual | Lint/unit/mock-acceptance (`check`), registry docs (`docs`), Trivy + govulncheck gates, security summary, fork-facing mock matrix, and the live sandbox acceptance suite on a self-hosted EC2 runner |
+| Versioning | `.github/workflows/versioning.yml` | After every CI run on `master` (`workflow_run`), manual | release-please: opens/updates the Release PR; creates the `vX.Y.Z` tag when it merges |
+| Release | `.github/workflows/release.yml` | Push of a `v*` tag | GoReleaser: builds, GPG-signs, attests and publishes binaries + release SBOM |
+| PR Title Check | `.github/workflows/pr-title.yml` | PR | Enforces Conventional Commit PR titles (they become the squash-commit subjects release-please reads) |
+| Cleanup EC2 runners | `.github/workflows/cleanup-ec2-runners.yml` | Cron (nightly drain + 30-min leak reaper), manual | Lifecycle backstop for the warm-pool sandbox runner |
+
+Checks that live outside these workflows: CodeQL (GitHub default setup), the
+DCO bot, and the `security/snyk (Namecheap)` integration.
+
+## Life of a change
+
+```mermaid
+flowchart TD
+    A[Feature PR opened] -->|CI: full run| B[Squash-merge to master]
+    B -->|CI: full run| C[Versioning opens/updates Release PR]
+    C -->|CI: gate skips all test jobs| D[Maintainer merges Release PR]
+    D -->|CI: gate skips all test jobs| E[Versioning creates vX.Y.Z tag]
+    E -->|Release workflow| F[GoReleaser publishes signed binaries]
+    F --> G[Terraform Registry indexes the version]
+```
+
+A single code change used to run the full pipeline **four** times on its way
+to a release (PR, merge, Release PR, Release PR merge). The `changes` gate in
+`ci.yml` cuts that to the two runs that test something new — the Release PR
+only touches `CHANGELOG.md` and `.release-please-manifest.json`, so re-testing
+the already-merged code there added no signal. In this repository the waste is
+not just hosted-runner minutes: each gated-away run also skips a start/stop
+cycle of the **self-hosted EC2 sandbox runner** (`t3.medium` + the whitelisted
+Elastic IP), so the gate saves real AWS cost per release, and removes two trips
+through the single-EIP acceptance queue that other runs would otherwise wait
+behind.
+
+## The changes gate
+
+The first job in CI, `changes` (check name "Detect Changes"), uses
+[dorny/paths-filter](https://github.com/dorny/paths-filter) to classify the
+diff, and the other jobs skip themselves via `needs: changes` plus an `if:`
+condition on its `code` output. `code` is false **only** when the diff touches
+nothing but root-level markdown (`README.md`, `CHANGELOG.md`, `CLAUDE.md`,
+...), `LICENSE`, or `.release-please-manifest.json`. Everything else —
+including `docs/**`, `templates/**` and `examples/**` — counts as code:
+`docs/` is published to the Terraform Registry at each release tag and is
+user-visible, so doc changes get the full pipeline like any other change
+(see [CLAUDE.md](CLAUDE.md) for the matching `fix(docs):` commit convention
+that makes such corrections actually release).
+
+`workflow_dispatch` runs bypass the filter and always count as code: manual
+dispatch is a maintainer explicitly asking for a run — it is the documented
+path for live acceptance on Dependabot branches — and there is no diff to
+classify anyway.
+
+What runs when (rows are change kinds, columns are jobs; the pre-existing
+fork/Dependabot/event conditions still apply on top of the gate):
+
+| Change | Check / Docs / Trivy / govulncheck / summary | Mock acceptance matrix | EC2 start → acceptance → stop | CI OK |
+|---|---|---|---|---|
+| Code, workflows, `docs/**`, `templates/**`, `examples/**` — same-repo PR or push to `master` | runs | skipped (fork/Dependabot only) | runs | pass |
+| Same, but fork or Dependabot PR | runs | runs | skipped (no secrets) | pass |
+| Root `*.md` / `LICENSE` / manifest only — any PR or push | skipped | skipped | skipped | pass |
+| Release PR (changelog + manifest) and its merge | skipped | skipped | skipped | pass |
+| `workflow_dispatch` (any ref) | runs | skipped (PR-only job) | runs | pass |
+
+### Why a gate job instead of workflow-level `paths-ignore`
+
+`paths-ignore` on the CI triggers looks simpler but breaks two things:
+
+1. **Required checks are never reported on filtered PRs.** The "Protect
+   master" ruleset requires the `Check`, `Security scan (Trivy)` and
+   `Security scan (govulncheck)` checks; if the workflow doesn't trigger at
+   all, those checks stay "Expected" forever and a docs-only PR can never be
+   merged. A job skipped by an `if:` condition, by contrast, reports
+   "skipped" — which **does** satisfy branch protection.
+2. **The release chain dies.** `versioning.yml` triggers on
+   `workflow_run: [CI]` for `master`. If a push to `master` doesn't start CI
+   at all, that event never fires — release-please wouldn't run after the
+   Release PR merge and the tag would never be created. With the gate, CI
+   always runs (its jobs just skip), so `workflow_run` always fires.
+
+### The EC2 runner lifecycle under the gate
+
+`stop-runner` keeps its `if: always() && needs.start-runner.outputs.ec2-instance-id != ''`
+condition and is **not** gated on `changes`: `always()` keeps the condition
+evaluating even when `start-runner` was skipped by the gate, and the empty
+`ec2-instance-id` output then makes it skip cleanly instead of failing or
+hanging. Conversely, whenever a runner **was** started, stop-runner still runs
+regardless of anything else in the run. The nightly
+`cleanup-ec2-runners.yml` drain is unaffected either way.
+
+### The CI OK job
+
+`ci-ok` (check name "CI OK") runs `if: always()`, checks every other job's
+result, and fails if any of them failed or was cancelled ("skipped" is fine —
+whether from the gate or from the pre-existing fork/Dependabot conditions).
+It exists because:
+
+- a run whose jobs were **all** skipped needs at least one executed job for
+  the run-level conclusion — which gates Versioning — to be a deterministic
+  `success`;
+- **"CI OK" must be a required status check.** The individual checks alone
+  cannot be relied on: if the `changes` gate job itself *fails* (API flake,
+  runner loss), every test job is `skipped`, and skipped checks satisfy
+  branch protection — a failing "CI OK" is the only thing that blocks such a
+  PR from merging untested.
+
+## Cost and speed effect
+
+For every Release PR and every Release-PR merge, the gate removes: a full
+hosted-runner pass (check + docs + two security scans + summary), one
+start/stop cycle of the EC2 sandbox runner (billed instance time plus the
+cold-boot or warm-start overhead), one pass of the ~10-minute live sandbox
+suite, and one slot in the single-EIP acceptance queue. Post-merge release
+latency drops accordingly: after merging a Release PR, CI concludes in
+under a minute instead of after a full acceptance pass, so the tag and
+GoReleaser start that much sooner.
+
+## Editing the pipeline — invariants to keep
+
+- **Don't add `paths`/`paths-ignore` to `ci.yml` triggers** (see above).
+- **Keep `ci-ok` in `needs` sync**: every job added to `ci.yml` must also be
+  added to the `ci-ok` `needs:` list. "CI OK" only guards the jobs it
+  watches.
+- **New expensive jobs should take the gate**: `needs: changes` +
+  `if: needs.changes.outputs.code == 'true'` (combined with any
+  event/actor conditions the job needs, as `start-runner` does).
+- **Never gate `stop-runner` on `changes`** — its `always()` + instance-id
+  guard is what guarantees a started runner is always stopped.
+- **The gate's ignore list must stay a subset of "files that can't affect the
+  binary, tests, or published docs"** — when in doubt, let the job run. In
+  particular `docs/**`, `templates/**` and `examples/**` must never be added
+  to it: registry-published documentation is a user-visible deliverable, and
+  examples are type-checked against the provider by the `docs` job.
+- **The Release PR must keep touching only `CHANGELOG.md` and
+  `.release-please-manifest.json`.** If `.release-please-config.json` ever
+  grows `extra-files` (e.g. a version constant in a `.go` file), the Release
+  PR starts containing code and the manifest must come **out** of the gate's
+  ignore list (or the extra files handled explicitly).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,8 @@ The `docs/` directory (`index.md`, `guides/`, `resources/`) is reserved for Terr
 ## Pull Requests
 
 - All CI checks must pass before merge (unit tests, acceptance tests, CodeQL, DCO).
+- CI is gated on changed paths (see `CI.md`): a PR touching only root-level markdown, `LICENSE`, or `.release-please-manifest.json` skips every test job — those show as **skipped** with a green "CI OK", which is expected, not a regression. `docs/`, `templates/` and `examples/` count as code and run the full pipeline.
+- When editing `.github/workflows/ci.yml`: every job must be listed in the `ci-ok` job's `needs:`; new expensive jobs take the gate (`needs: changes` + `if: needs.changes.outputs.code == 'true'`); never add `paths`/`paths-ignore` to the triggers and never gate `stop-runner` on `changes`. Rationale and invariants live in `CI.md`.
 - PRs should include both unit tests and Terraform acceptance tests where applicable.
 - Acceptance tests use `resource.Test()` with `TestStep` — see `namecheap/provider_test.go` for examples.
 - `SECURITY_COMPLIANCE.md` is the authoritative reference for the compliance gates a PR is judged against (dependency drift, vulnerability/license scans, SBOM, supply-chain pinning). Check it before proposing anything that touches `go.mod`, CI workflows, or action pins.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,6 +160,14 @@ disk; `git checkout -- docs/` restores it.
 
 ### What runs on your PR
 
+If your PR touches only root-level markdown (`README.md`, `CHANGELOG.md`,
+...), `LICENSE`, or `.release-please-manifest.json`, CI's `changes` gate
+skips every test job — they report "skipped", the "CI OK" summary check
+passes, and the PR is mergeable. Anything else (code, workflows, and notably
+`docs/`, `templates/` and `examples/`, which are registry-published or
+type-checked deliverables) runs the full pipeline described below. See
+[CI.md](CI.md) for the mechanics.
+
 Every pull request — **including PRs from forks** — runs, on GitHub-hosted
 runners with no secrets:
 

--- a/README.md
+++ b/README.md
@@ -97,9 +97,11 @@ resource "namecheap_domain_host_record" "www" {
 
 ### Testing
 
-Every pull request runs a fast, credential-free mock-backed acceptance suite
-(`make testacc-mock`) on GitHub-hosted runners across a Terraform + OpenTofu
-version matrix:
+Every code-touching pull request runs a fast, credential-free mock-backed
+acceptance suite (`make testacc-mock`) on GitHub-hosted runners across a
+Terraform + OpenTofu version matrix (PRs touching only root-level markdown,
+`LICENSE`, or the release-please manifest skip the test jobs — see
+[CI.md](CI.md)):
 
 | Engine | Versions tested in CI |
 | --- | --- |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,7 +9,7 @@ Three workflows participate:
 
 | Workflow | Trigger | Role |
 |---|---|---|
-| [`ci.yml`](.github/workflows/ci.yml) | PRs, push to any branch | Lint, vet, unit tests, acceptance tests |
+| [`ci.yml`](.github/workflows/ci.yml) | PRs, push to `master`, manual | Lint, vet, unit tests, acceptance tests (see [CI.md](CI.md)) |
 | [`versioning.yml`](.github/workflows/versioning.yml) | `ci.yml` success on `master` | Runs release-please to open/update the Release PR |
 | [`release.yml`](.github/workflows/release.yml) | push of a `v*` tag | GoReleaser build + GPG sign + SBOM + attestation |
 
@@ -26,7 +26,11 @@ release-please parses to compute the version bump.
    `versioning.yml` runs release-please, which computes the next SemVer bump
    (`fix:` → patch, `feat:` → minor, `feat!:`/`BREAKING CHANGE:` → major),
    updates `CHANGELOG.md` and `.release-please-manifest.json`, and opens or
-   updates a PR titled `chore(master): release X.Y.Z`.
+   updates a PR titled `chore(master): release X.Y.Z`. On the Release PR
+   itself (and its merge commit) CI's `changes` gate skips all test jobs —
+   the diff is changelog + manifest only, already-tested code — and the
+   always-run "CI OK" job concludes the run green so `workflow_run` still
+   fires; see [CI.md](CI.md).
 3. **Maintainer merges the Release PR** when the accumulated changes are worth
    shipping. This is the only manual gate. Merging tags the commit `vX.Y.Z`.
 4. **`release.yml` publishes** the binaries for the new tag, and the Terraform

--- a/SECURITY_COMPLIANCE.md
+++ b/SECURITY_COMPLIANCE.md
@@ -27,8 +27,11 @@ CI gates (in [`.github/workflows/ci.yml`](.github/workflows/ci.yml), `check` job
 
 ## Vulnerability, misconfig, secret, and license scanning
 
-- [Trivy](https://trivy.dev) runs on every push in the `security` job with
-  `scanners: vuln,misconfig,secret,license` (#166, #176).
+- [Trivy](https://trivy.dev) runs on every code-touching push and PR in the
+  `security` job with `scanners: vuln,misconfig,secret,license` (#166, #176).
+  Changes gated away as non-code — root-level markdown, `LICENSE`, the
+  release-please manifest — skip the scan jobs (see [CI.md](CI.md)); nothing
+  in that set can alter the module graph or the shipped artifacts.
 - Gate: `CRITICAL,HIGH` with `ignore-unfixed: true` — unfixable advisories
   surface in the run log but don't block merges.
 - License policy lives in [`trivy.yaml`](trivy.yaml) at repo root. Denylist
@@ -39,7 +42,7 @@ CI gates (in [`.github/workflows/ci.yml`](.github/workflows/ci.yml), `check` job
   (package + license combination) to `trivy.yaml`, with a justification and
   a reviewer from outside the requesting team.
 - [govulncheck](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck) runs on
-  every push in the `govulncheck` job as a Go-native gate complementary to
+  every code-touching push and PR in the `govulncheck` job as a Go-native gate complementary to
   Trivy (#233). It performs call-graph **reachability** analysis against the Go
   vulnerability database (<https://vuln.go.dev>) and the standard library for
   the pinned Go toolchain, and **fails the build when a vulnerable symbol is


### PR DESCRIPTION
## Why

A single code change currently runs the full pipeline **4 times** on its way to a release: on the PR, on its merge to `master`, on the release-please Release PR, and on that PR's merge — although the Release PR only touches `CHANGELOG.md` and `.release-please-manifest.json`. Two of the four runs re-test code that was already tested (tracked in DEVOPS-21842). In this repository that waste is not just hosted-runner minutes: each redundant run also performs a full start/stop cycle of the **self-hosted EC2 sandbox runner** (`t3.medium` + the whitelisted Elastic IP) and a ~10-minute live sandbox suite, so every gated-away run saves real AWS cost and frees a slot in the single-EIP acceptance queue.

Same pattern as namecheap/terraform-provider-jenkins#200.

## What

- Adds a `changes` gate job (`dorny/paths-filter@v4.0.2`, pinned by SHA per `SECURITY_COMPLIANCE.md`, `predicate-quantifier: every`). All test jobs — `check`, `docs`, both security scans, the security summary, the `acceptance_mock` matrix, and the EC2 `start-runner`/`acceptance_test` pair — take `needs: changes` + an `if:` on its `code` output, combined with their pre-existing fork/Dependabot/event conditions. They skip when the diff touches only root-level markdown (`*.md`), `LICENSE`, or `.release-please-manifest.json`.
- `docs/**`, `templates/**` and `examples/**` are treated as code and run the full suite: `docs/` is rendered by the Terraform Registry from the repo at each release tag, so it is a user-visible deliverable, and every example is type-checked by the `docs` job.
- **`stop-runner` is intentionally NOT gated**: its existing `always() && needs.start-runner.outputs.ec2-instance-id != ''` condition already skips cleanly when `start-runner` was skipped by the gate (the output is empty), and still stops any runner that was actually started — no change to the EC2 lifecycle semantics, and the nightly `cleanup-ec2-runners.yml` backstop is unaffected.
- **`workflow_dispatch` bypasses the filter** (always `code=true`): manual dispatch is a maintainer explicitly asking for a run — it is the documented path for live acceptance on Dependabot branches (`gh workflow run CI --ref <branch>`), and paths-filter has no base to diff against on that event anyway.
- Adds an always-run **`CI OK`** summary job (`needs:` every job, fails on `failure`/`cancelled`, passes on `success`/`skipped`) so a fully-skipped run still concludes `success` — required by `versioning.yml`'s `workflow_run` gate — and can serve as the single required check.
- Adds `CI.md` (human-oriented pipeline map + editing invariants) and updates `CONTRIBUTING.md`, `README.md`, `RELEASE.md`, `SECURITY_COMPLIANCE.md`, and `CLAUDE.md` where they describe when CI jobs run.

`.release-please-config.json` was checked before putting the manifest in the ignore list: `release-type: go` with no `extra-files`, so the Release PR touches only `CHANGELOG.md` + `.release-please-manifest.json`. If `extra-files` is ever added, the manifest must come out of the ignore list (noted in `CI.md`'s invariants).

## Why not `paths-ignore` on the triggers

1. The `Check` / `Security scan (Trivy)` / `Security scan (govulncheck)` checks are required by the "Protect master" ruleset, and a path-filtered required check is never reported on PRs touching only excluded files — such a PR could never merge. Checks skipped via `if:` **do** satisfy branch protection.
2. If CI didn't trigger at all on the Release-PR merge push, `versioning.yml`'s `workflow_run: [CI]` would never fire and release-please would never create the tag, breaking the release-please → tag → GoReleaser chain.

## Branch protection

The "Protect master" ruleset currently requires: `Check`, `Security scan (Trivy)`, `Security scan (govulncheck)` (all from this workflow), and `security/snyk (Namecheap)`. **After this PR merges, "CI OK" must be added to that list.** This is mandatory, not optional: the gate fails open — if the `changes` job itself fails (API flake, runner loss), every test job reports "skipped", and skipped checks satisfy the existing required checks — so a failing "CI OK" is the only thing that blocks such a PR from merging untested. The existing required checks can stay (they'll report "skipped" on docs-only PRs, which passes) or be replaced by "CI OK" alone.

## Verification

- `actionlint` (v1.7.10) passes on the modified workflow.
- This PR itself exercises the `code=true` path (workflow + markdown changes → full suite, EC2 acceptance included).
- The next release-please Release PR will exercise the skip path: expect every test job "skipped", "CI OK" green, and a normal tag + GoReleaser run after its merge.
- Dependabot PRs are unchanged: `check`/`docs`/scans + `acceptance_mock` run (their diffs touch `go.mod`/workflows — code), the EC2 jobs stay skipped, and the manual `workflow_dispatch` path now explicitly bypasses the gate.
