### PR TITLE
ci: stop overriding the provider namespace on the opentofu mock leg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -518,15 +518,20 @@ jobs:
       - name: Mock acceptance tests
         # ENGINE comes from the workflow-defined matrix (trusted), not from any
         # ${{ github.event.* }} value, so it is safe to branch on in the shell.
-        # OpenTofu resolves provider source addresses more strictly than
-        # Terraform, so the test harness is pointed at an address it accepts.
+        # TF_ACC_PROVIDER_HOST retargets the reattached provider's address at
+        # the OpenTofu registry. Do NOT also set TF_ACC_PROVIDER_NAMESPACE: with
+        # it unset the harness registers the provider under both default
+        # namespaces ("-" and "hashicorp"), which is what import steps that
+        # carry an explicit Config resolve to — terraform-plugin-testing writes
+        # those configs verbatim, without the required_providers source it
+        # injects into apply steps, so a custom namespace 404s against the real
+        # registry (see TestAccMockDomainHostRecordImportFormats).
         env:
           ENGINE: ${{ matrix.engine }}
         run: |
           if [ "${ENGINE}" = "opentofu" ]; then
             bin="$(command -v tofu)"
             export TF_ACC_PROVIDER_HOST="registry.opentofu.org"
-            export TF_ACC_PROVIDER_NAMESPACE="namecheap"
           else
             bin="$(command -v terraform)"
           fi


### PR DESCRIPTION
## Problem

The `Mock acceptance (opentofu 1.12.3)` job deterministically fails `TestAccMockDomainHostRecordImportFormats` and `TestAccMockDomainHostRecordRefusesAmbiguousMatch` on Dependabot PRs #316 and #317. The failure is unrelated to those PRs' contents and reproduces locally on master.

## Root cause

`TF_ACC_PROVIDER_NAMESPACE=namecheap` makes the test harness reattach the in-process provider only at `registry.opentofu.org/namecheap/namecheap`. terraform-plugin-testing injects a matching `required_providers` source into **apply-step** configs, but **import steps that carry an explicit `Config`** are written to the working directory verbatim (`testStepNewImportState`). OpenTofu then resolves the bare provider name to the default `hashicorp` namespace and queries the real OpenTofu registry, where no such provider exists:

- `ImportFormats`: import-first step with `ImportStatePersist: true` skips `init` → `tofu import` fails with *Inconsistent dependency lock file*.
- `RefusesAmbiguousMatch`: its first step fails by design (`ExpectError`), so there is no prior applied config to inherit; the import step's raw config makes `tofu init` 404 against the registry.

Every other import test passes because it omits `Config` on the import step and inherits the previous step's merged (injected) config. The matrix job only runs on Dependabot/fork PRs, so the tests introduced in #310 first met OpenTofu on #316/#317.

## Fix

Leave `TF_ACC_PROVIDER_NAMESPACE` unset: the harness then registers the provider under both default namespaces (`-` and `hashicorp`), which matches raw and injected configs alike. `TF_ACC_PROVIDER_HOST` stays, since unmanaged reattached providers never contact the registry — the address only has to be one OpenTofu derives from the config.

## Verification

`TF_ACC_TERRAFORM_PATH=$(command -v tofu) TF_ACC_PROVIDER_HOST=registry.opentofu.org make testacc-mock` — full mock suite passes locally under OpenTofu 1.11.7, including both previously failing tests. The terraform legs are untouched by this change.

## Follow-up

Once this lands, `@dependabot rebase` #316 and #317. Merging #316 also clears the Trivy failure on master (CVE-2026-71556 in go-git v5.19.1, fixed in v5.19.2).