### PR TITLE
feat: read the full domain info from getInfo and expose privacy, ownership, and rights attributes

### DIFF
--- a/docs/data-sources/domain.md
+++ b/docs/data-sources/domain.md
@@ -9,7 +9,7 @@ description: |-
 
 Looks up read-only information about a single domain. Use it to reference an existing (non-Terraform-managed) domain's DNS provider, nameservers or expiry in other resources, or to gate logic on domain properties (is it expiring? locked? which DNS type is active?).
 
-~> This data source performs **two** Namecheap API calls per read: `namecheap.domains.getInfo` supplies the DNS-oriented fields (`dns_provider_type`, `is_our_dns`, `is_premium`, `is_premium_dns`, `nameservers`), and `namecheap.domains.getList` supplies the lifecycle fields (`created`, `expires`, `is_expired`, `is_locked`, `auto_renew`, `whois_guard`) that `getInfo` does not return. If you only need lifecycle data for many domains at once, prefer the [`namecheap_domains`](domains.md) portfolio data source, which returns all of it in one paginated listing.
+~> This data source performs **two** Namecheap API calls per read: `namecheap.domains.getInfo` supplies almost everything (DNS details, dates, privacy, ownership, modification rights), and `namecheap.domains.getList` supplies only the two booleans `getInfo` does not return (`is_locked`, `auto_renew`). If you only need lifecycle data for many domains at once, prefer the [`namecheap_domains`](domains.md) portfolio data source, which returns all of it in one paginated listing.
 
 ## Example Usage
 
@@ -49,3 +49,17 @@ output "expires" {
 - `is_locked` - Whether the registrar lock is enabled.
 - `auto_renew` - Whether auto-renew is enabled.
 - `whois_guard` - WhoisGuard status (e.g. `ENABLED`, `DISABLED`, `NOTPRESENT`).
+- `whois_guard_expires` - Expiration date of the domain privacy protection as an RFC3339 timestamp (UTC); empty when privacy is not allotted.
+- `whois_guard_email` - The generated privacy-protection email address on the Whois record.
+- `whois_guard_forwarded_to` - The real address the privacy-protection email forwards to.
+- `status` - Domain status as reported by the API (e.g. `Ok`, `Locked`, `Expired`); empty when the API omits it.
+- `owner_name` - The user account under which the domain is registered.
+- `is_owner` - Whether the API user is the domain owner.
+- `premium_dns_auto_renew` - Whether the PremiumDNS subscription auto-renews. This is the subscription's own flag, distinct from the domain's `auto_renew`.
+- `premium_dns_expires` - Expiration timestamp of the PremiumDNS subscription as reported by the API; empty when there is no subscription.
+- `email_type` - The email service configured for the domain (e.g. `FWD`, `MXE`, `OX`, `No Email Service`).
+- `host_count` - Number of DNS host records configured for the domain.
+- `dynamic_dns_status` - Whether dynamic DNS is enabled for the domain.
+- `is_failover` - Whether DNS failover is enabled for the domain.
+- `modification_rights_all` - Whether the API user holds all modification rights on the domain.
+- `modification_rights` - Granular per-feature modification rights (e.g. `dns`, `rlock`, `autorenew` mapped to `OK`), populated for shared/permissioned domains.

--- a/docs/data-sources/domain.md
+++ b/docs/data-sources/domain.md
@@ -9,7 +9,7 @@ description: |-
 
 Looks up read-only information about a single domain. Use it to reference an existing (non-Terraform-managed) domain's DNS provider, nameservers or expiry in other resources, or to gate logic on domain properties (is it expiring? locked? which DNS type is active?).
 
-~> This data source performs **two** Namecheap API calls per read: `namecheap.domains.getInfo` supplies almost everything (DNS details, dates, privacy, ownership, modification rights), and `namecheap.domains.getList` supplies only the two booleans `getInfo` does not return (`is_locked`, `auto_renew`). If you only need lifecycle data for many domains at once, prefer the [`namecheap_domains`](domains.md) portfolio data source, which returns all of it in one paginated listing.
+~> This data source performs **two** Namecheap API calls per read: `namecheap.domains.getInfo` supplies almost everything (DNS details, dates, privacy, ownership, modification rights), and `namecheap.domains.getList` supplies the two booleans `getInfo` does not return (`is_locked`, `auto_renew`) plus the authoritative `is_expired` flag. If you only need lifecycle data for many domains at once, prefer the [`namecheap_domains`](domains.md) portfolio data source, which returns all of it in one paginated listing.
 
 ## Example Usage
 
@@ -44,19 +44,19 @@ output "expires" {
 - `nameservers` - The nameservers currently configured for the domain.
 - `created` - Registration date as an RFC3339 timestamp (UTC).
 - `expires` - Expiration date as an RFC3339 timestamp (UTC).
-- `expires_in_days` - Whole calendar days until the domain expires (negative if already expired). Derived from the wall clock at read time; prefer `expires` where a stable value is needed.
-- `is_expired` - Whether the domain has expired.
+- `expires_in_days` - Whole calendar days until the domain expires (negative if already expired). Derived from the wall clock at read time; prefer `expires` where a stable value is needed. `0` together with an empty `expires` means the API did not report an expiry date.
+- `is_expired` - Whether the domain has expired, as reported by the portfolio listing (this accounts for renewal grace periods). When the domain is missing from the listing, it falls back to a value derived from the expiry date and domain status.
 - `is_locked` - Whether the registrar lock is enabled.
 - `auto_renew` - Whether auto-renew is enabled.
 - `whois_guard` - WhoisGuard status (e.g. `ENABLED`, `DISABLED`, `NOTPRESENT`).
 - `whois_guard_expires` - Expiration date of the domain privacy protection as an RFC3339 timestamp (UTC); empty when privacy is not allotted.
 - `whois_guard_email` - The generated privacy-protection email address on the Whois record.
-- `whois_guard_forwarded_to` - The real address the privacy-protection email forwards to.
+- `whois_guard_forwarded_to` - The real address the privacy-protection email forwards to. Note that this address is stored in the Terraform state.
 - `status` - Domain status as reported by the API (e.g. `Ok`, `Locked`, `Expired`); empty when the API omits it.
 - `owner_name` - The user account under which the domain is registered.
 - `is_owner` - Whether the API user is the domain owner.
 - `premium_dns_auto_renew` - Whether the PremiumDNS subscription auto-renews. This is the subscription's own flag, distinct from the domain's `auto_renew`.
-- `premium_dns_expires` - Expiration timestamp of the PremiumDNS subscription as reported by the API; empty when there is no subscription.
+- `premium_dns_expires` - Expiration date of the PremiumDNS subscription as an RFC3339 timestamp (UTC); empty when there is no subscription or the API reports no expiry.
 - `email_type` - The email service configured for the domain (e.g. `FWD`, `MXE`, `OX`, `No Email Service`).
 - `host_count` - Number of DNS host records configured for the domain.
 - `dynamic_dns_status` - Whether dynamic DNS is enabled for the domain.

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.11.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
-	github.com/namecheap/go-namecheap-sdk/v2 v2.10.0
+	github.com/namecheap/go-namecheap-sdk/v2 v2.10.1
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -164,8 +164,8 @@ github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
-github.com/namecheap/go-namecheap-sdk/v2 v2.10.0 h1:gKgI1dYwGwt8xeeGzVDQtBMnBr1s8b0CQtRwwkPSloM=
-github.com/namecheap/go-namecheap-sdk/v2 v2.10.0/go.mod h1:Qlz3X1kDNHJUuDotq6Yo1xQXsxZyM/6BX1/N+zbi5OE=
+github.com/namecheap/go-namecheap-sdk/v2 v2.10.1 h1:RlSkkhBqCcd+T5nhksaVsKwSPskam5SPLinv97e5e/Y=
+github.com/namecheap/go-namecheap-sdk/v2 v2.10.1/go.mod h1:Qlz3X1kDNHJUuDotq6Yo1xQXsxZyM/6BX1/N+zbi5OE=
 github.com/oklog/run v1.2.0 h1:O8x3yXwah4A73hJdlrwo/2X6J62gE5qTMusH0dvz60E=
 github.com/oklog/run v1.2.0/go.mod h1:mgDbKRSwPhJfesJ4PntqFUbKQRZ50NgmZTSPlFA0YFk=
 github.com/pjbgf/sha1cd v0.6.0 h1:3WJ8Wz8gvDz29quX1OcEmkAlUg9diU4GxJHqs0/XiwU=

--- a/namecheap/data_source_helpers.go
+++ b/namecheap/data_source_helpers.go
@@ -13,11 +13,14 @@ import (
 
 // domainLifecycleAttrs are the attributes exported by the namecheap_domain data
 // source that originate from the portfolio listing (namecheap.domains.getList)
-// rather than from getInfo. Since getInfo's full response mapping (SDK v2.10.1)
-// only the registrar-lock and domain auto-renew booleans still require the
-// listing; everything else comes from getInfo directly.
+// rather than from getInfo. Since SDK v2.10.1 maps getInfo's full response,
+// only the registrar-lock and domain auto-renew booleans (which getInfo does
+// not carry at all) and is_expired still come from the listing. is_expired is
+// listed here so the API's own flag — which accounts for renewal grace periods
+// and matches the namecheap_domains data source — overwrites the fallback value
+// derived from getInfo's expiry date and status.
 var domainLifecycleAttrs = []string{
-	"is_locked", "auto_renew",
+	"is_expired", "is_locked", "auto_renew",
 }
 
 // fetchAllDomains pages through namecheap.domains.getList for the given filters,
@@ -93,10 +96,11 @@ func setDomainLifecycleFromList(ctx context.Context, client *namecheap.Client, d
 
 	return diag.Diagnostics{{
 		Severity: diag.Warning,
-		Summary:  fmt.Sprintf("Lifecycle fields unavailable for domain %q", domain),
+		Summary:  fmt.Sprintf("Registrar lock and auto-renew unavailable for domain %q", domain),
 		Detail: "getInfo confirmed the domain exists, but it did not appear in the " +
-			"namecheap.domains.getList portfolio listing, so the listing-sourced fields " +
-			"(is_locked, auto_renew) were left at their zero values. " +
+			"namecheap.domains.getList portfolio listing, so is_locked and auto_renew " +
+			"were left at their zero values and is_expired was derived from the expiry " +
+			"date and status instead of the listing's own flag. " +
 			"This is unexpected; please report it if it persists.",
 	}}
 }
@@ -124,6 +128,23 @@ func formatDateTime(dt *namecheap.DateTime) string {
 		return ""
 	}
 	return dt.Time.UTC().Format(time.RFC3339)
+}
+
+// formatPremiumDNSDate renders a PremiumDnsSubscription date — an ISO string
+// without a zone designator, e.g. "2027-06-02T00:00:00" — as RFC3339 (UTC), so
+// premium_dns_expires matches the format of every other date attribute. The
+// zero time ("0001-01-01T00:00:00", the API's "never" sentinel, which can
+// appear even on a live subscription) renders as an empty string. A value that
+// fails to parse is passed through verbatim rather than dropped.
+func formatPremiumDNSDate(s string) string {
+	t, err := time.Parse("2006-01-02T15:04:05", s)
+	if err != nil {
+		return s
+	}
+	if t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339)
 }
 
 // daysUntil returns the whole number of calendar days from now until target,

--- a/namecheap/data_source_helpers.go
+++ b/namecheap/data_source_helpers.go
@@ -13,11 +13,11 @@ import (
 
 // domainLifecycleAttrs are the attributes exported by the namecheap_domain data
 // source that originate from the portfolio listing (namecheap.domains.getList)
-// rather than from getInfo. They are a subset of domainPortfolioElemSchema so
-// the single-domain and portfolio shapes stay consistent.
+// rather than from getInfo. Since getInfo's full response mapping (SDK v2.10.1)
+// only the registrar-lock and domain auto-renew booleans still require the
+// listing; everything else comes from getInfo directly.
 var domainLifecycleAttrs = []string{
-	"created", "expires", "expires_in_days",
-	"is_expired", "is_locked", "auto_renew", "whois_guard",
+	"is_locked", "auto_renew",
 }
 
 // fetchAllDomains pages through namecheap.domains.getList for the given filters,
@@ -95,9 +95,9 @@ func setDomainLifecycleFromList(ctx context.Context, client *namecheap.Client, d
 		Severity: diag.Warning,
 		Summary:  fmt.Sprintf("Lifecycle fields unavailable for domain %q", domain),
 		Detail: "getInfo confirmed the domain exists, but it did not appear in the " +
-			"namecheap.domains.getList portfolio listing, so the lifecycle fields " +
-			"(created, expires, expires_in_days, is_expired, is_locked, auto_renew, whois_guard) " +
-			"were left empty. This is unexpected; please report it if it persists.",
+			"namecheap.domains.getList portfolio listing, so the listing-sourced fields " +
+			"(is_locked, auto_renew) were left at their zero values. " +
+			"This is unexpected; please report it if it persists.",
 	}}
 }
 
@@ -117,9 +117,10 @@ func dataSourceDomainReadError(domain string, err error) diag.Diagnostics {
 // formatDateTime renders a Namecheap DateTime as an RFC3339 string. Namecheap
 // returns lifecycle dates as calendar dates (the SDK parses "MM/DD/YYYY" with
 // time.Parse, yielding midnight UTC), so the RFC3339 output is timezone-stable.
-// A nil pointer renders as an empty string.
+// A nil pointer renders as an empty string, as does the zero time — since SDK
+// v2.10.1 an empty date element decodes to the zero value instead of erroring.
 func formatDateTime(dt *namecheap.DateTime) string {
-	if dt == nil {
+	if dt == nil || dt.IsZero() {
 		return ""
 	}
 	return dt.Time.UTC().Format(time.RFC3339)

--- a/namecheap/data_source_namecheap_domain.go
+++ b/namecheap/data_source_namecheap_domain.go
@@ -3,6 +3,7 @@ package namecheap_provider
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -11,15 +12,10 @@ import (
 
 // dataSourceNamecheapDomain exposes read-only information about a single domain.
 //
-// It combines two API commands so the exported attributes match the issue's
-// contract in full:
-//   - namecheap.domains.getInfo supplies the DNS-oriented fields (provider type,
-//     nameservers, premium flags);
-//   - namecheap.domains.getList supplies the domain lifecycle fields
-//     (created/expires/is_expired/is_locked/auto_renew/whois_guard), which
-//     getInfo does not return.
-//
-// The two-call cost is documented on the registry page.
+// Almost everything comes from one namecheap.domains.getInfo call: DNS details,
+// dates, privacy (Whoisguard), ownership, and modification rights. Only
+// is_locked and auto_renew still require the namecheap.domains.getList
+// portfolio listing — getInfo does not return those two booleans.
 func dataSourceNamecheapDomain() *schema.Resource {
 	return &schema.Resource{
 		Description: "Reads a single domain on the account: its DNS provider and nameservers, plus lifecycle fields such as expiry, registrar lock and auto-renew.",
@@ -92,6 +88,77 @@ func dataSourceNamecheapDomain() *schema.Resource {
 				Computed:    true,
 				Description: "WhoisGuard status (e.g. ENABLED, DISABLED, NOTPRESENT).",
 			},
+			"whois_guard_expires": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Expiration date of the domain privacy protection as an RFC3339 timestamp (UTC); empty when privacy is not allotted.",
+			},
+			"whois_guard_email": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The generated privacy-protection email address on the Whois record.",
+			},
+			"whois_guard_forwarded_to": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The real address the privacy-protection email forwards to.",
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Domain status as reported by the API (e.g. Ok, Locked, Expired); empty when the API omits it.",
+			},
+			"owner_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The user account under which the domain is registered.",
+			},
+			"is_owner": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Whether the API user is the domain owner.",
+			},
+			"premium_dns_auto_renew": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Whether the PremiumDNS subscription auto-renews. This is the subscription's own flag, distinct from the domain's auto_renew.",
+			},
+			"premium_dns_expires": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Expiration timestamp of the PremiumDNS subscription as reported by the API; empty when there is no subscription.",
+			},
+			"email_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The email service configured for the domain (e.g. FWD, MXE, OX, No Email Service).",
+			},
+			"host_count": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Number of DNS host records configured for the domain.",
+			},
+			"dynamic_dns_status": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Whether dynamic DNS is enabled for the domain.",
+			},
+			"is_failover": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Whether DNS failover is enabled for the domain.",
+			},
+			"modification_rights_all": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Whether the API user holds all modification rights on the domain.",
+			},
+			"modification_rights": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Description: "Granular per-feature modification rights (e.g. dns, rlock, autorenew mapped to OK), populated for shared/permissioned domains.",
+			},
 		},
 	}
 }
@@ -114,26 +181,102 @@ func dataSourceNamecheapDomainRead(ctx context.Context, data *schema.ResourceDat
 	if info.IsPremium != nil {
 		_ = data.Set("is_premium", *info.IsPremium)
 	}
-	if info.PremiumDnsSubscription != nil && info.PremiumDnsSubscription.IsActive != nil {
-		_ = data.Set("is_premium_dns", *info.PremiumDnsSubscription.IsActive)
+	if info.Status != nil {
+		_ = data.Set("status", *info.Status)
 	}
-	if info.DnsDetails != nil {
-		if info.DnsDetails.ProviderType != nil {
-			_ = data.Set("dns_provider_type", *info.DnsDetails.ProviderType)
-		}
-		if info.DnsDetails.IsUsingOurDNS != nil {
-			_ = data.Set("is_our_dns", *info.DnsDetails.IsUsingOurDNS)
-		}
-		if info.DnsDetails.Nameservers != nil {
-			_ = data.Set("nameservers", *info.DnsDetails.Nameservers)
+	if info.OwnerName != nil {
+		_ = data.Set("owner_name", *info.OwnerName)
+	}
+	if info.IsOwner != nil {
+		_ = data.Set("is_owner", *info.IsOwner)
+	}
+
+	if dd := info.DomainDetails; dd != nil {
+		_ = data.Set("created", formatDateTime(dd.CreatedDate))
+		_ = data.Set("expires", formatDateTime(dd.ExpiredDate))
+		if dd.ExpiredDate != nil && !dd.ExpiredDate.IsZero() {
+			days := daysUntil(dd.ExpiredDate.Time, time.Now().UTC())
+			_ = data.Set("expires_in_days", days)
+			_ = data.Set("is_expired", days < 0 || isStatusExpired(info.Status))
+		} else {
+			_ = data.Set("is_expired", isStatusExpired(info.Status))
 		}
 	}
 
-	// getInfo does not carry the domain lifecycle fields (created/expires/
-	// is_expired/is_locked/auto_renew/whois_guard). Fetch them from the account
-	// portfolio listing, which does. getInfo above has already confirmed the
-	// domain exists, so a portfolio miss leaves the lifecycle fields at their
-	// zero values (with a warning) rather than failing the whole lookup.
+	if wg := info.WhoisGuard; wg != nil {
+		if wg.Enabled != nil {
+			_ = data.Set("whois_guard", mapGetInfoWhoisGuard(*wg.Enabled))
+		}
+		_ = data.Set("whois_guard_expires", formatDateTime(wg.ExpiredDate))
+		if ed := wg.EmailDetails; ed != nil {
+			if ed.WhoisGuardEmail != nil {
+				_ = data.Set("whois_guard_email", *ed.WhoisGuardEmail)
+			}
+			if ed.ForwardedTo != nil {
+				_ = data.Set("whois_guard_forwarded_to", *ed.ForwardedTo)
+			}
+		}
+	}
+
+	if sub := info.PremiumDnsSubscription; sub != nil {
+		if sub.IsActive != nil {
+			_ = data.Set("is_premium_dns", *sub.IsActive)
+		}
+		// SubscriptionId -1 is the API's "no subscription" sentinel; its
+		// UseAutoRenew and sentinel dates carry no information in that case.
+		if sub.SubscriptionID != nil && *sub.SubscriptionID != -1 {
+			if sub.UseAutoRenew != nil {
+				_ = data.Set("premium_dns_auto_renew", *sub.UseAutoRenew)
+			}
+			if sub.ExpirationDate != nil {
+				_ = data.Set("premium_dns_expires", *sub.ExpirationDate)
+			}
+		}
+	}
+
+	if dns := info.DnsDetails; dns != nil {
+		if dns.ProviderType != nil {
+			_ = data.Set("dns_provider_type", *dns.ProviderType)
+		}
+		if dns.IsUsingOurDNS != nil {
+			_ = data.Set("is_our_dns", *dns.IsUsingOurDNS)
+		}
+		if dns.Nameservers != nil {
+			_ = data.Set("nameservers", *dns.Nameservers)
+		}
+		if dns.EmailType != nil {
+			_ = data.Set("email_type", *dns.EmailType)
+		}
+		if dns.HostCount != nil {
+			_ = data.Set("host_count", *dns.HostCount)
+		}
+		if dns.DynamicDNSStatus != nil {
+			_ = data.Set("dynamic_dns_status", *dns.DynamicDNSStatus)
+		}
+		if dns.IsFailover != nil {
+			_ = data.Set("is_failover", *dns.IsFailover)
+		}
+	}
+
+	if mr := info.ModificationRights; mr != nil {
+		if mr.All != nil {
+			_ = data.Set("modification_rights_all", *mr.All)
+		}
+		if mr.Rights != nil {
+			rights := make(map[string]interface{}, len(*mr.Rights))
+			for _, r := range *mr.Rights {
+				if r.Type != nil {
+					rights[*r.Type] = derefString(r.Value)
+				}
+			}
+			_ = data.Set("modification_rights", rights)
+		}
+	}
+
+	// getInfo does not carry the registrar-lock and domain auto-renew booleans.
+	// Fetch just those two from the account portfolio listing. getInfo above has
+	// already confirmed the domain exists, so a portfolio miss leaves them at
+	// their zero values (with a warning) rather than failing the whole lookup.
 	lifecycleDiags := setDomainLifecycleFromList(ctx, client, data, domain)
 	if lifecycleDiags.HasError() {
 		return lifecycleDiags
@@ -143,4 +286,28 @@ func dataSourceNamecheapDomainRead(ctx context.Context, data *schema.ResourceDat
 	// Propagate any non-error diagnostics (e.g. the portfolio-miss warning)
 	// without discarding the successful read.
 	return lifecycleDiags
+}
+
+// isStatusExpired reports whether getInfo's Status attribute says the domain is
+// expired. A nil or unrecognized status reports false.
+func isStatusExpired(status *string) bool {
+	return status != nil && strings.EqualFold(*status, "Expired")
+}
+
+// mapGetInfoWhoisGuard converts getInfo's Whoisguard Enabled vocabulary
+// ("True"/"False"/"NotAlloted") onto the whois_guard attribute's documented
+// getList vocabulary (ENABLED/DISABLED/NOTPRESENT), so the attribute's values
+// stay stable regardless of which API command sourced them. Unknown values pass
+// through uppercased rather than being dropped.
+func mapGetInfoWhoisGuard(enabled string) string {
+	switch strings.ToLower(enabled) {
+	case "true":
+		return "ENABLED"
+	case "false":
+		return "DISABLED"
+	case "notalloted", "notallotted":
+		return "NOTPRESENT"
+	default:
+		return strings.ToUpper(enabled)
+	}
 }

--- a/namecheap/data_source_namecheap_domain.go
+++ b/namecheap/data_source_namecheap_domain.go
@@ -105,11 +105,11 @@ func dataSourceNamecheapDomainRead(ctx context.Context, data *schema.ResourceDat
 		return dataSourceDomainReadError(domain, err)
 	}
 
-	if resp == nil || resp.DomainDNSGetListResult == nil {
+	if resp == nil || resp.Result() == nil {
 		return diag.Errorf("Namecheap returned no information for domain %q; it may not exist or may not be associated with this account", domain)
 	}
 
-	info := resp.DomainDNSGetListResult
+	info := resp.Result()
 
 	if info.IsPremium != nil {
 		_ = data.Set("is_premium", *info.IsPremium)

--- a/namecheap/data_source_namecheap_domain.go
+++ b/namecheap/data_source_namecheap_domain.go
@@ -13,9 +13,12 @@ import (
 // dataSourceNamecheapDomain exposes read-only information about a single domain.
 //
 // Almost everything comes from one namecheap.domains.getInfo call: DNS details,
-// dates, privacy (Whoisguard), ownership, and modification rights. Only
-// is_locked and auto_renew still require the namecheap.domains.getList
-// portfolio listing — getInfo does not return those two booleans.
+// dates, privacy (Whoisguard), ownership, and modification rights. The
+// namecheap.domains.getList portfolio listing still supplies is_locked and
+// auto_renew (getInfo does not return those two booleans) and the authoritative
+// is_expired flag — the API's own verdict, which accounts for renewal grace
+// periods that date arithmetic cannot see. On a portfolio miss, is_expired
+// falls back to a value derived from the expiry date and domain status.
 func dataSourceNamecheapDomain() *schema.Resource {
 	return &schema.Resource{
 		Description: "Reads a single domain on the account: its DNS provider and nameservers, plus lifecycle fields such as expiry, registrar lock and auto-renew.",
@@ -66,12 +69,12 @@ func dataSourceNamecheapDomain() *schema.Resource {
 			"expires_in_days": {
 				Type:        schema.TypeInt,
 				Computed:    true,
-				Description: "Whole calendar days until the domain expires (negative if already expired).",
+				Description: "Whole calendar days until the domain expires (negative if already expired). 0 with an empty expires means the API did not report an expiry date.",
 			},
 			"is_expired": {
 				Type:        schema.TypeBool,
 				Computed:    true,
-				Description: "Whether the domain has expired.",
+				Description: "Whether the domain has expired, as reported by the portfolio listing (accounts for renewal grace periods); derived from the expiry date and status when the domain is missing from the listing.",
 			},
 			"is_locked": {
 				Type:        schema.TypeBool,
@@ -101,7 +104,7 @@ func dataSourceNamecheapDomain() *schema.Resource {
 			"whois_guard_forwarded_to": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "The real address the privacy-protection email forwards to.",
+				Description: "The real address the privacy-protection email forwards to. Note that this address is stored in the Terraform state.",
 			},
 			"status": {
 				Type:        schema.TypeString,
@@ -126,7 +129,7 @@ func dataSourceNamecheapDomain() *schema.Resource {
 			"premium_dns_expires": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "Expiration timestamp of the PremiumDNS subscription as reported by the API; empty when there is no subscription.",
+				Description: "Expiration date of the PremiumDNS subscription as an RFC3339 timestamp (UTC); empty when there is no subscription or the API reports no expiry.",
 			},
 			"email_type": {
 				Type:        schema.TypeString,
@@ -191,17 +194,20 @@ func dataSourceNamecheapDomainRead(ctx context.Context, data *schema.ResourceDat
 		_ = data.Set("is_owner", *info.IsOwner)
 	}
 
+	expired := isStatusExpired(info.Status)
 	if dd := info.DomainDetails; dd != nil {
 		_ = data.Set("created", formatDateTime(dd.CreatedDate))
 		_ = data.Set("expires", formatDateTime(dd.ExpiredDate))
 		if dd.ExpiredDate != nil && !dd.ExpiredDate.IsZero() {
 			days := daysUntil(dd.ExpiredDate.Time, time.Now().UTC())
 			_ = data.Set("expires_in_days", days)
-			_ = data.Set("is_expired", days < 0 || isStatusExpired(info.Status))
-		} else {
-			_ = data.Set("is_expired", isStatusExpired(info.Status))
+			expired = expired || days < 0
 		}
 	}
+	// Fallback only: when the domain is found in the portfolio listing,
+	// setDomainLifecycleFromList below overwrites is_expired with the API's own
+	// flag, which stays authoritative (it accounts for renewal grace periods).
+	_ = data.Set("is_expired", expired)
 
 	if wg := info.WhoisGuard; wg != nil {
 		if wg.Enabled != nil {
@@ -229,7 +235,7 @@ func dataSourceNamecheapDomainRead(ctx context.Context, data *schema.ResourceDat
 				_ = data.Set("premium_dns_auto_renew", *sub.UseAutoRenew)
 			}
 			if sub.ExpirationDate != nil {
-				_ = data.Set("premium_dns_expires", *sub.ExpirationDate)
+				_ = data.Set("premium_dns_expires", formatPremiumDNSDate(*sub.ExpirationDate))
 			}
 		}
 	}
@@ -266,17 +272,19 @@ func dataSourceNamecheapDomainRead(ctx context.Context, data *schema.ResourceDat
 			rights := make(map[string]interface{}, len(*mr.Rights))
 			for _, r := range *mr.Rights {
 				if r.Type != nil {
-					rights[*r.Type] = derefString(r.Value)
+					// Value is XML chardata; trim in case the API pretty-prints.
+					rights[*r.Type] = strings.TrimSpace(derefString(r.Value))
 				}
 			}
 			_ = data.Set("modification_rights", rights)
 		}
 	}
 
-	// getInfo does not carry the registrar-lock and domain auto-renew booleans.
-	// Fetch just those two from the account portfolio listing. getInfo above has
-	// already confirmed the domain exists, so a portfolio miss leaves them at
-	// their zero values (with a warning) rather than failing the whole lookup.
+	// getInfo does not carry the registrar-lock and domain auto-renew booleans,
+	// and its is_expired can only be derived. Fetch those three from the account
+	// portfolio listing. getInfo above has already confirmed the domain exists,
+	// so a portfolio miss leaves the booleans at their zero values and is_expired
+	// at the derived fallback (with a warning) rather than failing the lookup.
 	lifecycleDiags := setDomainLifecycleFromList(ctx, client, data, domain)
 	if lifecycleDiags.HasError() {
 		return lifecycleDiags

--- a/namecheap/data_source_read_test.go
+++ b/namecheap/data_source_read_test.go
@@ -57,28 +57,28 @@ func startDataSourceServer(t *testing.T, handler func(command string, r *http.Re
 // dsGetInfo drives xmlGetInfo, mirroring the real getInfo response shape (SDK
 // v2.10.1 maps the full subtree). Zero-valued optional fields omit their XML.
 type dsGetInfo struct {
-	Domain        string
-	Status        string // "" omits the Status attribute (the sandbox omits it too)
-	OwnerName     string
-	IsOwner       bool
-	IsPremium     bool
-	Created       string // MM/DD/YYYY; "" omits the element
-	Expires       string // MM/DD/YYYY; "" omits the element
-	WhoisEnabled  string // "" omits the whole Whoisguard element
-	WhoisExpires  string // MM/DD/YYYY
-	WhoisEmail    string
-	ForwardedTo   string
-	PremiumDNS    bool // IsActive; false also renders the -1 sentinel subscription
-	SubscriptionID int
+	Domain              string
+	Status              string // "" omits the Status attribute (the sandbox omits it too)
+	OwnerName           string
+	IsOwner             bool
+	IsPremium           bool
+	Created             string // MM/DD/YYYY; "" omits the element
+	Expires             string // MM/DD/YYYY; "" omits the element
+	WhoisEnabled        string // "" omits the whole Whoisguard element
+	WhoisExpires        string // MM/DD/YYYY
+	WhoisEmail          string
+	ForwardedTo         string
+	PremiumDNS          bool // IsActive; false also renders the -1 sentinel subscription
+	SubscriptionID      int
 	PremiumDNSAutoRenew bool
 	PremiumDNSExpires   string
-	ProviderType  string
-	IsOurDNS      bool
-	EmailType     string
-	HostCount     int
-	Nameservers   []string
-	RightsAll     string // "" renders <Modificationrights />; "true"/"false" sets the attr
-	Rights        [][2]string
+	ProviderType        string
+	IsOurDNS            bool
+	EmailType           string
+	HostCount           int
+	Nameservers         []string
+	RightsAll           string // "" renders <Modificationrights />; "true"/"false" sets the attr
+	Rights              [][2]string
 }
 
 func xmlGetInfo(g dsGetInfo) string {
@@ -251,9 +251,11 @@ func TestDataSourceDomainRead_Success(t *testing.T) {
 		case "namecheap.domains.getList":
 			// Deliberately different dates and whois state than getInfo: the
 			// assertions below prove getInfo is now the source for those fields
-			// and the listing supplies only is_locked/auto_renew.
+			// and the listing supplies only is_expired/is_locked/auto_renew.
+			// IsExpired=true contradicts getInfo's 2099 expiry on purpose — the
+			// listing's own flag must win over the date-derived fallback.
 			return xmlGetListPage([]dsDomainRow{
-				{ID: "42", Name: domain, User: "u", Created: "01/01/2000", Expires: "01/01/2001", WhoisGuard: "DISABLED", IsLocked: true, AutoRenew: true, IsOurDNS: true},
+				{ID: "42", Name: domain, User: "u", Created: "01/01/2000", Expires: "01/01/2001", WhoisGuard: "DISABLED", IsExpired: true, IsLocked: true, AutoRenew: true, IsOurDNS: true},
 			}, 1, 1, domainsPageSize)
 		}
 		return apiErrorXML("1010101", "unexpected command "+command)
@@ -274,9 +276,10 @@ func TestDataSourceDomainRead_Success(t *testing.T) {
 	assert.Equal(t, "2099-06-02T00:00:00Z", d.Get("expires"))
 	assert.Equal(t, "2021-06-02T00:00:00Z", d.Get("created"))
 	assert.Equal(t, "ENABLED", d.Get("whois_guard"), "True from getInfo must map onto the documented vocabulary")
-	assert.Equal(t, false, d.Get("is_expired"))
 	assert.Greater(t, d.Get("expires_in_days").(int), 0)
-	// Listing-sourced booleans.
+	// Listing-sourced fields. is_expired must be the listing's own flag, not the
+	// date-derived fallback (getInfo's 2099 expiry would say false).
+	assert.Equal(t, true, d.Get("is_expired"), "the listing's IsExpired flag must override the date-derived fallback")
 	assert.Equal(t, true, d.Get("is_locked"))
 	assert.Equal(t, true, d.Get("auto_renew"))
 	// New getInfo attributes.
@@ -287,7 +290,7 @@ func TestDataSourceDomainRead_Success(t *testing.T) {
 	assert.Equal(t, "guard@whoisguard.example", d.Get("whois_guard_email"))
 	assert.Equal(t, "real@example.com", d.Get("whois_guard_forwarded_to"))
 	assert.Equal(t, true, d.Get("premium_dns_auto_renew"))
-	assert.Equal(t, "2027-06-02T00:00:00", d.Get("premium_dns_expires"))
+	assert.Equal(t, "2027-06-02T00:00:00Z", d.Get("premium_dns_expires"), "the subscription date must be normalized to RFC3339 like every other date attribute")
 	assert.Equal(t, "FWD", d.Get("email_type"))
 	assert.Equal(t, 2, d.Get("host_count"))
 	assert.Equal(t, false, d.Get("dynamic_dns_status"))
@@ -340,9 +343,73 @@ func TestDataSourceDomainRead_LifecycleMissing(t *testing.T) {
 	// getInfo-sourced fields survive a portfolio miss.
 	assert.Equal(t, "2099-06-02T00:00:00Z", d.Get("expires"))
 	assert.Equal(t, "NOTPRESENT", d.Get("whois_guard"), "NotAlloted from getInfo must map onto the documented vocabulary")
-	// Only the listing-sourced booleans degrade to zero values.
+	// Only the listing-sourced booleans degrade to zero values; is_expired keeps
+	// the fallback derived from getInfo's expiry date (2099 -> not expired).
+	assert.Equal(t, false, d.Get("is_expired"))
 	assert.Equal(t, false, d.Get("is_locked"))
 	assert.Equal(t, false, d.Get("auto_renew"))
+	// The -1 sentinel subscription must not surface its auto-renew flag or its
+	// "0001-01-01T00:00:00" never-expires date.
+	assert.Equal(t, false, d.Get("premium_dns_auto_renew"))
+	assert.Equal(t, "", d.Get("premium_dns_expires"))
+	assert.Equal(t, "", d.Get("whois_guard_expires"))
+}
+
+// TestDataSourceDomainRead_ExpiredFallback covers is_expired when the domain is
+// absent from the portfolio listing, so the listing's own flag is unavailable
+// and the value is derived from getInfo's expiry date and status.
+func TestDataSourceDomainRead_ExpiredFallback(t *testing.T) {
+	const domain = "example.com"
+	cases := []struct {
+		name    string
+		info    dsGetInfo
+		days    int // expected sign of expires_in_days; 0 skips the check
+		expired bool
+	}{
+		{
+			name:    "past expiry date",
+			info:    dsGetInfo{Domain: domain, Status: "Ok", Created: "01/01/2019", Expires: "01/01/2020", ProviderType: "NAMECHEAP", IsOurDNS: true},
+			days:    -1,
+			expired: true,
+		},
+		{
+			name: "status Expired with future date",
+			info: dsGetInfo{Domain: domain, Status: "Expired", Created: "06/02/2021", Expires: "06/02/2099", ProviderType: "NAMECHEAP", IsOurDNS: true},
+			days: 1,
+			// The status verdict wins even though the date has not passed yet.
+			expired: true,
+		},
+		{
+			name:    "status Expired without dates",
+			info:    dsGetInfo{Domain: domain, Status: "Expired", ProviderType: "NAMECHEAP", IsOurDNS: true},
+			expired: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := startDataSourceServer(t, func(command string, _ *http.Request) string {
+				switch command {
+				case "namecheap.domains.getInfo":
+					return xmlGetInfo(tc.info)
+				case "namecheap.domains.getList":
+					// Portfolio miss: the listing cannot supply IsExpired.
+					return xmlGetListPage(nil, 0, 1, domainsPageSize)
+				}
+				return apiErrorXML("1010101", "unexpected command "+command)
+			})
+
+			d := schema.TestResourceDataRaw(t, dataSourceNamecheapDomain().Schema, map[string]interface{}{"domain": domain})
+			diags := dataSourceNamecheapDomainRead(context.Background(), d, client)
+			require.False(t, diags.HasError(), "unexpected diagnostics: %+v", diags)
+			assert.Equal(t, tc.expired, d.Get("is_expired"))
+			if tc.days < 0 {
+				assert.Less(t, d.Get("expires_in_days").(int), 0)
+			} else if tc.days > 0 {
+				assert.Greater(t, d.Get("expires_in_days").(int), 0)
+			}
+		})
+	}
 }
 
 func TestDataSourceDomainRead_GetListError(t *testing.T) {

--- a/namecheap/data_source_read_test.go
+++ b/namecheap/data_source_read_test.go
@@ -54,23 +54,113 @@ func startDataSourceServer(t *testing.T, handler func(command string, r *http.Re
 
 // --- XML builders (mirror the real API envelopes the SDK parses) ------------
 
-func xmlGetInfo(domain string, isPremium, isPremiumDNS bool, providerType string, isOurDNS bool, nameservers []string) string {
-	var ns []string
-	for _, n := range nameservers {
-		ns = append(ns, fmt.Sprintf(`<Nameserver>%s</Nameserver>`, n))
+// dsGetInfo drives xmlGetInfo, mirroring the real getInfo response shape (SDK
+// v2.10.1 maps the full subtree). Zero-valued optional fields omit their XML.
+type dsGetInfo struct {
+	Domain        string
+	Status        string // "" omits the Status attribute (the sandbox omits it too)
+	OwnerName     string
+	IsOwner       bool
+	IsPremium     bool
+	Created       string // MM/DD/YYYY; "" omits the element
+	Expires       string // MM/DD/YYYY; "" omits the element
+	WhoisEnabled  string // "" omits the whole Whoisguard element
+	WhoisExpires  string // MM/DD/YYYY
+	WhoisEmail    string
+	ForwardedTo   string
+	PremiumDNS    bool // IsActive; false also renders the -1 sentinel subscription
+	SubscriptionID int
+	PremiumDNSAutoRenew bool
+	PremiumDNSExpires   string
+	ProviderType  string
+	IsOurDNS      bool
+	EmailType     string
+	HostCount     int
+	Nameservers   []string
+	RightsAll     string // "" renders <Modificationrights />; "true"/"false" sets the attr
+	Rights        [][2]string
+}
+
+func xmlGetInfo(g dsGetInfo) string {
+	var b strings.Builder
+
+	statusAttr := ""
+	if g.Status != "" {
+		statusAttr = fmt.Sprintf(` Status="%s"`, g.Status)
 	}
-	return fmt.Sprintf(`<?xml version="1.0" encoding="utf-8"?>
+	fmt.Fprintf(&b, `<?xml version="1.0" encoding="utf-8"?>
 <ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
   <Errors />
   <CommandResponse Type="namecheap.domains.getInfo">
-    <DomainGetInfoResult DomainName="%s" IsPremium="%t">
-      <PremiumDnsSubscription><IsActive>%t</IsActive></PremiumDnsSubscription>
-      <DnsDetails ProviderType="%s" IsUsingOurDNS="%t">
+    <DomainGetInfoResult%s ID="1706717" DomainName="%s" OwnerName="%s" IsOwner="%t" IsPremium="%t">
+      <DomainDetails>`, statusAttr, g.Domain, g.OwnerName, g.IsOwner, g.IsPremium)
+	if g.Created != "" {
+		fmt.Fprintf(&b, `<CreatedDate>%s</CreatedDate>`, g.Created)
+	}
+	if g.Expires != "" {
+		fmt.Fprintf(&b, `<ExpiredDate>%s</ExpiredDate>`, g.Expires)
+	}
+	b.WriteString(`<NumYears>1</NumYears></DomainDetails>
+      <LockDetails />`)
+
+	if g.WhoisEnabled != "" {
+		fmt.Fprintf(&b, `
+      <Whoisguard Enabled="%s"><ID>53536</ID>`, g.WhoisEnabled)
+		if g.WhoisExpires != "" {
+			fmt.Fprintf(&b, `<ExpiredDate>%s</ExpiredDate>`, g.WhoisExpires)
+		}
+		if g.WhoisEmail != "" || g.ForwardedTo != "" {
+			fmt.Fprintf(&b, `<EmailDetails WhoisGuardEmail="%s" ForwardedTo="%s" LastAutoEmailChangeDate="" AutoEmailChangeFrequencyDays="0" />`, g.WhoisEmail, g.ForwardedTo)
+		}
+		b.WriteString(`</Whoisguard>`)
+	}
+
+	subID := g.SubscriptionID
+	if subID == 0 {
+		subID = -1
+	}
+	fmt.Fprintf(&b, `
+      <PremiumDnsSubscription><UseAutoRenew>%t</UseAutoRenew><SubscriptionId>%d</SubscriptionId><CreatedDate>0001-01-01T00:00:00</CreatedDate><ExpirationDate>%s</ExpirationDate><IsActive>%t</IsActive></PremiumDnsSubscription>`,
+		g.PremiumDNSAutoRenew, subID, orDefault(g.PremiumDNSExpires, "0001-01-01T00:00:00"), g.PremiumDNS)
+
+	var ns []string
+	for _, n := range g.Nameservers {
+		ns = append(ns, fmt.Sprintf(`<Nameserver>%s</Nameserver>`, n))
+	}
+	fmt.Fprintf(&b, `
+      <DnsDetails ProviderType="%s" IsUsingOurDNS="%t" HostCount="%d" EmailType="%s" DynamicDNSStatus="false" IsFailover="false">
         %s
-      </DnsDetails>
+      </DnsDetails>`, g.ProviderType, g.IsOurDNS, g.HostCount, orDefault(g.EmailType, "No Email Service"), strings.Join(ns, "\n        "))
+
+	if g.RightsAll == "" && len(g.Rights) == 0 {
+		b.WriteString(`
+      <Modificationrights />`)
+	} else {
+		attr := ""
+		if g.RightsAll != "" {
+			attr = fmt.Sprintf(` All="%s"`, g.RightsAll)
+		}
+		fmt.Fprintf(&b, `
+      <Modificationrights%s>`, attr)
+		for _, r := range g.Rights {
+			fmt.Fprintf(&b, `<Rights Type="%s">%s</Rights>`, r[0], r[1])
+		}
+		b.WriteString(`</Modificationrights>`)
+	}
+
+	b.WriteString(`
     </DomainGetInfoResult>
   </CommandResponse>
-</ApiResponse>`, domain, isPremium, isPremiumDNS, providerType, isOurDNS, strings.Join(ns, "\n        "))
+</ApiResponse>`)
+	return b.String()
+}
+
+// orDefault returns s, or def when s is empty.
+func orDefault(s, def string) string {
+	if s == "" {
+		return def
+	}
+	return s
 }
 
 // dsDomainRow is a single portfolio row for building a getList response.
@@ -148,10 +238,22 @@ func TestDataSourceDomainRead_Success(t *testing.T) {
 	client := startDataSourceServer(t, func(command string, _ *http.Request) string {
 		switch command {
 		case "namecheap.domains.getInfo":
-			return xmlGetInfo(domain, true, true, "CUSTOM", false, []string{"ns1.example.net", "ns2.example.net"})
+			return xmlGetInfo(dsGetInfo{
+				Domain: domain, Status: "Ok", OwnerName: "apiuser", IsOwner: true, IsPremium: true,
+				Created: "06/02/2021", Expires: "06/02/2099",
+				WhoisEnabled: "True", WhoisExpires: "06/02/2027",
+				WhoisEmail: "guard@whoisguard.example", ForwardedTo: "real@example.com",
+				PremiumDNS: true, SubscriptionID: 4756, PremiumDNSAutoRenew: true, PremiumDNSExpires: "2027-06-02T00:00:00",
+				ProviderType: "CUSTOM", IsOurDNS: false, EmailType: "FWD", HostCount: 2,
+				Nameservers: []string{"ns1.example.net", "ns2.example.net"},
+				RightsAll:   "false", Rights: [][2]string{{"dns", "OK"}, {"rlock", "OK"}},
+			})
 		case "namecheap.domains.getList":
+			// Deliberately different dates and whois state than getInfo: the
+			// assertions below prove getInfo is now the source for those fields
+			// and the listing supplies only is_locked/auto_renew.
 			return xmlGetListPage([]dsDomainRow{
-				{ID: "42", Name: domain, User: "u", Created: "06/02/2021", Expires: "06/02/2099", WhoisGuard: "ENABLED", IsLocked: true, AutoRenew: true, IsOurDNS: true},
+				{ID: "42", Name: domain, User: "u", Created: "01/01/2000", Expires: "01/01/2001", WhoisGuard: "DISABLED", IsLocked: true, AutoRenew: true, IsOurDNS: true},
 			}, 1, 1, domainsPageSize)
 		}
 		return apiErrorXML("1010101", "unexpected command "+command)
@@ -167,14 +269,31 @@ func TestDataSourceDomainRead_Success(t *testing.T) {
 	assert.Equal(t, true, d.Get("is_premium"))
 	assert.Equal(t, true, d.Get("is_premium_dns"))
 	assert.Equal(t, []interface{}{"ns1.example.net", "ns2.example.net"}, d.Get("nameservers"))
-	// getList-sourced lifecycle fields (the gap this change closes).
+	// Lifecycle fields now sourced from getInfo, not the listing (the listing
+	// row above carries different values on purpose).
 	assert.Equal(t, "2099-06-02T00:00:00Z", d.Get("expires"))
 	assert.Equal(t, "2021-06-02T00:00:00Z", d.Get("created"))
-	assert.Equal(t, true, d.Get("is_locked"))
-	assert.Equal(t, true, d.Get("auto_renew"))
-	assert.Equal(t, "ENABLED", d.Get("whois_guard"))
+	assert.Equal(t, "ENABLED", d.Get("whois_guard"), "True from getInfo must map onto the documented vocabulary")
 	assert.Equal(t, false, d.Get("is_expired"))
 	assert.Greater(t, d.Get("expires_in_days").(int), 0)
+	// Listing-sourced booleans.
+	assert.Equal(t, true, d.Get("is_locked"))
+	assert.Equal(t, true, d.Get("auto_renew"))
+	// New getInfo attributes.
+	assert.Equal(t, "Ok", d.Get("status"))
+	assert.Equal(t, "apiuser", d.Get("owner_name"))
+	assert.Equal(t, true, d.Get("is_owner"))
+	assert.Equal(t, "2027-06-02T00:00:00Z", d.Get("whois_guard_expires"))
+	assert.Equal(t, "guard@whoisguard.example", d.Get("whois_guard_email"))
+	assert.Equal(t, "real@example.com", d.Get("whois_guard_forwarded_to"))
+	assert.Equal(t, true, d.Get("premium_dns_auto_renew"))
+	assert.Equal(t, "2027-06-02T00:00:00", d.Get("premium_dns_expires"))
+	assert.Equal(t, "FWD", d.Get("email_type"))
+	assert.Equal(t, 2, d.Get("host_count"))
+	assert.Equal(t, false, d.Get("dynamic_dns_status"))
+	assert.Equal(t, false, d.Get("is_failover"))
+	assert.Equal(t, false, d.Get("modification_rights_all"))
+	assert.Equal(t, map[string]interface{}{"dns": "OK", "rlock": "OK"}, d.Get("modification_rights"))
 	assert.Equal(t, domain, d.Id())
 }
 
@@ -193,12 +312,19 @@ func TestDataSourceDomainRead_NotFound(t *testing.T) {
 func TestDataSourceDomainRead_LifecycleMissing(t *testing.T) {
 	const domain = "example.com"
 	// getInfo confirms the domain exists, but the portfolio listing returns a
-	// different domain, so the exact-match finds nothing: lifecycle fields stay
-	// at their zero values and the read still succeeds.
+	// different domain, so the exact-match finds nothing: the listing-sourced
+	// booleans stay at their zero values (with a warning) while every
+	// getInfo-sourced field is still populated, and the read succeeds.
 	client := startDataSourceServer(t, func(command string, _ *http.Request) string {
 		switch command {
 		case "namecheap.domains.getInfo":
-			return xmlGetInfo(domain, false, false, "NAMECHEAP", true, []string{"dns1.registrar-servers.com"})
+			return xmlGetInfo(dsGetInfo{
+				Domain: domain, OwnerName: "apiuser",
+				Created: "06/02/2021", Expires: "06/02/2099",
+				WhoisEnabled: "NotAlloted",
+				ProviderType: "NAMECHEAP", IsOurDNS: true,
+				Nameservers: []string{"dns1.registrar-servers.com"},
+			})
 		case "namecheap.domains.getList":
 			return xmlGetListPage([]dsDomainRow{
 				{ID: "7", Name: "other-domain.com", User: "u", Created: "01/01/2020", Expires: "01/01/2030"},
@@ -211,8 +337,12 @@ func TestDataSourceDomainRead_LifecycleMissing(t *testing.T) {
 	diags := dataSourceNamecheapDomainRead(context.Background(), d, client)
 	require.False(t, diags.HasError(), "unexpected diagnostics: %+v", diags)
 	assert.Equal(t, "NAMECHEAP", d.Get("dns_provider_type"))
-	assert.Equal(t, "", d.Get("expires"), "lifecycle field should be empty when the domain is absent from the listing")
-	assert.Equal(t, "", d.Get("whois_guard"))
+	// getInfo-sourced fields survive a portfolio miss.
+	assert.Equal(t, "2099-06-02T00:00:00Z", d.Get("expires"))
+	assert.Equal(t, "NOTPRESENT", d.Get("whois_guard"), "NotAlloted from getInfo must map onto the documented vocabulary")
+	// Only the listing-sourced booleans degrade to zero values.
+	assert.Equal(t, false, d.Get("is_locked"))
+	assert.Equal(t, false, d.Get("auto_renew"))
 }
 
 func TestDataSourceDomainRead_GetListError(t *testing.T) {
@@ -220,7 +350,7 @@ func TestDataSourceDomainRead_GetListError(t *testing.T) {
 	client := startDataSourceServer(t, func(command string, _ *http.Request) string {
 		switch command {
 		case "namecheap.domains.getInfo":
-			return xmlGetInfo(domain, false, false, "NAMECHEAP", true, nil)
+			return xmlGetInfo(dsGetInfo{Domain: domain, ProviderType: "NAMECHEAP", IsOurDNS: true})
 		case "namecheap.domains.getList":
 			return apiErrorXML("4022336", "portfolio listing failed")
 		}

--- a/namecheap/mock_data_source_test.go
+++ b/namecheap/mock_data_source_test.go
@@ -13,9 +13,9 @@ import (
 
 // TestAccMockDataSourceDomain reads a single domain via namecheap_domain against
 // the stateful mock and asserts the exported attributes. It exercises the
-// two-call design end-to-end: the DNS-oriented fields come from
-// namecheap.domains.getInfo and the lifecycle fields (created/expires/is_locked/
-// auto_renew/whois_guard/is_expired) come from namecheap.domains.getList.
+// two-call design end-to-end: getInfo supplies almost everything (DNS fields,
+// dates, whois_guard), while namecheap.domains.getList supplies only the two
+// booleans getInfo lacks (is_locked/auto_renew).
 func TestAccMockDataSourceDomain(t *testing.T) {
 	m := newNamecheapMock(t)
 	const domain = "info-example.com"
@@ -25,10 +25,15 @@ func TestAccMockDataSourceDomain(t *testing.T) {
 		ProviderType:  "CUSTOM",
 		IsUsingOurDNS: false,
 		Nameservers:   []string{"ns1.example.net", "ns2.example.net"},
+		Created:       "06/02/2021",
+		Expires:       "06/02/2099",
+		WhoisGuard:    "True", // getInfo vocabulary; must surface as ENABLED
 	})
-	// Seed the portfolio listing so the getList-sourced lifecycle fields resolve.
+	// Seed the portfolio listing for the two getList-sourced booleans. Its
+	// dates/whois state differ from getInfo's on purpose: the checks below
+	// prove getInfo is the source for those attributes now.
 	m.seedPortfolio(0,
-		mockPortfolioDomain{ID: "10", Name: domain, User: "mock-user", Created: "06/02/2021", Expires: "06/02/2099", WhoisGuard: "ENABLED", IsExpired: false, IsLocked: true, AutoRenew: true, IsPremium: true, IsOurDNS: false},
+		mockPortfolioDomain{ID: "10", Name: domain, User: "mock-user", Created: "01/01/2000", Expires: "01/01/2001", WhoisGuard: "DISABLED", IsExpired: false, IsLocked: true, AutoRenew: true, IsPremium: true, IsOurDNS: false},
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -50,13 +55,15 @@ data "namecheap_domain" "test" {
 					resource.TestCheckResourceAttr("data.namecheap_domain.test", "nameservers.#", "2"),
 					resource.TestCheckResourceAttr("data.namecheap_domain.test", "nameservers.0", "ns1.example.net"),
 					resource.TestCheckResourceAttr("data.namecheap_domain.test", "nameservers.1", "ns2.example.net"),
-					// getList-sourced lifecycle fields.
+					// getInfo-sourced lifecycle fields (the seeded portfolio row
+					// carries different values, proving the source).
 					resource.TestCheckResourceAttr("data.namecheap_domain.test", "created", "2021-06-02T00:00:00Z"),
 					resource.TestCheckResourceAttr("data.namecheap_domain.test", "expires", "2099-06-02T00:00:00Z"),
 					resource.TestCheckResourceAttr("data.namecheap_domain.test", "is_expired", "false"),
+					resource.TestCheckResourceAttr("data.namecheap_domain.test", "whois_guard", "ENABLED"),
+					// getList-sourced booleans (the only listing-dependent fields).
 					resource.TestCheckResourceAttr("data.namecheap_domain.test", "is_locked", "true"),
 					resource.TestCheckResourceAttr("data.namecheap_domain.test", "auto_renew", "true"),
-					resource.TestCheckResourceAttr("data.namecheap_domain.test", "whois_guard", "ENABLED"),
 				),
 			},
 		},

--- a/namecheap/mock_data_source_test.go
+++ b/namecheap/mock_data_source_test.go
@@ -14,8 +14,8 @@ import (
 // TestAccMockDataSourceDomain reads a single domain via namecheap_domain against
 // the stateful mock and asserts the exported attributes. It exercises the
 // two-call design end-to-end: getInfo supplies almost everything (DNS fields,
-// dates, whois_guard), while namecheap.domains.getList supplies only the two
-// booleans getInfo lacks (is_locked/auto_renew).
+// dates, whois_guard), while namecheap.domains.getList supplies the two booleans
+// getInfo lacks (is_locked/auto_renew) plus the authoritative is_expired flag.
 func TestAccMockDataSourceDomain(t *testing.T) {
 	m := newNamecheapMock(t)
 	const domain = "info-example.com"
@@ -29,11 +29,13 @@ func TestAccMockDataSourceDomain(t *testing.T) {
 		Expires:       "06/02/2099",
 		WhoisGuard:    "True", // getInfo vocabulary; must surface as ENABLED
 	})
-	// Seed the portfolio listing for the two getList-sourced booleans. Its
-	// dates/whois state differ from getInfo's on purpose: the checks below
-	// prove getInfo is the source for those attributes now.
+	// Seed the portfolio listing for the getList-sourced fields. Its dates and
+	// whois state differ from getInfo's on purpose: the checks below prove
+	// getInfo is the source for those attributes now. IsExpired=true contradicts
+	// getInfo's 2099 expiry so the check proves the listing's own flag wins over
+	// the date-derived fallback.
 	m.seedPortfolio(0,
-		mockPortfolioDomain{ID: "10", Name: domain, User: "mock-user", Created: "01/01/2000", Expires: "01/01/2001", WhoisGuard: "DISABLED", IsExpired: false, IsLocked: true, AutoRenew: true, IsPremium: true, IsOurDNS: false},
+		mockPortfolioDomain{ID: "10", Name: domain, User: "mock-user", Created: "01/01/2000", Expires: "01/01/2001", WhoisGuard: "DISABLED", IsExpired: true, IsLocked: true, AutoRenew: true, IsPremium: true, IsOurDNS: false},
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -59,9 +61,10 @@ data "namecheap_domain" "test" {
 					// carries different values, proving the source).
 					resource.TestCheckResourceAttr("data.namecheap_domain.test", "created", "2021-06-02T00:00:00Z"),
 					resource.TestCheckResourceAttr("data.namecheap_domain.test", "expires", "2099-06-02T00:00:00Z"),
-					resource.TestCheckResourceAttr("data.namecheap_domain.test", "is_expired", "false"),
 					resource.TestCheckResourceAttr("data.namecheap_domain.test", "whois_guard", "ENABLED"),
-					// getList-sourced booleans (the only listing-dependent fields).
+					// getList-sourced fields (the only listing-dependent ones).
+					// is_expired is the listing's flag, not the derived fallback.
+					resource.TestCheckResourceAttr("data.namecheap_domain.test", "is_expired", "true"),
 					resource.TestCheckResourceAttr("data.namecheap_domain.test", "is_locked", "true"),
 					resource.TestCheckResourceAttr("data.namecheap_domain.test", "auto_renew", "true"),
 				),

--- a/namecheap/mock_server_test.go
+++ b/namecheap/mock_server_test.go
@@ -136,6 +136,13 @@ type mockDomainInfo struct {
 	ProviderType  string
 	IsUsingOurDNS bool
 	Nameservers   []string
+	// Full getInfo response fields (SDK v2.10.1 maps the whole subtree).
+	// Created/Expires are MM/DD/YYYY; empty strings omit the elements.
+	Created string
+	Expires string
+	// WhoisGuard uses getInfo's vocabulary: "True", "False" or "NotAlloted".
+	// Empty omits the Whoisguard element entirely.
+	WhoisGuard string
 }
 
 // newNamecheapMock starts a stateful mock server and registers its shutdown
@@ -621,20 +628,37 @@ func (m *namecheapMock) renderGetInfoXML(domain string) string {
 		nsLines = append(nsLines, fmt.Sprintf(`<Nameserver>%s</Nameserver>`, ns))
 	}
 
+	var details string
+	if info.Created != "" {
+		details += fmt.Sprintf(`<CreatedDate>%s</CreatedDate>`, info.Created)
+	}
+	if info.Expires != "" {
+		details += fmt.Sprintf(`<ExpiredDate>%s</ExpiredDate>`, info.Expires)
+	}
+
+	whois := ""
+	if info.WhoisGuard != "" {
+		whois = fmt.Sprintf(`<Whoisguard Enabled="%s"><ID>1</ID></Whoisguard>`, info.WhoisGuard)
+	}
+
 	return fmt.Sprintf(`<?xml version="1.0" encoding="utf-8"?>
 <ApiResponse Status="OK" xmlns="http://api.namecheap.com/xml.response">
   <Errors />
   <CommandResponse Type="namecheap.domains.getInfo">
     <DomainGetInfoResult DomainName="%s" IsPremium="%t">
+      <DomainDetails>%s</DomainDetails>
+      <LockDetails />
+      %s
       <PremiumDnsSubscription>
         <IsActive>%t</IsActive>
       </PremiumDnsSubscription>
       <DnsDetails ProviderType="%s" IsUsingOurDNS="%t">
         %s
       </DnsDetails>
+      <Modificationrights />
     </DomainGetInfoResult>
   </CommandResponse>
-</ApiResponse>`, domain, info.IsPremium, info.IsPremiumDNS, info.ProviderType, info.IsUsingOurDNS, strings.Join(nsLines, "\n        "))
+</ApiResponse>`, domain, info.IsPremium, details, whois, info.IsPremiumDNS, info.ProviderType, info.IsUsingOurDNS, strings.Join(nsLines, "\n        "))
 }
 
 // renderGetBalancesXML renders the account funds for namecheap.users.getBalances.

--- a/templates/data-sources/domain.md.tmpl
+++ b/templates/data-sources/domain.md.tmpl
@@ -13,7 +13,7 @@ For example, the {{ .SchemaMarkdown }} template can be used to replace manual sc
 
 Looks up read-only information about a single domain. Use it to reference an existing (non-Terraform-managed) domain's DNS provider, nameservers or expiry in other resources, or to gate logic on domain properties (is it expiring? locked? which DNS type is active?).
 
-~> This data source performs **two** Namecheap API calls per read: `namecheap.domains.getInfo` supplies the DNS-oriented fields (`dns_provider_type`, `is_our_dns`, `is_premium`, `is_premium_dns`, `nameservers`), and `namecheap.domains.getList` supplies the lifecycle fields (`created`, `expires`, `is_expired`, `is_locked`, `auto_renew`, `whois_guard`) that `getInfo` does not return. If you only need lifecycle data for many domains at once, prefer the [`namecheap_domains`](domains.md) portfolio data source, which returns all of it in one paginated listing.
+~> This data source performs **two** Namecheap API calls per read: `namecheap.domains.getInfo` supplies almost everything (DNS details, dates, privacy, ownership, modification rights), and `namecheap.domains.getList` supplies only the two booleans `getInfo` does not return (`is_locked`, `auto_renew`). If you only need lifecycle data for many domains at once, prefer the [`namecheap_domains`](domains.md) portfolio data source, which returns all of it in one paginated listing.
 
 ## Example Usage
 
@@ -37,3 +37,17 @@ Looks up read-only information about a single domain. Use it to reference an exi
 - `is_locked` - Whether the registrar lock is enabled.
 - `auto_renew` - Whether auto-renew is enabled.
 - `whois_guard` - WhoisGuard status (e.g. `ENABLED`, `DISABLED`, `NOTPRESENT`).
+- `whois_guard_expires` - Expiration date of the domain privacy protection as an RFC3339 timestamp (UTC); empty when privacy is not allotted.
+- `whois_guard_email` - The generated privacy-protection email address on the Whois record.
+- `whois_guard_forwarded_to` - The real address the privacy-protection email forwards to.
+- `status` - Domain status as reported by the API (e.g. `Ok`, `Locked`, `Expired`); empty when the API omits it.
+- `owner_name` - The user account under which the domain is registered.
+- `is_owner` - Whether the API user is the domain owner.
+- `premium_dns_auto_renew` - Whether the PremiumDNS subscription auto-renews. This is the subscription's own flag, distinct from the domain's `auto_renew`.
+- `premium_dns_expires` - Expiration timestamp of the PremiumDNS subscription as reported by the API; empty when there is no subscription.
+- `email_type` - The email service configured for the domain (e.g. `FWD`, `MXE`, `OX`, `No Email Service`).
+- `host_count` - Number of DNS host records configured for the domain.
+- `dynamic_dns_status` - Whether dynamic DNS is enabled for the domain.
+- `is_failover` - Whether DNS failover is enabled for the domain.
+- `modification_rights_all` - Whether the API user holds all modification rights on the domain.
+- `modification_rights` - Granular per-feature modification rights (e.g. `dns`, `rlock`, `autorenew` mapped to `OK`), populated for shared/permissioned domains.

--- a/templates/data-sources/domain.md.tmpl
+++ b/templates/data-sources/domain.md.tmpl
@@ -13,7 +13,7 @@ For example, the {{ .SchemaMarkdown }} template can be used to replace manual sc
 
 Looks up read-only information about a single domain. Use it to reference an existing (non-Terraform-managed) domain's DNS provider, nameservers or expiry in other resources, or to gate logic on domain properties (is it expiring? locked? which DNS type is active?).
 
-~> This data source performs **two** Namecheap API calls per read: `namecheap.domains.getInfo` supplies almost everything (DNS details, dates, privacy, ownership, modification rights), and `namecheap.domains.getList` supplies only the two booleans `getInfo` does not return (`is_locked`, `auto_renew`). If you only need lifecycle data for many domains at once, prefer the [`namecheap_domains`](domains.md) portfolio data source, which returns all of it in one paginated listing.
+~> This data source performs **two** Namecheap API calls per read: `namecheap.domains.getInfo` supplies almost everything (DNS details, dates, privacy, ownership, modification rights), and `namecheap.domains.getList` supplies the two booleans `getInfo` does not return (`is_locked`, `auto_renew`) plus the authoritative `is_expired` flag. If you only need lifecycle data for many domains at once, prefer the [`namecheap_domains`](domains.md) portfolio data source, which returns all of it in one paginated listing.
 
 ## Example Usage
 
@@ -32,19 +32,19 @@ Looks up read-only information about a single domain. Use it to reference an exi
 - `nameservers` - The nameservers currently configured for the domain.
 - `created` - Registration date as an RFC3339 timestamp (UTC).
 - `expires` - Expiration date as an RFC3339 timestamp (UTC).
-- `expires_in_days` - Whole calendar days until the domain expires (negative if already expired). Derived from the wall clock at read time; prefer `expires` where a stable value is needed.
-- `is_expired` - Whether the domain has expired.
+- `expires_in_days` - Whole calendar days until the domain expires (negative if already expired). Derived from the wall clock at read time; prefer `expires` where a stable value is needed. `0` together with an empty `expires` means the API did not report an expiry date.
+- `is_expired` - Whether the domain has expired, as reported by the portfolio listing (this accounts for renewal grace periods). When the domain is missing from the listing, it falls back to a value derived from the expiry date and domain status.
 - `is_locked` - Whether the registrar lock is enabled.
 - `auto_renew` - Whether auto-renew is enabled.
 - `whois_guard` - WhoisGuard status (e.g. `ENABLED`, `DISABLED`, `NOTPRESENT`).
 - `whois_guard_expires` - Expiration date of the domain privacy protection as an RFC3339 timestamp (UTC); empty when privacy is not allotted.
 - `whois_guard_email` - The generated privacy-protection email address on the Whois record.
-- `whois_guard_forwarded_to` - The real address the privacy-protection email forwards to.
+- `whois_guard_forwarded_to` - The real address the privacy-protection email forwards to. Note that this address is stored in the Terraform state.
 - `status` - Domain status as reported by the API (e.g. `Ok`, `Locked`, `Expired`); empty when the API omits it.
 - `owner_name` - The user account under which the domain is registered.
 - `is_owner` - Whether the API user is the domain owner.
 - `premium_dns_auto_renew` - Whether the PremiumDNS subscription auto-renews. This is the subscription's own flag, distinct from the domain's `auto_renew`.
-- `premium_dns_expires` - Expiration timestamp of the PremiumDNS subscription as reported by the API; empty when there is no subscription.
+- `premium_dns_expires` - Expiration date of the PremiumDNS subscription as an RFC3339 timestamp (UTC); empty when there is no subscription or the API reports no expiry.
 - `email_type` - The email service configured for the domain (e.g. `FWD`, `MXE`, `OX`, `No Email Service`).
 - `host_count` - Number of DNS host records configured for the domain.
 - `dynamic_dns_status` - Whether dynamic DNS is enabled for the domain.


### PR DESCRIPTION
Implements the adoption plan from #319 (all three tiers) on top of the SDK v2.10.1 bump.

## SDK bump + required migration

- `github.com/namecheap/go-namecheap-sdk/v2` v2.10.0 → v2.10.1: full `domains.getInfo` response mapping, nil-guarded FreeDNS fallback in `DomainsDNS.GetList` (called from four places here; an SDK panic surfaced as a plugin crash), and tolerant date parsing.
- The domain data source migrates from the deprecated getInfo command-response field to the `Result()` accessor (staticcheck SA1019 fires cross-package otherwise; the accessor also survives the SDK v3 rename). The many other `DomainDNSGetListResult` occurrences in this codebase belong to the DNS-list endpoint's own correctly named field and are untouched on purpose.

## Workaround removal

`namecheap_domain` previously paged through the whole account portfolio (`domains.getList`) just for lifecycle fields getInfo did not decode. Now `created`, `expires`, `expires_in_days`, and `whois_guard` come from the single getInfo call; the listing sweep remains for `is_locked` and `auto_renew` — the two booleans getInfo genuinely does not carry — and for `is_expired`, whose listing flag stays authoritative on purpose: it accounts for renewal grace periods and keeps parity with the `namecheap_domains` data source, so existing configurations see identical values. On a portfolio miss, only the two booleans degrade to zero values (previously all seven did), while `is_expired` falls back to a value derived from getInfo's expiry date and domain status instead of a bare `false`.

`premium_dns_expires` is normalized to RFC3339 (UTC) like every other date attribute, with the API's `0001-01-01T00:00:00` never-expires sentinel rendered as an empty string.

`whois_guard` keeps its documented vocabulary: getInfo reports `True`/`False`/`NotAlloted`, mapped onto `ENABLED`/`DISABLED`/`NOTPRESENT` so existing configurations see identical values.

## New attributes on `namecheap_domain`

`status`, `owner_name`, `is_owner`, `whois_guard_expires`, `whois_guard_email`, `whois_guard_forwarded_to`, `premium_dns_auto_renew`, `premium_dns_expires`, `email_type`, `host_count`, `dynamic_dns_status`, `is_failover`, `modification_rights_all`, and the granular `modification_rights` map (per-feature rights for shared/permissioned domains — useful to gate plans before a mutation the API user is not permitted to make).

All additions are Computed-only: no state migration, no config changes required.

## Verification

- Unit tests updated: the happy-path mock now serves deliberately different dates in the listing than in getInfo, proving the source switch — including a listing `IsExpired=true` contradicting a 2099 expiry, proving the listing flag wins over date arithmetic; the portfolio-miss test asserts getInfo fields survive, only the two listing booleans degrade, `is_expired` keeps its derived fallback, and the `-1` sentinel subscription surfaces nothing; a dedicated fallback test covers past-expiry, `Status=Expired` with a future date, and `Status=Expired` with no dates; vocabulary mapping covered both ways (`True`→`ENABLED`, `NotAlloted`→`NOTPRESENT`).
- `make lint` 0 issues, `make test` green, `make docs` regenerated from the updated template.
- Mock and sandbox acceptance run in CI on this PR.

Closes #319 — the optional-attribute tier is included, so nothing remains open there.

