### PR TITLE
fix(deps): bump github.com/namecheap/go-namecheap-sdk/v2 from 2.10.1 to 2.10.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.11.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
-	github.com/namecheap/go-namecheap-sdk/v2 v2.10.1
+	github.com/namecheap/go-namecheap-sdk/v2 v2.10.2
 	github.com/stretchr/testify v1.12.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -162,8 +162,8 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
-github.com/namecheap/go-namecheap-sdk/v2 v2.10.1 h1:RlSkkhBqCcd+T5nhksaVsKwSPskam5SPLinv97e5e/Y=
-github.com/namecheap/go-namecheap-sdk/v2 v2.10.1/go.mod h1:Qlz3X1kDNHJUuDotq6Yo1xQXsxZyM/6BX1/N+zbi5OE=
+github.com/namecheap/go-namecheap-sdk/v2 v2.10.2 h1:MpF42HasIu30A3mtuEKpklZDlLXwVYzUiFZOJHhS3zw=
+github.com/namecheap/go-namecheap-sdk/v2 v2.10.2/go.mod h1:3eN88+y7YqS3Z8oxxKgnfhJ9EQzqb454wVWo7UU/qaQ=
 github.com/oklog/run v1.2.0 h1:O8x3yXwah4A73hJdlrwo/2X6J62gE5qTMusH0dvz60E=
 github.com/oklog/run v1.2.0/go.mod h1:mgDbKRSwPhJfesJ4PntqFUbKQRZ50NgmZTSPlFA0YFk=
 github.com/pjbgf/sha1cd v0.6.0 h1:3WJ8Wz8gvDz29quX1OcEmkAlUg9diU4GxJHqs0/XiwU=


### PR DESCRIPTION
## Summary

Bumps the internal SDK to [v2.10.2](https://github.com/namecheap/go-namecheap-sdk/releases/tag/v2.10.2) (released today), which contains two fixes:

- expose `DomainDetails` on the `domains.renew` result and accept non-padded API dates (namecheap/go-namecheap-sdk#177)
- internal testify bump to 1.12.0 (namecheap/go-namecheap-sdk#175)

No other `go.mod` pins have newer versions available after the full sweep in #325 — this is a single-module bump (`go.mod`/`go.sum` only, 3 lines).

## Verification

- `make build`, `make format`, `make check` — clean
- `make lint` — 0 issues
- `make test` — all unit tests pass
- `make testacc-mock` — full mock acceptance suite passes
- Go toolchain pin unchanged; `go mod tidy` leaves no drift