### PR TITLE
ci: drop ec2 runner warm-pool reuse in favor of terminate-per-run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -585,6 +585,33 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
+      - name: Wait for the sandbox EIP to be free
+        # stop-runner's terminate is fire-and-forget, and the workflow queue
+        # above only waits for the older RUN to finish -- not for its
+        # instance to reach `terminated`, which is when AWS auto-releases
+        # the EIP. A back-to-back run can therefore arrive here while the
+        # previous instance is still shutting down with the EIP attached.
+        # The action's own AssociateAddress does not set AllowReassociation
+        # and swallows the failure with a warning, so the run would only
+        # fail later (and less obviously) at acceptance_test's "Verify
+        # sandbox EIP" gate. Poll here instead: a single read-only
+        # DescribeAddresses call when the EIP is already free (the common
+        # case), a short wait only under genuine back-to-back contention.
+        # On timeout, proceed anyway -- the action will warn and the verify
+        # gate still fails cleanly.
+        run: |
+          for i in $(seq 1 24); do
+            assoc="$(aws ec2 describe-addresses \
+              --allocation-ids "$SANDBOX_EIP_ALLOCATION_ID" \
+              --query 'Addresses[0].AssociationId' --output text)"
+            if [ -z "$assoc" ] || [ "$assoc" = "None" ]; then
+              echo "Sandbox EIP is free."
+              exit 0
+            fi
+            echo "Sandbox EIP still associated (${assoc}); waiting for the previous instance to finish terminating (${i}/24)..."
+            sleep 5
+          done
+          echo "::warning::Sandbox EIP still associated after 120s; proceeding — the launch will warn and the acceptance \"Verify sandbox EIP\" gate will fail cleanly if the association cannot be made."
       - name: Start EC2 runner
         id: start-ec2-runner
         uses: namecheap/ec2-github-runner@54ee3e45b519c062993c2b01eb77552fcc329b9d # v4.0.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -561,14 +561,13 @@ jobs:
       public-ip: ${{ steps.eip-ip.outputs.public-ip }}
     steps:
       - name: Wait for older acceptance runs to finish (single sandbox EIP)
-        # The acceptance pipeline uses one whitelisted Elastic IP and one
-        # warm-pool instance; two runs at once would both try to attach that
-        # EIP and start that instance, fighting over them. Queue this run (FIFO,
-        # no cancellation) behind any older in-progress CI run so only one holds
-        # the sandbox EIP at a time. The older run frees it when its stop-runner
-        # stops the pooled instance (reuse: stop, not terminate — the EIP stays
-        # attached to the stopped instance); this run's "Pre-attach sandbox EIP"
-        # step then re-attaches it before start-up.
+        # The acceptance pipeline uses one whitelisted Elastic IP; two runs at
+        # once would both try to associate it. Queue this run (FIFO, no
+        # cancellation) behind any older in-progress CI run so only one holds
+        # the sandbox EIP at a time. The older run frees it when its
+        # stop-runner terminates the instance (termination auto-disassociates
+        # the EIP back to the account); this run's launch then associates it
+        # via eip-allocation-id.
         uses: ahmadnassri/action-workflow-queue@542658b3a8270cac81ae15d401b0d974732808ac # v1.2.0
         with:
           timeout: 1800000 # 30 min cap for a backlog of queued acceptance runs
@@ -586,67 +585,9 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
-      - name: Pre-attach sandbox EIP to the warm-pool instance
-        # Warm-restart fix. The action associates the EIP itself only on a COLD
-        # launch (eip-allocation-id); on a warm restart it just StartInstances
-        # the pooled instance and assumes the EIP is still attached -- but it
-        # can drift off while the instance sits stopped, landing the runner on a
-        # non-whitelisted auto-assigned IP. Associating AFTER mode:start is not
-        # an option: it changes the public IP of an already-registered runner
-        # and severs its connection to GitHub (the job then hangs). So attach
-        # the EIP to the stopped pool instance HERE, before the action starts
-        # it, so it boots with the whitelisted IP and registers on it.
-        #
-        # The filter also matches `stopping` (unlike the action's own
-        # findStoppedPoolInstance, which matches `stopped` only): the previous
-        # run's stop-runner can return while its instance is still stopping,
-        # and a run queued right behind it would then see an "empty" pool and
-        # cold-launch a duplicate that nothing drains until the nightly pass
-        # (observed 2026-07-10: stop at 08:45:51, next run's lookup at
-        # 08:46:04 -> pool_empty -> second instance all day). When the chosen
-        # instance is still stopping, wait for it to finish stopping so the
-        # action's own lookup finds it. ec2-github-runner#69 fixes the same
-        # race action-side (mode:stop waits for `stopped`); this is the
-        # consumer-side belt to that suspender, and it also covers older
-        # action pins. No match => cold launch, where eip-allocation-id
-        # handles association.
-        env:
-          POOL_TAG: sandbox-acceptance
-          INSTANCE_TYPE: t3.medium
-        run: |
-          pairs="$(aws ec2 describe-instances \
-            --filters "Name=tag:ec2-github-runner:managed,Values=true" \
-                      "Name=tag:ec2-github-runner:repository,Values=${GITHUB_REPOSITORY}" \
-                      "Name=tag:ec2-github-runner:pool,Values=${POOL_TAG}" \
-                      "Name=instance-state-name,Values=stopped,stopping" \
-                      "Name=instance-type,Values=${INSTANCE_TYPE}" \
-            --query 'Reservations[].Instances[].[InstanceId,State.Name]' --output text)"
-          count="$(printf '%s' "$pairs" | grep -c . || true)"
-          if [ "$count" = "0" ]; then
-            echo "No stopped or stopping warm-pool instance; cold launch will associate the EIP via eip-allocation-id."
-            exit 0
-          fi
-          if [ "$count" != "1" ]; then
-            echo "::warning::Found ${count} warm-pool instances ($(printf '%s' "$pairs" | tr '\n\t' ' :')); the reaper is not draining them. Pre-attaching to the first reusable one; the acceptance \"Verify sandbox EIP\" gate will fail cleanly if the action reuses a different one."
-          fi
-          # Prefer an already-stopped instance (no wait); otherwise take the
-          # stopping one and wait out its transition.
-          target="$(printf '%s\n' "$pairs" | awk '$2 == "stopped" { print $1; exit }')"
-          if [ -z "$target" ]; then
-            target="$(printf '%s\n' "$pairs" | awk '$2 == "stopping" { print $1; exit }')"
-            echo "Warm-pool instance ${target} is still stopping; waiting for it to reach stopped."
-            if ! aws ec2 wait instance-stopped --instance-ids "$target"; then
-              echo "::warning::Instance ${target} did not reach stopped in time; falling back to a cold launch (eip-allocation-id associates the EIP there). The stuck instance is left for the reaper."
-              exit 0
-            fi
-          fi
-          aws ec2 associate-address \
-            --allocation-id "$SANDBOX_EIP_ALLOCATION_ID" \
-            --instance-id "$target" --allow-reassociation >/dev/null
-          echo "Pre-attached ${SANDBOX_EIP_ALLOCATION_ID} to stopped warm-pool instance ${target}."
       - name: Start EC2 runner
         id: start-ec2-runner
-        uses: namecheap/ec2-github-runner@54ee3e45b519c062993c2b01eb77552fcc329b9d # v4.0.2 @ 2026-07-10: warm-pool reuse:stop reliability fixes (#67/#68/#69)
+        uses: namecheap/ec2-github-runner@54ee3e45b519c062993c2b01eb77552fcc329b9d # v4.0.2
         with:
           mode: start
           github-token: ${{ steps.app-token.outputs.token }}
@@ -658,32 +599,25 @@ jobs:
           ec2-instance-type: t3.medium
           subnet-id: subnet-01c4ff5a
           security-group-id: sg-106ec76d
-          reuse: stop
-          reuse-pool-tag: sandbox-acceptance
           iam-role-name: AmazonSSMRoleForInstancesQuickSetup
           # SSE-EBS on the runner's root volume. Uses the launch
           # account's default aws/ebs KMS key; AMI snapshot-id is
           # dropped so AWS re-encrypts at launch time.
           encrypt-ebs: "true"
-          # Runs once, as root, on the cold-launch bootstrap only (not on
-          # every warm restart) -- but /opt/ci persists across stop/start on
-          # the same root volume, so a one-time chown here is all the
-          # unprivileged `runner` user needs to create JOB_HOME under it for
-          # every subsequent job. Without this, scripts/hygiene-sweep.sh's
-          # `mkdir -p /opt/ci/jobs/current` fails outright: /opt is root-owned
-          # 755, and the actions-runner process (and everything run.sh spawns)
-          # runs as the unprivileged `runner` user, which has no write access
-          # to create a new directory directly under /opt.
+          # Runs once, as root, during the launch bootstrap. Without this,
+          # scripts/hygiene-sweep.sh's `mkdir -p /opt/ci/jobs/current` fails
+          # outright: /opt is root-owned 755, and the actions-runner process
+          # (and everything run.sh spawns) runs as the unprivileged `runner`
+          # user, which has no write access to create a new directory
+          # directly under /opt.
           pre-runner-script: |
             mkdir -p /opt/ci
             chown -R runner:runner /opt/ci
           # The action associates this EIP early in its own bootstrap, which is
           # what gives the instance outbound internet connectivity while it
-          # registers the runner -- on a cold launch, and (since the EIP is left
-          # attached across stop/start) implicitly on a warm restart too. The
-          # single whitelisted sandbox EIP is also what the Namecheap sandbox
-          # API allows, so this association is load-bearing for the acceptance
-          # tests, not just for bootstrap.
+          # registers the runner. The single whitelisted sandbox EIP is also
+          # what the Namecheap sandbox API allows, so this association is
+          # load-bearing for the acceptance tests, not just for bootstrap.
           eip-allocation-id: ${{ env.SANDBOX_EIP_ALLOCATION_ID }}
           aws-resource-tags: >
             [
@@ -696,10 +630,9 @@ jobs:
         # the source of truth for the IP the Namecheap sandbox API allows) so
         # acceptance_test's credential-free "Verify sandbox EIP" gate can check
         # the runner's actual public IP against it. The EIP is already attached
-        # by this point -- via eip-allocation-id on a cold launch, or the
-        # "Pre-attach sandbox EIP" step above on a warm restart -- so this only
-        # reads and publishes; it never re-associates a running/registered
-        # instance (doing so would change its IP and sever the runner).
+        # by this point via eip-allocation-id, so this only reads and
+        # publishes; it never re-associates a running/registered instance
+        # (doing so would change its IP and sever the runner).
         run: |
           ip="$(aws ec2 describe-addresses \
             --allocation-ids "$SANDBOX_EIP_ALLOCATION_ID" \
@@ -722,7 +655,7 @@ jobs:
       # PRIMARY workspace-hygiene mechanism (git clean -ffdx before checkout).
       # Runs before our own scripts exist on disk, so it — not a custom
       # pre-checkout script — is what guarantees a clean $GITHUB_WORKSPACE at
-      # the start of every run, warm-pool reuse included.
+      # the start of every run.
       - uses: actions/checkout@v7
         with:
           clean: true
@@ -737,8 +670,8 @@ jobs:
         # terraform-plugin-testing's scratch dirs both default to $TMPDIR, and
         # without this they'd write to /tmp, which neither this sweep nor the
         # post-job sweep below ever touches -- leaving test artifacts/tfstate
-        # on the reused warm-pool disk. Nesting it under JOB_HOME means it's
-        # wiped for free by the same pre/post sweep of that path.
+        # outside the swept path. Nesting it under JOB_HOME means it's wiped
+        # for free by the same pre/post sweep of that path.
         run: |
           scripts/hygiene-sweep.sh pre /opt/ci/jobs/current
           mkdir -p /opt/ci/jobs/current/tmp
@@ -946,11 +879,9 @@ jobs:
         # "Configure AWS credentials" above doesn't skip stopping the
         # instance.
         if: always()
-        uses: namecheap/ec2-github-runner@54ee3e45b519c062993c2b01eb77552fcc329b9d # v4.0.2 @ 2026-07-10: warm-pool reuse:stop reliability fixes (#67/#68/#69)
+        uses: namecheap/ec2-github-runner@54ee3e45b519c062993c2b01eb77552fcc329b9d # v4.0.2
         with:
           mode: stop
-          reuse: stop
-          reuse-pool-tag: sandbox-acceptance
           github-token: ${{ steps.app-token.outputs.token }}
           label: ${{ needs.start-runner.outputs.label }}
           ec2-instance-id: ${{ needs.start-runner.outputs.ec2-instance-id }}

--- a/.github/workflows/cleanup-ec2-runners.yml
+++ b/.github/workflows/cleanup-ec2-runners.yml
@@ -10,7 +10,24 @@ name: Cleanup EC2 runners
 #
 # Schedule: every 30 min at :07/:37 UTC, offset from :00/:30 per GitHub's
 # documented advice on avoiding top-of-hour/half-hour scheduling congestion.
-# The action's own default thresholds apply.
+#
+# Thresholds are deliberately tighter than the action's defaults, because
+# with a single whitelisted EIP a leaked instance is an acceptance OUTAGE
+# (it holds the EIP every run needs), not just a billing leak:
+#   - reaper-stopped-max-age: 1 — nothing legitimate is ever `stopped` in
+#     terminate-per-run mode (cold launch / terminate / TTL / cleanup never
+#     call StopInstances), so any stopped instance is a legacy warm-pool
+#     leftover (parked by a pre-cutover master/branch run, EIP still
+#     attached) or an anomaly; drain it on the next tick. At the action's
+#     1440 default such an instance would block every acceptance run for up
+#     to ~24h (decideReap skips `stopped` within max-age before any runner
+#     check).
+#   - max-age-minutes: 20 — a leaked RUNNING instance (start-runner killed
+#     after launch, wedged job) is reaped within ~20 min + the 30-min cron
+#     cadence + schedule lag (worst case ~1h) instead of the default 120's
+#     ~2.5h. Safe: busy runners are never reaped, and deregistered-runner
+#     reaping has the action's 15-min grace floor protecting in-flight
+#     starts.
 #
 # workflow_dispatch lets the reaper be triggered/inspected manually, and
 # defaults to dry-run so an operator can preview behavior before relying on
@@ -63,8 +80,13 @@ jobs:
         with:
           mode: cleanup
           github-token: ${{ steps.app-token.outputs.token }}
+          # See the header comment for why both thresholds are tighter than
+          # the action's defaults (single-EIP outage math, legacy warm-pool
+          # leftovers).
+          reaper-stopped-max-age: 1
+          max-age-minutes: 20
 
       - name: Leak reaper (dry run)
         if: ${{ !(github.event_name == 'schedule' || inputs.dry_run == false) }}
         run: |
-          echo "DRY RUN: would run mode:cleanup (default thresholds)"
+          echo "DRY RUN: would run mode:cleanup reaper-stopped-max-age=1 max-age-minutes=20"

--- a/.github/workflows/cleanup-ec2-runners.yml
+++ b/.github/workflows/cleanup-ec2-runners.yml
@@ -1,51 +1,25 @@
 name: Cleanup EC2 runners
 
-# Daily lifecycle backstop for the warm-pool sandbox runner started in ci.yml
-# (see start-runner / stop-runner, `reuse: stop` + `reuse-pool-tag:
-# sandbox-acceptance`). A warm/stopped instance is never re-terminated by its
-# own TTL on subsequent warm boots (max-lifetime-minutes only arms on the
-# FIRST cold boot), so something outside ci.yml has to guarantee the pool is
-# drained at least once a day (G7) and that crashed/cancelled leftovers don't
-# linger for hours (belt-and-braces on top of ci.yml's own pre/post hygiene
-# sweeps). EIP release for the warm-pool instance now happens exclusively as
-# an automatic AWS side effect of instance termination, which only occurs
-# here, in the nightly full drain below -- the EIP (eipalloc-1796f61b, this
-# repo's dedicated whitelisted sandbox IP) stays attached to the pool instance
-# across every warm stop/start cycle in between. This workflow never touches
-# the EIP directly.
+# Lifecycle backstop for the ephemeral sandbox runner started in ci.yml (see
+# start-runner / stop-runner). Every run launches a fresh instance and
+# terminates it in stop-runner, so under normal operation there is nothing to
+# clean up; this reaper catches crashed/cancelled leftovers (a stop-runner
+# that never ran, a wedged bootstrap) so they don't bill for hours (G7). EIP
+# release happens as an automatic AWS side effect of instance termination;
+# this workflow never touches the EIP directly.
 #
-# Two passes share this one workflow:
-#   - nightly full drain (7 23 * * * UTC, i.e. right after the working day
-#     ends; :07 offset from the top of the hour per the same GitHub
-#     scheduling-congestion advice as the leak reaper below -- and observed
-#     schedule delays run to hours, so an early-off-peak slot keeps the drain
-#     landing well before the next workday starts): tiny
-#     reaper-stopped-max-age so the day's pool instance -- stopped anywhere
-#     from seconds to ~24h earlier -- is always past the threshold and gets
-#     terminated.
-#   - leak reaper (7,37 * * * * UTC, i.e. every 30 min offset from :00/:30 per
-#     GitHub's documented advice on avoiding top-of-hour/half-hour scheduling
-#     congestion): the action's own default reaper-stopped-max-age, catching
-#     crashed/cancelled leftovers without draining the warm pool mid-day.
+# Schedule: every 30 min at :07/:37 UTC, offset from :00/:30 per GitHub's
+# documented advice on avoiding top-of-hour/half-hour scheduling congestion.
+# The action's own default thresholds apply.
 #
-# workflow_dispatch lets either pass be triggered/inspected manually, and
+# workflow_dispatch lets the reaper be triggered/inspected manually, and
 # defaults to dry-run so an operator can preview behavior before relying on
-# the schedules (see the issue's verification plan).
+# the schedule.
 on:
   schedule:
-    - cron: "7 23 * * *" # nightly full drain, UTC (end of workday)
     - cron: "7,37 * * * *" # leak reaper, every 30 min, UTC
   workflow_dispatch:
     inputs:
-      mode:
-        description: >-
-          Which pass to run. Ignored on schedule-triggered runs, where the
-          pass is derived from which cron fired (see "Determine pass" below).
-        type: choice
-        options:
-          - nightly-drain
-          - leak-reap
-        default: leak-reap
       dry_run:
         description: >-
           Preview what would run without calling any live cleanup action.
@@ -78,63 +52,19 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
 
-      - name: Determine pass
-        id: pass
-        # The cron strings below must match `on.schedule` above byte-for-byte
-        # -- this is the only place cron strings are compared. A
-        # workflow_dispatch run (github.event.schedule unset) falls through
-        # to the manually-chosen mode. github.event.schedule / inputs.mode are
-        # passed in via `env:` rather than interpolated directly into the
-        # shell script, per the repo-wide "no ${{ github.event.* }} in run:"
-        # rule in SECURITY_COMPLIANCE.md (this value is never fork/attacker
-        # controlled -- it's one of this same workflow's own cron strings, or
-        # unset -- but keeping the pattern consistent costs nothing).
-        env:
-          EVENT_SCHEDULE: ${{ github.event.schedule }}
-          DISPATCH_MODE: ${{ inputs.mode }}
-        run: |
-          if [ "${EVENT_SCHEDULE}" = "7 23 * * *" ]; then
-            echo "kind=nightly-drain" >> "$GITHUB_OUTPUT"
-          elif [ "${EVENT_SCHEDULE}" = "7,37 * * * *" ]; then
-            echo "kind=leak-reap" >> "$GITHUB_OUTPUT"
-          else
-            echo "kind=${DISPATCH_MODE}" >> "$GITHUB_OUTPUT"
-          fi
-
       # Dry-run guards are written as explicit boolean expressions rather than
-      # relying on `inputs.dry_run != true` truthiness/coercion: every live
-      # step's condition is `(schedule-triggered OR dry_run explicitly false)`
-      # ANDed with the matching pass kind; every placeholder step negates only
-      # the schedule/dry_run half, keeping the same kind check, so exactly one
-      # of the two ever fires for a given pass.
-
-      - name: Nightly full drain
-        if: ${{ (github.event_name == 'schedule' || inputs.dry_run == false) && steps.pass.outputs.kind == 'nightly-drain' }}
-        # reaper-stopped-max-age is deliberately tiny (1) so the day's pool
-        # instance -- stopped anywhere from seconds to ~24h earlier -- is
-        # always older than the threshold and gets terminated.
-        uses: namecheap/ec2-github-runner@54ee3e45b519c062993c2b01eb77552fcc329b9d # v4.0.2 @ 2026-07-10: warm-pool reuse:stop reliability fixes (#67/#68/#69)
-        with:
-          mode: cleanup
-          github-token: ${{ steps.app-token.outputs.token }}
-          reaper-stopped-max-age: 1
-
-      - name: Nightly full drain (dry run)
-        if: ${{ !(github.event_name == 'schedule' || inputs.dry_run == false) && steps.pass.outputs.kind == 'nightly-drain' }}
-        run: |
-          echo "DRY RUN: would run mode:cleanup reaper-stopped-max-age=1"
+      # relying on `inputs.dry_run != true` truthiness/coercion: the live step
+      # runs when schedule-triggered OR dry_run is explicitly false; the
+      # placeholder negates exactly that, so exactly one of the two ever fires.
 
       - name: Leak reaper
-        # No reaper-stopped-max-age override here -- the action's own default
-        # threshold applies, per the issue's "default thresholds" requirement
-        # for this pass.
-        if: ${{ (github.event_name == 'schedule' || inputs.dry_run == false) && steps.pass.outputs.kind == 'leak-reap' }}
-        uses: namecheap/ec2-github-runner@54ee3e45b519c062993c2b01eb77552fcc329b9d # v4.0.2 @ 2026-07-10: warm-pool reuse:stop reliability fixes (#67/#68/#69)
+        if: ${{ github.event_name == 'schedule' || inputs.dry_run == false }}
+        uses: namecheap/ec2-github-runner@54ee3e45b519c062993c2b01eb77552fcc329b9d # v4.0.2
         with:
           mode: cleanup
           github-token: ${{ steps.app-token.outputs.token }}
 
       - name: Leak reaper (dry run)
-        if: ${{ !(github.event_name == 'schedule' || inputs.dry_run == false) && steps.pass.outputs.kind == 'leak-reap' }}
+        if: ${{ !(github.event_name == 'schedule' || inputs.dry_run == false) }}
         run: |
-          echo "DRY RUN: would run mode:cleanup (default reaper-stopped-max-age)"
+          echo "DRY RUN: would run mode:cleanup (default thresholds)"

--- a/CI.md
+++ b/CI.md
@@ -15,7 +15,7 @@ mechanics.
 | Versioning | `.github/workflows/versioning.yml` | After every CI run on `master` (`workflow_run`), manual | release-please: opens/updates the Release PR; creates the `vX.Y.Z` tag when it merges |
 | Release | `.github/workflows/release.yml` | Push of a `v*` tag | GoReleaser: builds, GPG-signs, attests and publishes binaries + release SBOM |
 | PR Title Check | `.github/workflows/pr-title.yml` | PR | Enforces Conventional Commit PR titles (they become the squash-commit subjects release-please reads) |
-| Cleanup EC2 runners | `.github/workflows/cleanup-ec2-runners.yml` | Cron (nightly drain + 30-min leak reaper), manual | Lifecycle backstop for the warm-pool sandbox runner |
+| Cleanup EC2 runners | `.github/workflows/cleanup-ec2-runners.yml` | Cron (30-min leak reaper), manual | Terminates EC2 runner instances leaked by crashed/cancelled runs |
 
 Checks that live outside these workflows: CodeQL (GitHub default setup), the
 DCO bot, and the `security/snyk (Namecheap)` integration.
@@ -96,8 +96,8 @@ condition and is **not** gated on `changes`: `always()` keeps the condition
 evaluating even when `start-runner` was skipped by the gate, and the empty
 `ec2-instance-id` output then makes it skip cleanly instead of failing or
 hanging. Conversely, whenever a runner **was** started, stop-runner still runs
-regardless of anything else in the run. The nightly
-`cleanup-ec2-runners.yml` drain is unaffected either way.
+regardless of anything else in the run. The scheduled
+`cleanup-ec2-runners.yml` leak reaper is unaffected either way.
 
 ### The CI OK job
 
@@ -124,7 +124,7 @@ its watch. It exists because:
 For every Release PR and every Release-PR merge, the gate removes: a full
 hosted-runner pass (check + docs + two security scans + summary), one
 start/stop cycle of the EC2 sandbox runner (billed instance time plus the
-cold-boot or warm-start overhead), one pass of the ~10-minute live sandbox
+boot overhead), one pass of the ~10-minute live sandbox
 suite, and one slot in the single-EIP acceptance queue. Post-merge release
 latency drops accordingly: after merging a Release PR, CI concludes in
 under a minute instead of after a full acceptance pass, so the tag and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,21 +186,19 @@ The live-API sandbox suite (`acceptance_test`, on the self-hosted EC2 runner) is
 fork PRs. So for a fork contribution, the mock suite is the acceptance signal;
 a maintainer validates against the live sandbox before merge.
 
-Since #279, the self-hosted EC2 runner behind `acceptance_test` is kept in a
-warm pool: it's stopped (not terminated) after each push and reused by the
-next one, so most pushes warm-start in seconds instead of paying the cold-boot
-tax every time. A full ~2-4 minute cold boot still happens on the first push
-after the nightly drain, or once the runner's 360-minute/20-cycle warm-reuse
-limit is hit. This is only possible because the sandbox pipeline is
-push-only and never runs fork/PR code, as above — that's what makes it safe
-for one job's disk to carry over to the next; fork PRs keep going through
-`acceptance_mock`, unchanged either way. Per-job disk (the checked-out
-workspace, `$HOME`, dotfiles) is wiped both before and after every run — only
-the Go/Terraform toolchain and build caches persist across a stop/start
-cycle. To force a clean cold boot (e.g. while debugging a toolchain issue),
-trigger [`cleanup-ec2-runners.yml`](.github/workflows/cleanup-ec2-runners.yml)
-via `workflow_dispatch` with `mode: nightly-drain`; leave `dry_run: true`
-(the default) to preview what it would do first.
+The self-hosted EC2 runner behind `acceptance_test` is launched fresh for
+every run and terminated afterwards, so each job starts from a pristine
+disk. (The #279 warm pool — stop/start reuse between runs — was removed
+under DEVOPS-22119: on this repo's baked AMI a warm restart measured no
+faster than the ~70-second cold launch, while parking the instance added a
+stop-wait to every run.) Fork PRs keep going through `acceptance_mock`,
+unchanged. Per-job disk (the checked-out workspace, `$HOME`, dotfiles) is
+still wiped both before and after every run as defense in depth. A scheduled
+leak reaper
+([`cleanup-ec2-runners.yml`](.github/workflows/cleanup-ec2-runners.yml),
+every 30 minutes; `workflow_dispatch` with `dry_run: true` by default for a
+manual preview) terminates any instance a crashed or cancelled run leaves
+behind.
 
 Definition of done for a change to provider behavior: unit tests **and** a
 mock-backed `TestAccMock*` case cover it, and both pass locally

--- a/SECURITY_COMPLIANCE.md
+++ b/SECURITY_COMPLIANCE.md
@@ -229,13 +229,22 @@ below for the lifecycle/cleanup/EIP mechanics:
     output — the exact symptom seen earlier in this PR).
 - **Leak reaper.**
   [`cleanup-ec2-runners.yml`](.github/workflows/cleanup-ec2-runners.yml) runs
-  `mode: cleanup` every 30 minutes (`7,37 * * * *` UTC, the action's default
-  thresholds) to terminate crashed/cancelled leftovers whose stop-runner
-  never ran. (The former nightly full-drain pass existed only to empty the
-  warm pool and was removed with it.) The reaper never touches the EIP
-  directly — it is released as an automatic AWS side effect of instance
-  termination. `workflow_dispatch` exposes a `dry_run` input (default
-  `true`) for safe manual runs.
+  `mode: cleanup` every 30 minutes (`7,37 * * * *` UTC) to terminate
+  leftovers whose stop-runner never ran. (The former nightly full-drain pass
+  existed only to empty the warm pool and was removed with it.) Because the
+  single whitelisted EIP makes any leaked instance an acceptance *outage*
+  rather than just a billing leak, both thresholds are set tighter than the
+  action's defaults: `reaper-stopped-max-age: 1` (nothing legitimate is ever
+  `stopped` in terminate-per-run mode, so a stopped instance — e.g. a legacy
+  warm-pool leftover parked by a pre-cutover run, EIP still attached — is
+  drained on the next tick instead of blocking every run for up to ~24h at
+  the 1440 default) and `max-age-minutes: 20` (a leaked *running* instance
+  is reaped within ~20 min + the 30-min cadence + schedule lag, worst case
+  ~1h, instead of ~2.5h at the 120 default; busy runners are never reaped
+  and the action's 15-min grace floor protects in-flight starts). The
+  reaper never touches the EIP directly — it is released as an automatic
+  AWS side effect of instance termination. `workflow_dispatch` exposes a
+  `dry_run` input (default `true`) for safe manual runs.
 - **One EIP per repo (no cross-repo mutex).** `eipalloc-1796f61b` was
   previously shared with `namecheap/mcp-server-namecheap`'s acceptance
   workflow, which could silently reassociate ("steal") it mid-run. That is

--- a/SECURITY_COMPLIANCE.md
+++ b/SECURITY_COMPLIANCE.md
@@ -203,7 +203,11 @@ below for the lifecycle/cleanup/EIP mechanics:
   `ahmadnassri/action-workflow-queue` (a single EIP can't serve two runners at
   once); there is no explicit release step anywhere — release happens as an
   automatic AWS side effect of `stop-runner` terminating the instance at the
-  end of every run (or of the leak reaper terminating a leaked one).
+  end of every run (or of the leak reaper terminating a leaked one). Because
+  that release only lands when the old instance reaches `terminated`,
+  `start-runner`'s "Wait for the sandbox EIP to be free" step polls
+  `DescribeAddresses` before launching, so a back-to-back run doesn't race
+  the previous instance's shutdown for the association.
 - **IAM prerequisite.** The CI AWS identity (`sys_github_runner_provisioner`)
   needs the full set below for the EIP + diagnostics model; an
   admin granting less will hit `UnauthorizedOperation` mid-cycle (see the

--- a/SECURITY_COMPLIANCE.md
+++ b/SECURITY_COMPLIANCE.md
@@ -126,11 +126,14 @@ before `tar -xzf` / `unzip` runs.
 
 ## Self-hosted runner supply chain
 
-The acceptance-test job runs on an EC2 instance launched by the self-hosted
-runner action. Since #279 that instance is kept warm (stopped, not
-terminated) between runs — see
-[Warm-pool lifecycle, hygiene sweeps, and the sandbox EIP](#warm-pool-lifecycle-hygiene-sweeps-and-the-sandbox-eip-279)
-below for the reuse/cleanup/EIP mechanics:
+The acceptance-test job runs on a fresh EC2 instance launched by the
+self-hosted runner action for every run and terminated by `stop-runner`
+afterwards. (The #279 warm pool — stop/start reuse between runs — was removed
+under DEVOPS-22119: on this repo's baked AMI a warm restart measured no faster
+than a cold launch, while parking the instance added a stop-wait to every
+run.) See
+[Runner lifecycle, hygiene sweeps, and the sandbox EIP](#runner-lifecycle-hygiene-sweeps-and-the-sandbox-eip)
+below for the lifecycle/cleanup/EIP mechanics:
 
 - Runner binary version is controlled via the SHA-pinned
   `namecheap/ec2-github-runner` action (currently bundles
@@ -150,47 +153,40 @@ below for the reuse/cleanup/EIP mechanics:
   (see the dedicated sandbox EIP bullet below), so this within-repo queue is
   the only serialization needed — there is no cross-repo mutex.
 
-### Warm-pool lifecycle, hygiene sweeps, and the sandbox EIP (#279)
+### Runner lifecycle, hygiene sweeps, and the sandbox EIP
 
-- **Warm pool.** `stop-runner` calls `namecheap/ec2-github-runner` with
-  `reuse: stop` and `reuse-pool-tag: sandbox-acceptance` instead of
-  terminating the instance, and `start-runner` reuses it on the next push.
-  Most pushes therefore warm-start in seconds; a cold boot (~2-4 min) only
-  happens after the nightly drain or the action's own `max-lifetime-minutes`
-  (default 360) / `reuse-max-cycles` (default 20) limits, both left at their
-  defaults. This is safe only because the sandbox pipeline is **push-only and
-  never runs fork/PR code** — warm reuse means job N+1 runs on job N's disk,
-  which the [fork-safe PR gating](#fork-safe-pull-request-ci) below makes a
-  guarantee about trusted code only, not a coincidence. The
-  `max-lifetime-minutes` TTL arms only on a cold boot and is **not** re-armed
-  by a warm restart, so it is a first-session backstop, not the real
-  daily-termination mechanism — that's the nightly drain below.
-- **Per-job hygiene sweeps.** Only the Go/Terraform toolchain
-  (`/opt/ci/toolcache`) and the Go build caches (`GOCACHE`/`GOMODCACHE` under
-  `/opt/ci/cache`) persist across a stop/start cycle. Everything else — the
-  checked-out workspace and the per-job `$HOME` at `/opt/ci/jobs/current` — is
-  wiped by `scripts/hygiene-sweep.sh` both before ("pre", which also emits a
+- **Per-run lifecycle.** `start-runner` launches a fresh instance for every
+  acceptance run and `stop-runner` terminates it afterwards (the action's
+  default `reuse: terminate`). The #279 warm pool (`reuse: stop` +
+  `reuse-pool-tag: sandbox-acceptance`) was removed under DEVOPS-22119: on
+  this repo's baked AMI a warm restart registered in the same ~70s as a cold
+  launch, while parking the instance added a 22-152s stop-wait to every run
+  and an EIP-drift failure class. A fresh disk per run also removes the
+  job-N+1-runs-on-job-N's-disk state carry-over the warm pool had to
+  document and sweep around; the sandbox pipeline remains **push-only and
+  never runs fork/PR code** (see
+  [fork-safe PR gating](#fork-safe-pull-request-ci) below). The action's
+  `max-lifetime-minutes` TTL (default 360) still arms on every launch as a
+  self-destruct backstop for instances whose stop-runner never ran.
+- **Per-job hygiene sweeps.** Defense in depth kept from the warm-pool era —
+  cheap, and self-diagnosing even on a fresh instance. The checked-out
+  workspace and the per-job `$HOME` at `/opt/ci/jobs/current` are wiped by
+  `scripts/hygiene-sweep.sh` both before ("pre", which also emits a
   `::warning::` and self-heals if it finds leftovers from a crashed or
   cancelled prior run that skipped its own cleanup) and after ("post",
-  `if: always()`, the step that actually guarantees no code, env vars, or
-  secrets remain on the stopped disk) every job. The initial workspace
-  freshness guarantee at the very start of a run instead comes from
-  `actions/checkout`'s own `clean: true`, since our script can't run before
-  the repo it lives in has been checked out.
+  `if: always()`, the step that guarantees no code, env vars, or secrets
+  remain on the disk) every job. The initial workspace freshness guarantee
+  at the very start of a run instead comes from `actions/checkout`'s own
+  `clean: true`, since our script can't run before the repo it lives in has
+  been checked out.
 - **Dedicated sandbox EIP.** The whitelisted Elastic IP
   (`eipalloc-1796f61b`) is passed to the action's `eip-allocation-id` input,
-  which associates it on every cold launch — that is what gives the instance
+  which associates it during every launch — that is what gives the instance
   connectivity during its own bootstrap (the fix for the CloudTrail-confirmed
-  cold-boot failures) and is also the IP the Namecheap sandbox API allows. The
-  action does **not** re-associate on a warm restart, and a pooled instance can
-  lose the association while it sits stopped, so `start-runner` pre-attaches the
-  EIP to the stopped pool instance *before* the action starts it (the
-  "Pre-attach sandbox EIP to the warm-pool instance" step, whose filter mirrors
-  the action's own pool selection), so the instance boots with the whitelisted
-  IP and the runner registers on it. Associating *after* `mode: start` is
-  deliberately avoided: it would change an already-registered runner's public
-  IP and sever its connection to GitHub, hanging the job. **This repository is
-  currently the
+  cold-boot failures) and is also the IP the Namecheap sandbox API allows.
+  Associating *after* `mode: start` is deliberately avoided: it would change
+  an already-registered runner's public IP and sever its connection to
+  GitHub, hanging the job. **This repository is currently the
   sole user of this allocation** — `mcp-server-namecheap`'s Acceptance (EC2)
   workflow is *disabled* pending its own dedicated EIP (#282 /
   `mcp-server-namecheap#16`, both still open), so nothing else associates the
@@ -205,49 +201,36 @@ below for the reuse/cleanup/EIP mechanics:
   really holds the whitelisted IP, which also confirms the association
   succeeded. Concurrent runs *within this repo* are still serialized by
   `ahmadnassri/action-workflow-queue` (a single EIP can't serve two runners at
-  once); there is no explicit release step anywhere — release only ever
-  happens as an automatic AWS side effect of `cleanup-ec2-runners.yml`
-  terminating the pool instance, which is normally the nightly full drain but
-  can occasionally be the leak-reaper pass instead, if the pool instance
-  happens to sit stopped past its default `reaper-stopped-max-age` before the
-  next drain runs (see below).
+  once); there is no explicit release step anywhere — release happens as an
+  automatic AWS side effect of `stop-runner` terminating the instance at the
+  end of every run (or of the leak reaper terminating a leaked one).
 - **IAM prerequisite.** The CI AWS identity (`sys_github_runner_provisioner`)
-  needs the full set below for the warm-pool + EIP + diagnostics model; an
+  needs the full set below for the EIP + diagnostics model; an
   admin granting less will hit `UnauthorizedOperation` mid-cycle (see the
   policy-diff comment on #281 for the ready-to-apply statements):
-  - **Instance lifecycle (cold launch):** `ec2:RunInstances`,
+  - **Instance lifecycle:** `ec2:RunInstances`,
     `ec2:TerminateInstances`, `ec2:CreateTags`, `ec2:DescribeImages`,
     `ec2:DescribeInstances`, `ec2:DescribeInstanceStatus`.
-  - **Warm pool (`reuse: stop`):** `ec2:StopInstances`, `ec2:StartInstances`,
-    `ec2:ModifyInstanceAttribute` — stopping the pool instance each run and
-    rewriting its user-data on warm restart. Without these, reuse can't work
-    at all.
-  - **EIP:** `ec2:AssociateAddress` (the action attaches the EIP on a cold
-    launch; `start-runner`'s "Pre-attach sandbox EIP" step attaches it to the
-    stopped pool instance on a warm restart) and `ec2:DescribeAddresses` (the
-    "Resolve sandbox EIP public IP" step). The pre-attach also uses the
-    already-required `ec2:DescribeInstances`. `ec2:DisassociateAddress` is
+    (`ec2:StopInstances`, `ec2:StartInstances` and
+    `ec2:ModifyInstanceAttribute` were needed only by the removed warm pool
+    and can be revoked.)
+  - **EIP:** `ec2:AssociateAddress` (the action attaches the EIP during
+    launch) and `ec2:DescribeAddresses` (the
+    "Resolve sandbox EIP public IP" step). `ec2:DisassociateAddress` is
     **not** required — the cross-repo EIP reaper that used it was removed with
     the mutex.
   - **Bootstrap diagnostics:** `ec2:GetConsoleOutput` and `ec2:DescribeTags`,
     for the action's fast-fail/console-capture on a failed registration
     (without them, failures degrade to timeout-only detection with no console
     output — the exact symptom seen earlier in this PR).
-- **Nightly drain and leak reaper.**
+- **Leak reaper.**
   [`cleanup-ec2-runners.yml`](.github/workflows/cleanup-ec2-runners.yml) runs
-  `mode: cleanup` on two schedules: a nightly full drain at `7 23 * * *` UTC
-  with a deliberately tiny `reaper-stopped-max-age` so the day's pool
-  instance always ages past the threshold and is terminated, and a
-  `7,37 * * * *` UTC leak-reaper pass at the action's own default threshold
-  that catches crashed/cancelled leftovers without draining the warm pool
-  during the day. Neither pass touches the EIP directly — it stays attached
-  to the pool instance across every warm stop/start cycle and is only
-  released as an automatic AWS side effect of whichever pass terminates
-  that instance first. That's normally the nightly full drain, but the
-  leak-reaper pass will do it instead if the pool instance is ever left
-  stopped long enough to age past its own default threshold between
-  drains (see the dedicated sandbox EIP bullet above).
-  `workflow_dispatch` exposes a `mode` choice and a `dry_run` input (default
+  `mode: cleanup` every 30 minutes (`7,37 * * * *` UTC, the action's default
+  thresholds) to terminate crashed/cancelled leftovers whose stop-runner
+  never ran. (The former nightly full-drain pass existed only to empty the
+  warm pool and was removed with it.) The reaper never touches the EIP
+  directly — it is released as an automatic AWS side effect of instance
+  termination. `workflow_dispatch` exposes a `dry_run` input (default
   `true`) for safe manual runs.
 - **One EIP per repo (no cross-repo mutex).** `eipalloc-1796f61b` was
   previously shared with `namecheap/mcp-server-namecheap`'s acceptance

--- a/scripts/hygiene-sweep.sh
+++ b/scripts/hygiene-sweep.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
-# Warm-pool runners reuse the same disk across jobs (job N+1 runs on job N's
-# disk), so repo code, per-job $HOME, and stray dotfiles must never survive
-# outside the run that created them. "pre" self-heals a crashed/cancelled
-# prior run (which would have skipped its own if: always() cleanup) by
-# warning and wiping any leftover content before the new job uses the path.
-# "post" silently wipes the same paths at the end of every job so nothing
-# sits on the stopped instance's disk during the idle window until the next
+# Repo code, per-job $HOME, and stray dotfiles must never survive outside
+# the run that created them (defense in depth kept from the warm-pool era,
+# when job N+1 ran on job N's disk; each run now gets a fresh instance).
+# "pre" self-heals a crashed/cancelled prior run (which would have skipped
+# its own if: always() cleanup) by warning and wiping any leftover content
+# before the new job uses the path. "post" silently wipes the same paths at
+# the end of every job so nothing sits on the instance's disk after the
 # run. Both modes leave every listed path existing and empty, so a healthy
 # prior run's "post" is exactly what makes the next run's "pre" find nothing
 # to warn about.


### PR DESCRIPTION
## Why

DEVOPS-22119 investigated the v4 `ec2-github-runner` reliability and speed regressions in this repo's acceptance CI. Measurements across 12 v4-era runs vs 7 v3-era runs showed the warm pool (`reuse: stop`, adopted with #279) delivers **negative** net value here:

| Metric | v3 (terminate) | v4 warm pool |
|---|---|---|
| `Start EC2 runner` step | 59-60 s | **70 s — warm hit and cold miss identical** |
| stop-runner job | ~6 s (fire-and-forget terminate) | 22-152 s (avg ~60 s, blocks on `stopped`) |
| Net per run | baseline | **≈ +65 s** |

The premise behind the warm pool (2-4 min cold-boot tax) does not hold on our baked `nc-al2023` AMI: a cold launch registers in ~70 s, and the ~10 s a warm boot actually saves is smaller than the action's fixed overheads (unconditional 30 s bootstrap wait, 15 s instance-running waiter floor, 3×10 s warm stability confirmations). Parking the instance also introduced the EIP-drift failure class that required the consumer-side "Pre-attach sandbox EIP" workaround step.

## What

- **ci.yml**: drop `reuse: stop` / `reuse-pool-tag` from `start-runner` and `stop-runner` (back to the action's default terminate-per-run); delete the "Pre-attach sandbox EIP" step — it only existed because a warm restart skipped the action's own `eip-allocation-id` association, which now runs on every launch.
- **cleanup-ec2-runners.yml**: remove the nightly full-drain pass (its only purpose was emptying the warm pool); keep the 30-minute leak reaper for crashed/cancelled leftovers. `workflow_dispatch` keeps the `dry_run` preview.
- **CI.md / CONTRIBUTING.md / SECURITY_COMPLIANCE.md / scripts/hygiene-sweep.sh**: update the runner-lifecycle description. Hygiene sweeps are kept as defense in depth. `ec2:StopInstances` / `ec2:StartInstances` / `ec2:ModifyInstanceAttribute` IAM grants are no longer required and can be revoked.

Every run now starts from a pristine disk, which also removes the job-N+1-runs-on-job-N's-disk consideration the warm pool had to document and sweep around.

## Verification

- Both workflows parse as valid YAML.
- `ci-ok`'s `needs:` list still matches the job list exactly (the gate's own assertion passes: 10 jobs watched).
- No `reuse`/warm-pool references remain in workflows or scripts; remaining doc mentions are deliberate historical context for the removal.
- The acceptance pipeline on this PR exercises the changed `start-runner`/`stop-runner` path end to end (cold launch + terminate).

Refs: DEVOPS-22119, #279 (warm-pool introduction).

## EIP handover race (second commit)

With terminate-per-run, the EIP is auto-released only when the old instance reaches `terminated`, while the workflow queue only waits for the older *run* to finish — so a back-to-back run could reach the launch while the previous instance is still shutting down with the EIP attached. The action's `AssociateAddress` does not set `AllowReassociation` and downgrades the failure to a warning (`src/aws.js:920-927`), which would surface only later at the "Verify sandbox EIP" gate. The second commit adds a **"Wait for the sandbox EIP to be free"** step in `start-runner`: a single read-only `DescribeAddresses` call when the EIP is already free (the common case), polling up to 120s only under genuine back-to-back contention, warning-then-proceed on timeout. No new IAM required.
