### PR TITLE
ci: bump pinned Terraform series to 1.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -485,7 +485,7 @@ jobs:
           - engine: terraform
             version: "1.5.7" # minimum supported Terraform
           - engine: terraform
-            version: "1.15.5" # latest pinned series (mirrors the sandbox job)
+            version: "1.16.0" # latest pinned series (mirrors the sandbox job)
           - engine: opentofu
             version: "1.12.3" # latest OpenTofu
     steps:
@@ -733,8 +733,8 @@ jobs:
           # are picked up automatically and never fail. A newer minor/major
           # release (1.16.0, 2.0.0) fails the build instead, so a maintainer can
           # review possible behavior changes before bumping tf_minor/tf_fallback.
-          tf_minor="1.15"
-          tf_fallback="1.15.5" # install target when the lookup is unavailable
+          tf_minor="1.16"
+          tf_fallback="1.16.0" # install target when the lookup is unavailable
           # checkpoint API == the source `terraform` itself uses for upgrade
           # notices (stable GA only, never RCs); current_version is the newest
           # stable, so when our series is current it IS the latest patch.


### PR DESCRIPTION
## Why

Master CI is red on run [33053762178](https://github.com/namecheap/terraform-provider-namecheap/actions/runs/33053762178) (the #327 merge commit): the acceptance job's `Resolve toolchain versions` tripwire fired because **HashiCorp released Terraform 1.16.0** while the pipeline pins the 1.15.x series. This is the tripwire working as designed — it fails fast so a maintainer reviews the new minor before CI silently adopts it.

## Review of 1.16.0 (per the tripwire's contract)

Checked the [v1.16 changelog](https://github.com/hashicorp/terraform/blob/v1.16/CHANGELOG.md):
- No plugin-protocol, state-format, or provider-installation changes affecting terraform-plugin-sdk/v2 providers.
- No CLI flag removals or behavior changes affecting terraform-plugin-testing (plan/apply/destroy, `-json`, exit codes).
- The only upgrade note (`bastion_host_key` now correctly applied by provisioners) is irrelevant to this provider's tests.

## What

- `tf_minor` 1.15 → 1.16, `tf_fallback` 1.15.5 → 1.16.0 in the sandbox acceptance job.
- The mirrored "latest pinned series" entry in the mock acceptance matrix 1.15.5 → 1.16.0 (the 1.5.7 minimum-supported and OpenTofu entries are untouched).

The acceptance run on this PR is the live verification: it installs 1.16.0 and runs the full suite against the sandbox.

Refs: DEVOPS-22119 (unblocks the post-#327 master run).
