### PR TITLE
ci: tolerate AWS CLI failures in the EIP wait poll

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -601,9 +601,18 @@ jobs:
         # gate still fails cleanly.
         run: |
           for i in $(seq 1 24); do
-            assoc="$(aws ec2 describe-addresses \
+            # Assignment inside the condition so a CLI failure (throttling,
+            # expired token, network blip) is handled here instead of
+            # aborting the whole job under the shell's -e: this step's
+            # contract is poll, warn, proceed — never turn a lookup hiccup
+            # into a red run of its own.
+            if ! assoc="$(aws ec2 describe-addresses \
               --allocation-ids "$SANDBOX_EIP_ALLOCATION_ID" \
-              --query 'Addresses[0].AssociationId' --output text)"
+              --query 'Addresses[0].AssociationId' --output text)"; then
+              echo "::warning::describe-addresses failed (attempt ${i}/24); retrying."
+              sleep 5
+              continue
+            fi
             if [ -z "$assoc" ] || [ "$assoc" = "None" ]; then
               echo "Sandbox EIP is free."
               exit 0


### PR DESCRIPTION
Closes #328.

The EIP wait step runs under the implicit `bash -e`, so any `describe-addresses` failure inside the command substitution (throttling, expired token, network blip — possible on any of the up-to-24 polls) failed `start-runner` outright, contradicting the step's poll-warn-proceed contract. The assignment now lives in the loop condition and a failed lookup becomes a warned, retried poll tick.

First of a stacked series for #328/#329/#330/#331 — merge this one first; the next PRs in the stack are based on it.