### PR TITLE
docs: state the actual EC2 sandbox gating — same-repo PRs run it, forks never do

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,11 +180,12 @@ runners with no secrets:
   sandbox. `check` proves the suite passes; this proves it passes on every engine
   the provider supports.
 
-The live-API sandbox suite (`acceptance_test`, on the self-hosted EC2 runner) is
-**push-only** — it runs on branch pushes within this repository, not on
-`pull_request` events, because it needs secrets that GitHub does not expose to
-fork PRs. So for a fork contribution, the mock suite is the acceptance signal;
-a maintainer validates against the live sandbox before merge.
+The live-API sandbox suite (`acceptance_test`, on the self-hosted EC2 runner)
+runs only for code from this repository — same-repo pull requests, pushes to
+master, and manual dispatch — and **never for fork PRs**, because it needs
+secrets that GitHub does not expose to forks. So for a fork contribution, the
+mock suite is the acceptance signal; a maintainer validates against the live
+sandbox before merge.
 
 The self-hosted EC2 runner behind `acceptance_test` is launched fresh for
 every run and terminated afterwards, so each job starts from a pristine

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,10 +189,10 @@ sandbox before merge.
 
 The self-hosted EC2 runner behind `acceptance_test` is launched fresh for
 every run and terminated afterwards, so each job starts from a pristine
-disk. (The #279 warm pool — stop/start reuse between runs — was removed
-under DEVOPS-22119: on this repo's baked AMI a warm restart measured no
-faster than the ~70-second cold launch, while parking the instance added a
-stop-wait to every run.) Fork PRs keep going through `acceptance_mock`,
+disk (the #279 warm pool was removed under DEVOPS-22119 — measurements and
+rationale live in
+[SECURITY_COMPLIANCE.md](SECURITY_COMPLIANCE.md#runner-lifecycle-hygiene-sweeps-and-the-sandbox-eip)).
+Fork PRs keep going through `acceptance_mock`,
 unchanged. Per-job disk (the checked-out workspace, `$HOME`, dotfiles) is
 still wiped both before and after every run as defense in depth. A scheduled
 leak reaper

--- a/SECURITY_COMPLIANCE.md
+++ b/SECURITY_COMPLIANCE.md
@@ -163,8 +163,9 @@ below for the lifecycle/cleanup/EIP mechanics:
   launch, while parking the instance added a 22-152s stop-wait to every run
   and an EIP-drift failure class. A fresh disk per run also removes the
   job-N+1-runs-on-job-N's-disk state carry-over the warm pool had to
-  document and sweep around; the sandbox pipeline remains **push-only and
-  never runs fork/PR code** (see
+  document and sweep around; the sandbox pipeline **never runs fork
+  (untrusted) code** — it runs only for same-repo pull requests, pushes to
+  master, and manual dispatch (see
   [fork-safe PR gating](#fork-safe-pull-request-ci) below). The action's
   `max-lifetime-minutes` TTL (default 360) still arms on every launch as a
   self-destruct backstop for instances whose stop-runner never ran.
@@ -268,9 +269,11 @@ secrets:
 - The trigger is `pull_request`, **never `pull_request_target`** — fork code runs
   only on GitHub-hosted runners with a read-only token and `secrets.*` redacted.
 - The secret-bound EC2 sandbox jobs (`start-runner`, `acceptance_test`,
-  `stop-runner`) are gated `github.event_name == 'push'`, so untrusted fork code
-  never reaches the self-hosted runner, the whitelisted Elastic IP, or the AWS /
-  Namecheap credentials. They keep running on every in-repo push, unchanged.
+  `stop-runner`) are gated on trusted code only: same-repo `pull_request`
+  events (`head.repo.full_name == github.repository`), pushes to master, and
+  `workflow_dispatch` — never Dependabot, never fork PRs. Untrusted fork code
+  therefore never reaches the self-hosted runner, the whitelisted Elastic IP,
+  or the AWS / Namecheap credentials.
 - The `acceptance_mock` job provides the fork-facing acceptance signal: it runs
   on `pull_request` on GitHub-hosted `ubuntu-latest`, references no `secrets.*`,
   and drives the in-process mock (see

--- a/SECURITY_COMPLIANCE.md
+++ b/SECURITY_COMPLIANCE.md
@@ -128,12 +128,10 @@ before `tar -xzf` / `unzip` runs.
 
 The acceptance-test job runs on a fresh EC2 instance launched by the
 self-hosted runner action for every run and terminated by `stop-runner`
-afterwards. (The #279 warm pool — stop/start reuse between runs — was removed
-under DEVOPS-22119: on this repo's baked AMI a warm restart measured no faster
-than a cold launch, while parking the instance added a stop-wait to every
-run.) See
+afterwards (the #279 warm pool was removed under DEVOPS-22119). See
 [Runner lifecycle, hygiene sweeps, and the sandbox EIP](#runner-lifecycle-hygiene-sweeps-and-the-sandbox-eip)
-below for the lifecycle/cleanup/EIP mechanics:
+below for the lifecycle/cleanup/EIP mechanics and the removal's measured
+rationale:
 
 - Runner binary version is controlled via the SHA-pinned
   `namecheap/ec2-github-runner` action (currently bundles
@@ -211,8 +209,10 @@ below for the lifecycle/cleanup/EIP mechanics:
   the previous instance's shutdown for the association.
 - **IAM prerequisite.** The CI AWS identity (`sys_github_runner_provisioner`)
   needs the full set below for the EIP + diagnostics model; an
-  admin granting less will hit `UnauthorizedOperation` mid-cycle (see the
-  policy-diff comment on #281 for the ready-to-apply statements):
+  admin granting less will hit `UnauthorizedOperation` mid-cycle. The list
+  below is authoritative. (The policy-diff comment on #281 predates the
+  warm-pool removal and re-grants the revoked trio below — do **not** apply
+  it as-is.)
   - **Instance lifecycle:** `ec2:RunInstances`,
     `ec2:TerminateInstances`, `ec2:CreateTags`, `ec2:DescribeImages`,
     `ec2:DescribeInstances`, `ec2:DescribeInstanceStatus`.
@@ -220,8 +220,12 @@ below for the lifecycle/cleanup/EIP mechanics:
     `ec2:ModifyInstanceAttribute` were needed only by the removed warm pool
     and can be revoked.)
   - **EIP:** `ec2:AssociateAddress` (the action attaches the EIP during
-    launch) and `ec2:DescribeAddresses` (the
-    "Resolve sandbox EIP public IP" step). `ec2:DisassociateAddress` is
+    launch — warn-only and without `AllowReassociation`, the behavior
+    tracked upstream as ec2-github-runner#76) and `ec2:DescribeAddresses`,
+    consumed by both of `start-runner`'s EIP steps: "Wait for the sandbox
+    EIP to be free" (the run's first caller, polling before launch) and
+    "Resolve sandbox EIP public IP" (which fails the job outright if the
+    grant is missing). `ec2:DisassociateAddress` is
     **not** required — the cross-repo EIP reaper that used it was removed with
     the mutex.
   - **Bootstrap diagnostics:** `ec2:GetConsoleOutput` and `ec2:DescribeTags`,


### PR DESCRIPTION
Closes #334.

Fixes the "push-only, never runs PR code" claim in SECURITY_COMPLIANCE.md's per-run-lifecycle bullet, plus two more instances of the same falsehood found while fixing it: the fork-safe section's "gated `github.event_name == 'push'`" bullet (the actual gate is same-repo PR ∨ master push ∨ dispatch) and CONTRIBUTING.md's parallel wording. The durable security claim — untrusted fork code never reaches the runner/EIP/credentials — is now stated without the false stronger claim.

Docs-only: the changes gate skips the expensive jobs on this PR by design.