### PR TITLE
docs: make the IAM section self-consistent after the warm-pool removal

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,10 +189,10 @@ sandbox before merge.
 
 The self-hosted EC2 runner behind `acceptance_test` is launched fresh for
 every run and terminated afterwards, so each job starts from a pristine
-disk. (The #279 warm pool — stop/start reuse between runs — was removed
-under DEVOPS-22119: on this repo's baked AMI a warm restart measured no
-faster than the ~70-second cold launch, while parking the instance added a
-stop-wait to every run.) Fork PRs keep going through `acceptance_mock`,
+disk (the #279 warm pool was removed under DEVOPS-22119 — measurements and
+rationale live in
+[SECURITY_COMPLIANCE.md](SECURITY_COMPLIANCE.md#runner-lifecycle-hygiene-sweeps-and-the-sandbox-eip)).
+Fork PRs keep going through `acceptance_mock`,
 unchanged. Per-job disk (the checked-out workspace, `$HOME`, dotfiles) is
 still wiped both before and after every run as defense in depth. A scheduled
 leak reaper

--- a/SECURITY_COMPLIANCE.md
+++ b/SECURITY_COMPLIANCE.md
@@ -128,12 +128,10 @@ before `tar -xzf` / `unzip` runs.
 
 The acceptance-test job runs on a fresh EC2 instance launched by the
 self-hosted runner action for every run and terminated by `stop-runner`
-afterwards. (The #279 warm pool — stop/start reuse between runs — was removed
-under DEVOPS-22119: on this repo's baked AMI a warm restart measured no faster
-than a cold launch, while parking the instance added a stop-wait to every
-run.) See
+afterwards (the #279 warm pool was removed under DEVOPS-22119). See
 [Runner lifecycle, hygiene sweeps, and the sandbox EIP](#runner-lifecycle-hygiene-sweeps-and-the-sandbox-eip)
-below for the lifecycle/cleanup/EIP mechanics:
+below for the lifecycle/cleanup/EIP mechanics and the removal's measured
+rationale:
 
 - Runner binary version is controlled via the SHA-pinned
   `namecheap/ec2-github-runner` action (currently bundles
@@ -211,8 +209,10 @@ below for the lifecycle/cleanup/EIP mechanics:
   the previous instance's shutdown for the association.
 - **IAM prerequisite.** The CI AWS identity (`sys_github_runner_provisioner`)
   needs the full set below for the EIP + diagnostics model; an
-  admin granting less will hit `UnauthorizedOperation` mid-cycle (see the
-  policy-diff comment on #281 for the ready-to-apply statements):
+  admin granting less will hit `UnauthorizedOperation` mid-cycle. The list
+  below is authoritative. (The policy-diff comment on #281 predates the
+  warm-pool removal and re-grants the revoked trio below — do **not** apply
+  it as-is.)
   - **Instance lifecycle:** `ec2:RunInstances`,
     `ec2:TerminateInstances`, `ec2:CreateTags`, `ec2:DescribeImages`,
     `ec2:DescribeInstances`, `ec2:DescribeInstanceStatus`.
@@ -220,8 +220,12 @@ below for the lifecycle/cleanup/EIP mechanics:
     `ec2:ModifyInstanceAttribute` were needed only by the removed warm pool
     and can be revoked.)
   - **EIP:** `ec2:AssociateAddress` (the action attaches the EIP during
-    launch) and `ec2:DescribeAddresses` (the
-    "Resolve sandbox EIP public IP" step). `ec2:DisassociateAddress` is
+    launch — warn-only and without `AllowReassociation`, the behavior
+    tracked upstream as ec2-github-runner#76) and `ec2:DescribeAddresses`,
+    consumed by both of `start-runner`'s EIP steps: "Wait for the sandbox
+    EIP to be free" (the run's first caller, polling before launch) and
+    "Resolve sandbox EIP public IP" (which fails the job outright if the
+    grant is missing). `ec2:DisassociateAddress` is
     **not** required — the cross-repo EIP reaper that used it was removed with
     the mutex.
   - **Bootstrap diagnostics:** `ec2:GetConsoleOutput` and `ec2:DescribeTags`,


### PR DESCRIPTION
Closes #335. Stacked on #342 (merge that first).

- **#281 pointer superseded**: the in-doc grant list is now explicitly authoritative; the #281 policy diff is flagged as pre-removal (it re-grants `StopInstances`/`StartInstances`/`ModifyInstanceAttribute`, which the doc says to revoke).
- **`ec2:DescribeAddresses` attribution**: both consumers named — the "Wait for the sandbox EIP to be free" step (the run's first caller) and "Resolve sandbox EIP public IP" — plus the warn-only/no-`AllowReassociation` `AssociateAddress` fact that motivates the wait step (upstream: namecheap/ec2-github-runner#76).
- **De-triplicated rationale**: the Runner-lifecycle bullet keeps the measurements (~70s, 22–152s); the supply-chain intro and CONTRIBUTING.md now carry one sentence plus a link instead of diverging copies.

Docs-only; the changes gate skips the expensive jobs.