### PR TITLE
fix(deps): bump go-namecheap-sdk from v2.10.2 to v2.10.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.11.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
-	github.com/namecheap/go-namecheap-sdk/v2 v2.10.2
+	github.com/namecheap/go-namecheap-sdk/v2 v2.10.3
 	github.com/stretchr/testify v1.12.1
 )
 
@@ -88,6 +88,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.26.3
+go 1.26.6
 
 tool github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs

--- a/go.sum
+++ b/go.sum
@@ -162,8 +162,8 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
-github.com/namecheap/go-namecheap-sdk/v2 v2.10.2 h1:MpF42HasIu30A3mtuEKpklZDlLXwVYzUiFZOJHhS3zw=
-github.com/namecheap/go-namecheap-sdk/v2 v2.10.2/go.mod h1:3eN88+y7YqS3Z8oxxKgnfhJ9EQzqb454wVWo7UU/qaQ=
+github.com/namecheap/go-namecheap-sdk/v2 v2.10.3 h1:89queS00ARkh/fTTO6p4THkiWzijfCURYa9cvBnXq8w=
+github.com/namecheap/go-namecheap-sdk/v2 v2.10.3/go.mod h1:7jacSIsKUdQxei+napxP4P3+chPhY3XTMHCmu+Q+dI0=
 github.com/oklog/run v1.2.0 h1:O8x3yXwah4A73hJdlrwo/2X6J62gE5qTMusH0dvz60E=
 github.com/oklog/run v1.2.0/go.mod h1:mgDbKRSwPhJfesJ4PntqFUbKQRZ50NgmZTSPlFA0YFk=
 github.com/pjbgf/sha1cd v0.6.0 h1:3WJ8Wz8gvDz29quX1OcEmkAlUg9diU4GxJHqs0/XiwU=


### PR DESCRIPTION
## Summary

Bumps `github.com/namecheap/go-namecheap-sdk/v2` from v2.10.2 to v2.10.3.

Note: `master` was already at SDK v2.10.2 (past the v2.10.0 baseline this
bump was originally scoped against), so this PR covers the remaining
v2.10.2 → v2.10.3 delta only.

Bundled changes in the SDK release:
- `fix(deps):` bump `stretchr/testify` from 1.12.0 to 1.12.1
- `ci:` gate `vendor/` integrity, add `govulncheck` (SDK repo CI only, no effect here)
- `chore:` require go1.26.6, the first Go patch carrying stdlib fixes — this SDK release also raised its own `go.mod` to `go 1.26.6`

## go.mod changes

- `github.com/namecheap/go-namecheap-sdk/v2`: `v2.10.2` → `v2.10.3`
- `go` directive: `1.26.3` → `1.26.6` (required by the SDK's new `go.mod`; produced by `go get`/`go mod tidy`, not hand-edited)

No other dependencies changed; `go.sum` only gained new hashes for the SDK module itself.

This is a dependency-only bump: no application code changes, and none of the newly-exposed SDK fields (Whois privacy on `domains.getInfo`, `DomainDetails` on `domains.renew`) are wired up here — that's out of scope for this PR.

## Verification

Run locally against the bumped `go.mod`/`go.sum`:
- `make format` — clean, no diff
- `make check` (`go vet`) — clean
- `make lint` (`golangci-lint run`) — 0 issues
- `make test` — all unit tests pass
- `make testacc-mock` — all mock-backed acceptance tests pass